### PR TITLE
feat: avoid container overlap with local drag bounds

### DIFF
--- a/src/__tests__/innerNoOverlap.spec.js
+++ b/src/__tests__/innerNoOverlap.spec.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { makeInnerSession } from '@/composables/useInnerNoOverlap'
+
+const CM = 1
+
+describe('makeInnerSession basic behaviours', () => {
+  let parent
+  beforeEach(() => {
+    parent = {
+      id: 'p',
+      dimensiones: { ancho: 20, largo: 20, alto: 20 },
+      posicion: { x: 0, y: 0 },
+      hijos: [],
+    }
+    global.window = { __GRID_SIZE_PX: 1 }
+  })
+
+  it('isValidLocal prevents overlap but allows touching', () => {
+    const moving = { id: 'm', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 5, y: 5 } }
+    const sibling = { id: 's', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 0, y: 0 } }
+    const sess = makeInnerSession({ parentEl: parent, movingEl: moving, siblings: [sibling], vista: 'XY', CM_TO_PX: CM })
+    expect(sess.isValidLocal({ x: 4, y: 0 })).toBe(false)
+    expect(sess.isValidLocal({ x: 5, y: 0 })).toBe(true)
+    expect(sess.isValidLocal({ x: 5, y: 15 })).toBe(true)
+  })
+
+  it('finalizeLocal snaps back to lastGood when invalid', () => {
+    const moving = { id: 'm', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 0, y: 0 } }
+    const sibling = { id: 's', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 5, y: 0 } }
+    const sess = makeInnerSession({ parentEl: parent, movingEl: moving, siblings: [sibling], vista: 'XY', CM_TO_PX: CM })
+    const bad = { x: 4, y: 0 }
+    const res = sess.finalizeLocal(bad)
+    expect(res).toEqual(sess.lastGoodLocal)
+    const good = { x: 10, y: 10 }
+    const res2 = sess.finalizeLocal(good)
+    expect(sess.isValidLocal(res2)).toBe(true)
+  })
+
+  it('dragBoundFuncLocal pushes against sibling without exiting bounds', () => {
+    const moving = { id: 'm', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 0, y: 0 } }
+    const sibling = { id: 's', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 5, y: 0 } }
+    const sess = makeInnerSession({ parentEl: parent, movingEl: moving, siblings: [sibling], vista: 'XY', CM_TO_PX: CM })
+    const next = sess.dragBoundFuncLocal({ x: 3, y: 0 }, sess.lastGoodLocal, { x: 5, y: 0 })
+    expect(next.x).toBe(0)
+    expect(next.y).toBe(0)
+  })
+})

--- a/src/__tests__/innerNoOverlap.spec.js
+++ b/src/__tests__/innerNoOverlap.spec.js
@@ -40,7 +40,7 @@ describe('makeInnerSession basic behaviours', () => {
     const moving = { id: 'm', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 0, y: 0 } }
     const sibling = { id: 's', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 5, y: 0 } }
     const sess = makeInnerSession({ parentEl: parent, movingEl: moving, siblings: [sibling], vista: 'XY', CM_TO_PX: CM })
-    const next = sess.dragBoundFuncLocal({ x: 3, y: 0 }, sess.lastGoodLocal, { x: 5, y: 0 })
+    const next = sess.dragBoundFuncLocal({ x: 3, y: 0 }, { x: 5, y: 0 })
     expect(next.x).toBe(0)
     expect(next.y).toBe(0)
   })

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -609,6 +609,19 @@ const layerRef = ref(null)
 
 const innerSessions = new Map()
 
+let rafId = null
+let needsDraw = false
+function scheduleDraw() {
+  if (rafId) return
+  rafId = requestAnimationFrame(() => {
+    rafId = null
+    if (needsDraw) {
+      layerRef.value.getNode()?.batchDraw()
+      needsDraw = false
+    }
+  })
+}
+
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
 const buffer = useCanvasBuffer()
@@ -1808,9 +1821,10 @@ const onShapeDragMove = (e, el) => {
     data.lastPointer = pointer
     const posWorld = shape.position()
     const posLocal = session.toLocal(posWorld, parent)
-    const nextLocal = session.dragBoundFuncLocal(posLocal, session.lastGoodLocal, vel)
+    const nextLocal = session.dragBoundFuncLocal(posLocal, vel)
     shape.position(session.toWorld(nextLocal, parent))
-    layerRef.value.getNode()?.batchDraw()
+    needsDraw = true
+    scheduleDraw()
   } else {
     updateElementPosition(e, el.id, el.forma === 'circular' ? 'circular' : 'rectangular')
   }
@@ -1828,7 +1842,8 @@ const onShapeDragEnd = (e, el) => {
     let finalLocal = session.finalizeLocal(candLocal)
     const finalWorld = session.toWorld(finalLocal, parent)
     shape.position(finalWorld)
-    layerRef.value.getNode()?.batchDraw()
+    needsDraw = true
+    scheduleDraw()
     const changed =
       Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
     if (changed) {

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -164,9 +164,9 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id)"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => canDragElement(elemento.id) && onShapeDragStart(e, elemento)"
+            @dragmove="(e) => canDragElement(elemento.id) && onShapeDragMove(e, elemento)"
+            @dragend="(e) => canDragElement(elemento.id) && onShapeDragEnd(e, elemento)"
               @transformstart="(e) => handleTransformStart(e, elemento.id)"
               @transform="(e) => handleTransformMove(e, elemento.id, 'rectangular')"
               @transformend="(e) => handleTransformEnd(e, elemento.id, 'rectangular')"
@@ -234,9 +234,9 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id, 'circular')"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => canDragElement(elemento.id) && onShapeDragStart(e, elemento)"
+            @dragmove="(e) => canDragElement(elemento.id) && onShapeDragMove(e, elemento)"
+            @dragend="(e) => canDragElement(elemento.id) && onShapeDragEnd(e, elemento)"
             @transformstart="(e) => handleTransformStart(e, elemento.id)"
             @transform="(e) => handleTransformMove(e, elemento.id, 'circular')"
             @transformend="(e) => handleTransformEnd(e, elemento.id, 'circular')"
@@ -267,9 +267,9 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id)"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => canDragElement(elemento.id) && onShapeDragStart(e, elemento)"
+            @dragmove="(e) => canDragElement(elemento.id) && onShapeDragMove(e, elemento)"
+            @dragend="(e) => canDragElement(elemento.id) && onShapeDragEnd(e, elemento)"
             @transformstart="(e) => handleTransformStart(e, elemento.id)"
             @transform="(e) => handleTransformMove(e, elemento.id, 'rectangular')"
             @transformend="(e) => handleTransformEnd(e, elemento.id, 'rectangular')"
@@ -589,6 +589,7 @@ import { resetEdgeState } from '@/composables/useEdgeState'
 import { resolveFinalByIntervals } from '@/utils/finalIntervals'
 import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
+import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -605,6 +606,8 @@ const emit = defineEmits(['select', 'drill-down'])
 const containerRef = ref(null)
 const stageRef = ref(null)
 const layerRef = ref(null)
+
+const innerSessions = new Map()
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
@@ -1573,6 +1576,34 @@ const createElementFromDrop = (data, dropEvent) => {
   candX = snapped.x
   candY = snapped.y
 
+  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
+    if (elemento.tipo === 'contenedores') {
+      const parent = canvasStore.elementoContenedorActual
+      const siblings = parent?.hijos?.map((id) => canvasStore.elementoPorId(id)).filter(Boolean) || []
+      const temp = {
+        id: '__temp',
+        dimensiones: { ancho: anchoCm, largo: largoCm, alto: altoCm },
+        posicion: { x: candX, y: candY },
+      }
+      const sess = makeInnerSession({
+        parentEl: parent,
+        movingEl: temp,
+        siblings,
+        vista: canvasStore.vistaActiva,
+        CM_TO_PX,
+      })
+      let local = sess.toLocal({ x: candX, y: candY }, parent)
+      local = sess.finalizeLocal(local)
+      if (!sess.isValidLocal(local)) {
+        showToast('No hay espacio aquí', 'error')
+        return
+      }
+      const world = sess.toWorld(local, parent)
+      candX = world.x
+      candY = world.y
+    }
+  }
+
   // 4. Calcular bbox candidato y verificar área
   const boundary = computeBoundary()
 
@@ -1735,6 +1766,81 @@ const createElementFromDrop = (data, dropEvent) => {
 
   // Seleccionar el elemento recién creado
   canvasStore.seleccionarElemento(nuevoElemento.id)
+}
+
+const onShapeDragStart = (e, el) => {
+  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
+    const shape = e.target
+    const parent =
+      canvasStore.elementoContenedorActual || canvasStore.elementoPorId(canvasStore.elementoSeleccionado)
+    const siblings = parent?.hijos?.map((id) => canvasStore.elementoPorId(id)).filter(Boolean) || []
+    const session = makeInnerSession({
+      parentEl: parent,
+      movingEl: el,
+      siblings,
+      vista: canvasStore.vistaActiva,
+      CM_TO_PX,
+    })
+    const pointer = e.evt ? { x: e.evt.clientX || 0, y: e.evt.clientY || 0 } : { x: 0, y: 0 }
+    innerSessions.set(el.id, {
+      session,
+      parent,
+      lastPointer: pointer,
+      initial: { x: el.posicion?.x ?? el.x ?? 0, y: el.posicion?.y ?? el.y ?? 0 },
+    })
+    isElementDragging.value = true
+    stageDragEnabled.value = false
+  } else {
+    startElementDrag(el.id)
+  }
+}
+
+const onShapeDragMove = (e, el) => {
+  const data = innerSessions.get(el.id)
+  if (data) {
+    const { session, parent } = data
+    const shape = e.target
+    const pointer = e.evt ? { x: e.evt.clientX || 0, y: e.evt.clientY || 0 } : { x: 0, y: 0 }
+    const vel = {
+      x: e.evt?.movementX ?? pointer.x - data.lastPointer.x,
+      y: e.evt?.movementY ?? pointer.y - data.lastPointer.y,
+    }
+    data.lastPointer = pointer
+    const posWorld = shape.position()
+    const posLocal = session.toLocal(posWorld, parent)
+    const nextLocal = session.dragBoundFuncLocal(posLocal, session.lastGoodLocal, vel)
+    shape.position(session.toWorld(nextLocal, parent))
+    layerRef.value.getNode()?.batchDraw()
+  } else {
+    updateElementPosition(e, el.id, el.forma === 'circular' ? 'circular' : 'rectangular')
+  }
+}
+
+const onShapeDragEnd = (e, el) => {
+  const data = innerSessions.get(el.id)
+  if (data) {
+    const { session, parent, initial } = data
+    innerSessions.delete(el.id)
+    isElementDragging.value = false
+    stageDragEnabled.value = true
+    const shape = e.target
+    let candLocal = session.toLocal(shape.position(), parent)
+    let finalLocal = session.finalizeLocal(candLocal)
+    const finalWorld = session.toWorld(finalLocal, parent)
+    shape.position(finalWorld)
+    layerRef.value.getNode()?.batchDraw()
+    const changed =
+      Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
+    if (changed) {
+      canvasStore.actualizarElementoConHistorial(
+        el.id,
+        { posicion: { x: finalWorld.x, y: finalWorld.y }, x: finalWorld.x, y: finalWorld.y },
+        `Elemento movido: ${el.id}`,
+      )
+    }
+  } else {
+    endElementDrag(el.id)
+  }
 }
 
 const getElementShadow = (elemento) => {

--- a/src/composables/useInnerNoOverlap.js
+++ b/src/composables/useInnerNoOverlap.js
@@ -26,8 +26,12 @@ export function makeInnerSession({ parentEl, movingEl, siblings, vista, CM_TO_PX
       }
       const pl = toLocal(s.posicion || { x: 0, y: 0 }, parentEl)
       return { x: pl.x, y: pl.y, w: sz.w, h: sz.h, id: s.id }
-    })
+  })
   let lastGoodLocal = toLocal(movingEl.posicion || { x: 0, y: 0 }, parentEl)
+  let contact = { id: null, axis: null }
+  const H = 1.0
+  let vxf = 0
+  let vyf = 0
   function isValidLocal(p) {
     if (
       p.x < bounds.minX - 0.5 ||
@@ -40,28 +44,69 @@ export function makeInnerSession({ parentEl, movingEl, siblings, vista, CM_TO_PX
     for (const B of sibRects) if (overlap(A, B)) return false
     return true
   }
-  function dragBoundFuncLocal(posLocal, lastLocal, vel) {
+  function inside(p, size, b) {
+    return (
+      p.x >= b.minX - 0.5 &&
+      p.y >= b.minY - 0.5 &&
+      p.x + size.w <= b.maxX + 0.5 &&
+      p.y + size.h <= b.maxY + 0.5
+    )
+  }
+  function dragBoundFuncLocal(posLocal, vel) {
     let p = clampRectToBounds(posLocal, mSize, bounds)
     const A = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
-    for (const B of sibRects) {
-      if (!overlap(A, B)) continue
-      const axis = Math.abs(vel.x) >= Math.abs(vel.y) ? 'x' : 'y'
-      if (axis === 'x') {
-        if (p.x >= B.x) p.x = B.x + B.w
-        else p.x = B.x - mSize.w
-        p = clampRectToBounds(p, mSize, bounds)
+    if (contact.id) {
+      const B = sibRects.find((s) => s.id === contact.id)
+      if (B) {
+        const touchingX = A.x + A.w > B.x - H && B.x + B.w > A.x - H
+        const touchingY = A.y + A.h > B.y - H && B.y + B.h > A.y - H
+        const stillTouching = contact.axis === 'x' ? touchingY : touchingX
+        if (stillTouching) {
+          if (contact.axis === 'x') {
+            p.x = p.x >= B.x ? B.x + B.w : B.x - mSize.w
+          } else {
+            p.y = p.y >= B.y ? B.y + B.h : B.y - mSize.h
+          }
+          p = clampRectToBounds(p, mSize, bounds)
+          A.x = p.x
+          A.y = p.y
+        } else {
+          contact = { id: null, axis: null }
+        }
       } else {
-        if (p.y >= B.y) p.y = B.y + B.h
-        else p.y = B.y - mSize.h
-        p = clampRectToBounds(p, mSize, bounds)
+        contact = { id: null, axis: null }
       }
-      A.x = p.x
-      A.y = p.y
     }
-    if (isValidLocal(p)) lastGoodLocal = p
+    if (!contact.id) {
+      const vx = vel.x || 0
+      const vy = vel.y || 0
+      vxf = 0.8 * vxf + 0.2 * vx
+      vyf = 0.8 * vyf + 0.2 * vy
+      for (const B of sibRects) {
+        if (!overlap({ x: p.x, y: p.y, w: mSize.w, h: mSize.h }, B)) continue
+        const axis = Math.abs(vxf) >= Math.abs(vyf) ? 'x' : 'y'
+        contact = { id: B.id, axis }
+        if (axis === 'x') {
+          p.x = p.x >= B.x ? B.x + B.w : B.x - mSize.w
+        } else {
+          p.y = p.y >= B.y ? B.y + B.h : B.y - mSize.h
+        }
+        p = clampRectToBounds(p, mSize, bounds)
+        A.x = p.x
+        A.y = p.y
+        break
+      }
+    }
+    if (inside(p, mSize, bounds)) {
+      let ok = true
+      const A2 = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+      for (const B of sibRects) if (overlap(A2, B)) { ok = false; break }
+      if (ok) lastGoodLocal = p
+    }
     return p
   }
   function finalizeLocal(candidateLocal) {
+    contact = { id: null, axis: null }
     let p = clampRectToBounds(candidateLocal, mSize, bounds)
     if (!isValidLocal(p)) p = lastGoodLocal
     const G = Math.max(1, window.__GRID_SIZE_PX || 10)

--- a/src/composables/useInnerNoOverlap.js
+++ b/src/composables/useInnerNoOverlap.js
@@ -1,0 +1,86 @@
+import { mapDimsByView } from '@/utils/innerViewDims'
+import { toLocal, toWorld } from '@/utils/innerLocalCoords'
+import { clampRectToBounds, overlap } from '@/utils/innerAABB'
+export function makeInnerSession({ parentEl, movingEl, siblings, vista, CM_TO_PX }) {
+  const { wCm, hCm } = mapDimsByView(parentEl, vista)
+  const bounds = {
+    minX: 0,
+    minY: 0,
+    maxX: Math.max(1, wCm * CM_TO_PX),
+    maxY: Math.max(1, hCm * CM_TO_PX),
+  }
+  parentEl.__wPx = bounds.maxX
+  parentEl.__hPx = bounds.maxY
+  const mSizeCm = mapDimsByView(movingEl, vista)
+  const mSize = {
+    w: Math.max(1, mSizeCm.wCm * CM_TO_PX),
+    h: Math.max(1, mSizeCm.hCm * CM_TO_PX),
+  }
+  const sibRects = siblings
+    .filter((s) => s && s.id !== movingEl.id)
+    .map((s) => {
+      const szCm = mapDimsByView(s, vista)
+      const sz = {
+        w: Math.max(1, szCm.wCm * CM_TO_PX),
+        h: Math.max(1, szCm.hCm * CM_TO_PX),
+      }
+      const pl = toLocal(s.posicion || { x: 0, y: 0 }, parentEl)
+      return { x: pl.x, y: pl.y, w: sz.w, h: sz.h, id: s.id }
+    })
+  let lastGoodLocal = toLocal(movingEl.posicion || { x: 0, y: 0 }, parentEl)
+  function isValidLocal(p) {
+    if (
+      p.x < bounds.minX - 0.5 ||
+      p.y < bounds.minY - 0.5 ||
+      p.x + mSize.w > bounds.maxX + 0.5 ||
+      p.y + mSize.h > bounds.maxY + 0.5
+    )
+      return false
+    const A = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+    for (const B of sibRects) if (overlap(A, B)) return false
+    return true
+  }
+  function dragBoundFuncLocal(posLocal, lastLocal, vel) {
+    let p = clampRectToBounds(posLocal, mSize, bounds)
+    const A = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+    for (const B of sibRects) {
+      if (!overlap(A, B)) continue
+      const axis = Math.abs(vel.x) >= Math.abs(vel.y) ? 'x' : 'y'
+      if (axis === 'x') {
+        if (p.x >= B.x) p.x = B.x + B.w
+        else p.x = B.x - mSize.w
+        p = clampRectToBounds(p, mSize, bounds)
+      } else {
+        if (p.y >= B.y) p.y = B.y + B.h
+        else p.y = B.y - mSize.h
+        p = clampRectToBounds(p, mSize, bounds)
+      }
+      A.x = p.x
+      A.y = p.y
+    }
+    if (isValidLocal(p)) lastGoodLocal = p
+    return p
+  }
+  function finalizeLocal(candidateLocal) {
+    let p = clampRectToBounds(candidateLocal, mSize, bounds)
+    if (!isValidLocal(p)) p = lastGoodLocal
+    const G = Math.max(1, window.__GRID_SIZE_PX || 10)
+    p = { x: Math.round(p.x / G) * G, y: Math.round(p.y / G) * G }
+    p = clampRectToBounds(p, mSize, bounds)
+    if (!isValidLocal(p)) p = lastGoodLocal
+    return p
+  }
+  return {
+    bounds,
+    mSize,
+    sibRects,
+    toLocal,
+    toWorld,
+    isValidLocal,
+    dragBoundFuncLocal,
+    finalizeLocal,
+    get lastGoodLocal() {
+      return lastGoodLocal
+    },
+  }
+}

--- a/src/utils/innerAABB.js
+++ b/src/utils/innerAABB.js
@@ -1,0 +1,13 @@
+export function clampRectToBounds(pos, size, bounds) {
+  const x = Math.min(Math.max(pos.x, bounds.minX), bounds.maxX - size.w)
+  const y = Math.min(Math.max(pos.y, bounds.minY), bounds.maxY - size.h)
+  return { x, y }
+}
+export function overlap(a, b, eps = 0.5) {
+  return (
+    a.x + a.w - eps > b.x &&
+    b.x + b.w - eps > a.x &&
+    a.y + a.h - eps > b.y &&
+    b.y + b.h - eps > a.y
+  )
+}

--- a/src/utils/innerLocalCoords.js
+++ b/src/utils/innerLocalCoords.js
@@ -1,0 +1,17 @@
+// Coord. locales robustas: si hijos vienen absolutos resta origen del contenedor; si ya son locales, no-op
+export function toLocal(pos, parent) {
+  const px = pos?.x || 0,
+    py = pos?.y || 0
+  const ox = parent?.posicion?.x || 0,
+    oy = parent?.posicion?.y || 0
+  const looksLocal = px >= -1 && py >= -1 && px <= (parent.__wPx || 1) + 1 && py <= (parent.__hPx || 1) + 1
+  return looksLocal ? { x: px, y: py } : { x: px - ox, y: py - oy }
+}
+export function toWorld(pos, parent) {
+  const px = pos?.x || 0,
+    py = pos?.y || 0
+  const ox = parent?.posicion?.x || 0,
+    oy = parent?.posicion?.y || 0
+  const looksLocal = px >= -1 && py >= -1 && px <= (parent.__wPx || 1) + 1 && py <= (parent.__hPx || 1) + 1
+  return looksLocal ? { x: px, y: py } : { x: px + ox, y: py + oy }
+}

--- a/src/utils/innerViewDims.js
+++ b/src/utils/innerViewDims.js
@@ -1,0 +1,8 @@
+export function mapDimsByView(el, vista) {
+  const a = el?.dimensiones?.ancho || 0,
+    b = el?.dimensiones?.largo || 0,
+    h = el?.dimensiones?.alto || 0
+  if (vista === 'XY') return { wCm: a, hCm: b }
+  if (vista === 'XZ') return { wCm: a, hCm: h }
+  return { wCm: b, hCm: h } // ZY
+}


### PR DESCRIPTION
## Summary
- add utilities for inner drag bounding and overlap detection
- wire CanvasView to use per-container drag sessions and validate drops
- ensure inner elements snap to grid and avoid sibling overlap

## Testing
- `npm run test:unit` *(fails: Failed to resolve component, ResizeObserver is not defined)*
- `npx vitest run src/__tests__/innerNoOverlap.spec.js --reporter verbose`


------
https://chatgpt.com/codex/tasks/task_e_68ade541ad108321814afe69f33cf6b3