### PR TITLE
feat: prevent container overlap in drill-down

### DIFF
--- a/src/__tests__/inner_no_overlap.spec.js
+++ b/src/__tests__/inner_no_overlap.spec.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { makeInnerSession } from '@/composables/useInnerNoOverlap'
+
+beforeEach(() => {
+  if (typeof window !== 'undefined') window.__GRID_SIZE_PX = 1
+})
+
+describe('inner session utils', () => {
+  const CM_TO_PX = 1
+  const makeSession = () => {
+    const parent = {
+      dimensiones: { ancho: 10, largo: 10, alto: 5 },
+      posicion: { x: 0, y: 0 }
+    }
+    const sibling = {
+      id: 'S',
+      dimensiones: { ancho: 5, largo: 5, alto: 5 },
+      posicion: { x: 0, y: 0 }
+    }
+    const moving = {
+      id: 'M',
+      dimensiones: { ancho: 5, largo: 5, alto: 5 },
+      posicion: { x: 5, y: 0 }
+    }
+    return makeInnerSession({
+      parentEl: parent,
+      movingEl: moving,
+      siblings: [sibling, moving],
+      vista: 'XY',
+      CM_TO_PX
+    })
+  }
+
+  it('isValidLocal detects overlap but allows touching boundaries', () => {
+    const session = makeSession()
+    expect(session.isValidLocal({ x: 5, y: 0 })).toBe(true)
+    expect(session.isValidLocal({ x: 4.4, y: 0 })).toBe(false)
+  })
+
+  it('finalizeLocal snaps back to lastGoodLocal on invalid drop', () => {
+    const session = makeSession()
+    const bad = session.finalizeLocal({ x: 4, y: 0 })
+    expect(bad.x).toBe(session.lastGoodLocal.x)
+    const good = session.finalizeLocal({ x: 2, y: 0 })
+    expect(good.x).toBe(2)
+  })
+
+  it('dragBoundFuncLocal keeps shape against sibling edge', () => {
+    const session = makeSession()
+    const res = session.dragBoundFuncLocal({ x: 4, y: 0 }, session.lastGoodLocal, { x: -5, y: 0 })
+    expect(res.x).toBe(5)
+    expect(res.y).toBe(0)
+  })
+})

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -164,9 +164,19 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id)"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => {
+              if (!canDragElement(elemento.id)) return
+              if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) handleInnerDragStart(e, elemento)
+              else startElementDrag(elemento.id)
+            }"
+            @dragmove="(e) => {
+              if (innerSessions.has(elemento.id)) handleInnerDragMove(e, elemento)
+              else if (canDragElement(elemento.id)) updateElementPosition(e, elemento.id)
+            }"
+            @dragend="(e) => {
+              if (innerSessions.has(elemento.id)) handleInnerDragEnd(e, elemento)
+              else if (canDragElement(elemento.id)) endElementDrag(elemento.id)
+            }"
               @transformstart="(e) => handleTransformStart(e, elemento.id)"
               @transform="(e) => handleTransformMove(e, elemento.id, 'rectangular')"
               @transformend="(e) => handleTransformEnd(e, elemento.id, 'rectangular')"
@@ -234,9 +244,19 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id, 'circular')"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => {
+              if (!canDragElement(elemento.id)) return
+              if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) handleInnerDragStart(e, elemento)
+              else startElementDrag(elemento.id)
+            }"
+            @dragmove="(e) => {
+              if (innerSessions.has(elemento.id)) handleInnerDragMove(e, elemento)
+              else if (canDragElement(elemento.id)) updateElementPosition(e, elemento.id, 'circular')
+            }"
+            @dragend="(e) => {
+              if (innerSessions.has(elemento.id)) handleInnerDragEnd(e, elemento)
+              else if (canDragElement(elemento.id)) endElementDrag(elemento.id)
+            }"
             @transformstart="(e) => handleTransformStart(e, elemento.id)"
             @transform="(e) => handleTransformMove(e, elemento.id, 'circular')"
             @transformend="(e) => handleTransformEnd(e, elemento.id, 'circular')"
@@ -267,9 +287,19 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id)"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => {
+              if (!canDragElement(elemento.id)) return
+              if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) handleInnerDragStart(e, elemento)
+              else startElementDrag(elemento.id)
+            }"
+            @dragmove="(e) => {
+              if (innerSessions.has(elemento.id)) handleInnerDragMove(e, elemento)
+              else if (canDragElement(elemento.id)) updateElementPosition(e, elemento.id)
+            }"
+            @dragend="(e) => {
+              if (innerSessions.has(elemento.id)) handleInnerDragEnd(e, elemento)
+              else if (canDragElement(elemento.id)) endElementDrag(elemento.id)
+            }"
             @transformstart="(e) => handleTransformStart(e, elemento.id)"
             @transform="(e) => handleTransformMove(e, elemento.id, 'rectangular')"
             @transformend="(e) => handleTransformEnd(e, elemento.id, 'rectangular')"
@@ -589,6 +619,7 @@ import { resetEdgeState } from '@/composables/useEdgeState'
 import { resolveFinalByIntervals } from '@/utils/finalIntervals'
 import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
+import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -996,6 +1027,7 @@ const dragBoundForElement = (pos, elemento, forma = 'rect') => {
 // RAF + Perf mode state per element
 const rafControllers = new Map()
 const perfContexts = new Map()
+const innerSessions = new Map()
 const throttle2 = throttleEveryNFrames(2)
 
 const startElementDrag = (elementId) => {
@@ -1171,6 +1203,62 @@ const updateElementPosition = (e, elementId, forma = 'rectangular') => {
   // Dejar feedback visual y draw al rAF loop; NO escribir en store
   const rec = rafControllers.get(elementId)
   if (rec && rec.ctrl) rec.ctrl.move({ x, y })
+}
+
+function handleInnerDragStart(evt, el) {
+  const parentEl = canvasStore.elementoContenedorActual || canvasStore.elementoSeleccionadoCompleto
+  if (!parentEl) return
+  const session = makeInnerSession({
+    parentEl,
+    movingEl: el,
+    siblings: elementosVisiblesEnCanvas.value,
+    vista: canvasStore.vistaActiva,
+    CM_TO_PX
+  })
+  innerSessions.set(el.id, {
+    session,
+    parentEl,
+    startWorld: { x: el.posicion?.x || 0, y: el.posicion?.y || 0 },
+    lastPointer: { x: evt.evt?.clientX || 0, y: evt.evt?.clientY || 0 }
+  })
+}
+
+function handleInnerDragMove(evt, el) {
+  const data = innerSessions.get(el.id)
+  if (!data) return
+  const { session, parentEl } = data
+  const pointer = { x: evt.evt?.clientX || 0, y: evt.evt?.clientY || 0 }
+  const vel = {
+    x: evt.evt?.movementX ?? pointer.x - data.lastPointer.x,
+    y: evt.evt?.movementY ?? pointer.y - data.lastPointer.y
+  }
+  data.lastPointer = pointer
+  const shape = evt.target
+  const posWorld = shape.position()
+  const posLocal = session.toLocal(posWorld, parentEl)
+  const nextLocal = session.dragBoundFuncLocal(posLocal, session.lastGoodLocal, vel)
+  shape.position(session.toWorld(nextLocal, parentEl))
+  layerRef.value.getNode().batchDraw()
+}
+
+function handleInnerDragEnd(evt, el) {
+  const data = innerSessions.get(el.id)
+  if (!data) return
+  const { session, parentEl, startWorld } = data
+  const shape = evt.target
+  const candidateLocal = session.toLocal(shape.position(), parentEl)
+  const finalLocal = session.finalizeLocal(candidateLocal)
+  const finalWorld = session.toWorld(finalLocal, parentEl)
+  shape.position(finalWorld)
+  layerRef.value.getNode().batchDraw()
+  if (finalWorld.x !== startWorld.x || finalWorld.y !== startWorld.y) {
+    canvasStore.actualizarElementoConHistorial(
+      el.id,
+      { posicion: { x: finalWorld.x, y: finalWorld.y }, x: finalWorld.x, y: finalWorld.y },
+      `Elemento movido: ${el.nombre || el.tipo || el.id}`
+    )
+  }
+  innerSessions.delete(el.id)
 }
 
 const endElementDrag = async (elementId) => {
@@ -1572,74 +1660,97 @@ const createElementFromDrop = (data, dropEvent) => {
   const snapped = snapToGrid(candX, candY, GRID_SIZE)
   candX = snapped.x
   candY = snapped.y
-
-  // 4. Calcular bbox candidato y verificar área
-  const boundary = computeBoundary()
-
-  // 5. Verificar que esté dentro del área (clampToArea)
-  let isInsideArea = true
-  if (boundary.type === 'rect') {
-    isInsideArea =
-      candX >= 0 &&
-      candY >= 0 &&
-      candX + finalWidth <= boundary.W &&
-      candY + finalHeight <= boundary.H
-
-    // Si está fuera, intentar clamp
-    if (!isInsideArea) {
-      const clamped = clampRectToRect(candX, candY, finalWidth, finalHeight, boundary.W, boundary.H)
-      candX = clamped.x
-      candY = clamped.y
-    }
-  } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, finalWidth, finalHeight, boundary.points)
-  }
-
-  // 6. Crear elemento temporal para detectar conflictos
-  const tempElement = {
-    id: '__temp_drop__',
-    x: candX,
-    y: candY,
-    width: finalWidth,
-    height: finalHeight,
-    ubicacion: elemento.ubicacion || elemento.montado || 'suelo',
-    tipo: elemento.tipo || elemento.categoria || 'elemento',
-    forma: elemento.forma || 'rectangular',
-  }
-
-  // 7. Ejecutar detectConflictsFor contra elementos existentes
-  const allElements = canvasStore.elementosVisibles
-  const conflicts = detectConflictsFor(tempElement, allElements)
-  const blockingConflicts = conflicts.filter((c) => c.bloqueante)
-
-  // 8. Si hay conflicto BLOQUEANTE o queda fuera de área, intentar nudgePlace
   let finalPosition = { x: candX, y: candY }
-  let placementSuccessful = blockingConflicts.length === 0 && isInsideArea
+  let placementSuccessful = true
+  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
+    const parentEl = canvasStore.elementoContenedorActual
+    const temp = {
+      id: '__temp_drop__',
+      dimensiones: elemento.dimensiones,
+      posicion: { x: candX, y: candY }
+    }
+    const session = makeInnerSession({
+      parentEl,
+      movingEl: temp,
+      siblings: elementosVisiblesEnCanvas.value,
+      vista: canvasStore.vistaActiva,
+      CM_TO_PX
+    })
+    const local = session.toLocal({ x: candX, y: candY }, parentEl)
+    const finalLocal = session.finalizeLocal(local)
+    if (!session.isValidLocal(finalLocal)) {
+      showToast('No hay espacio aquí para colocar el elemento', 'error')
+      return
+    }
+    finalPosition = session.toWorld(finalLocal, parentEl)
+  } else {
+    // 4. Calcular bbox candidato y verificar área
+    const boundary = computeBoundary()
 
-  if (!placementSuccessful) {
-    console.log(
-      '🔍 Posición inicial tiene conflictos o está fuera de área, intentando nudgePlace...',
-    )
+    // 5. Verificar que esté dentro del área (clampToArea)
+    let isInsideArea = true
+    if (boundary.type === 'rect') {
+      isInsideArea =
+        candX >= 0 &&
+        candY >= 0 &&
+        candX + finalWidth <= boundary.W &&
+        candY + finalHeight <= boundary.H
 
-    const nudgeResult = nudgePlace(
-      candX,
-      candY,
-      finalWidth,
-      finalHeight,
-      boundary,
-      allElements,
-      tempElement,
-      GRID_SIZE,
-      16, // máximo 16 intentos
-      detectConflictsFor, // Pasar la función como parámetro
-    )
+      // Si está fuera, intentar clamp
+      if (!isInsideArea) {
+        const clamped = clampRectToRect(candX, candY, finalWidth, finalHeight, boundary.W, boundary.H)
+        candX = clamped.x
+        candY = clamped.y
+      }
+    } else if (boundary.type === 'polygon') {
+      isInsideArea = rectInsidePolygon(candX, candY, finalWidth, finalHeight, boundary.points)
+    }
 
-    if (nudgeResult.found) {
-      finalPosition = { x: nudgeResult.x, y: nudgeResult.y }
-      placementSuccessful = true
-      console.log('✅ nudgePlace encontró posición válida:', finalPosition)
-    } else {
-      console.log('❌ nudgePlace no encontró posición válida')
+    // 6. Crear elemento temporal para detectar conflictos
+    const tempElement = {
+      id: '__temp_drop__',
+      x: candX,
+      y: candY,
+      width: finalWidth,
+      height: finalHeight,
+      ubicacion: elemento.ubicacion || elemento.montado || 'suelo',
+      tipo: elemento.tipo || elemento.categoria || 'elemento',
+      forma: elemento.forma || 'rectangular'
+    }
+
+    // 7. Ejecutar detectConflictsFor contra elementos existentes
+    const allElements = canvasStore.elementosVisibles
+    const conflicts = detectConflictsFor(tempElement, allElements)
+    const blockingConflicts = conflicts.filter((c) => c.bloqueante)
+
+    // 8. Si hay conflicto BLOQUEANTE o queda fuera de área, intentar nudgePlace
+    placementSuccessful = blockingConflicts.length === 0 && isInsideArea
+
+    if (!placementSuccessful) {
+      console.log(
+        '🔍 Posición inicial tiene conflictos o está fuera de área, intentando nudgePlace...',
+      )
+
+      const nudgeResult = nudgePlace(
+        candX,
+        candY,
+        finalWidth,
+        finalHeight,
+        boundary,
+        allElements,
+        tempElement,
+        GRID_SIZE,
+        16, // máximo 16 intentos
+        detectConflictsFor // Pasar la función como parámetro
+      )
+
+      if (nudgeResult.found) {
+        finalPosition = { x: nudgeResult.x, y: nudgeResult.y }
+        placementSuccessful = true
+        console.log('✅ nudgePlace encontró posición válida:', finalPosition)
+      } else {
+        console.log('❌ nudgePlace no encontró posición válida')
+      }
     }
   }
 

--- a/src/composables/useInnerNoOverlap.js
+++ b/src/composables/useInnerNoOverlap.js
@@ -1,0 +1,88 @@
+import { mapDimsByView } from '@/utils/innerViewDims'
+import { toLocal, toWorld } from '@/utils/innerLocalCoords'
+import { clampRectToBounds, overlap } from '@/utils/innerAABB'
+export function makeInnerSession({ parentEl, movingEl, siblings, vista, CM_TO_PX }) {
+  const { wCm, hCm } = mapDimsByView(parentEl, vista)
+  const bounds = {
+    minX: 0,
+    minY: 0,
+    maxX: Math.max(1, wCm * CM_TO_PX),
+    maxY: Math.max(1, hCm * CM_TO_PX)
+  }
+  parentEl.__wPx = bounds.maxX
+  parentEl.__hPx = bounds.maxY // hint para toLocal
+  const mSizeCm = mapDimsByView(movingEl, vista)
+  const mSize = {
+    w: Math.max(1, mSizeCm.wCm * CM_TO_PX),
+    h: Math.max(1, mSizeCm.hCm * CM_TO_PX)
+  }
+  const sibRects = siblings
+    .filter((s) => s && s.id !== movingEl.id)
+    .map((s) => {
+      const szCm = mapDimsByView(s, vista)
+      const sz = {
+        w: Math.max(1, szCm.wCm * CM_TO_PX),
+        h: Math.max(1, szCm.hCm * CM_TO_PX)
+      }
+      const pl = toLocal(s.posicion || { x: 0, y: 0 }, parentEl)
+      return { x: pl.x, y: pl.y, w: sz.w, h: sz.h, id: s.id }
+    })
+  let lastGoodLocal = toLocal(movingEl.posicion || { x: 0, y: 0 }, parentEl)
+  function isValidLocal(p) {
+    if (
+      p.x < bounds.minX - 0.5 ||
+      p.y < bounds.minY - 0.5 ||
+      p.x + mSize.w > bounds.maxX + 0.5 ||
+      p.y + mSize.h > bounds.maxY + 0.5
+    )
+      return false
+    const A = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+    for (const B of sibRects) if (overlap(A, B)) return false
+    return true
+  }
+  function dragBoundFuncLocal(posLocal, lastLocal, vel) {
+    // 1) clamp a bounds
+    let p = clampRectToBounds(posLocal, mSize, bounds)
+    // 2) si toca a un hermano, bloquea en el eje dominante
+    const A = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+    for (const B of sibRects) {
+      if (!overlap(A, B)) continue
+      const axis = Math.abs(vel.x) >= Math.abs(vel.y) ? 'x' : 'y'
+      if (axis === 'x') {
+        if (p.x >= B.x) p.x = B.x + B.w
+        else p.x = B.x - mSize.w
+        p = clampRectToBounds(p, mSize, bounds)
+      } else {
+        if (p.y >= B.y) p.y = B.y + B.h
+        else p.y = B.y - mSize.h
+        p = clampRectToBounds(p, mSize, bounds)
+      }
+    }
+    // 3) actualizar lastGood si quedó válido
+    if (isValidLocal(p)) lastGoodLocal = p
+    return p
+  }
+  function finalizeLocal(candidateLocal) {
+    let p = clampRectToBounds(candidateLocal, mSize, bounds)
+    if (!isValidLocal(p)) p = lastGoodLocal // fallback duro
+    // snap a grilla local (si aplica)
+    const G = Math.max(1, window.__GRID_SIZE_PX || 10)
+    p = { x: Math.round(p.x / G) * G, y: Math.round(p.y / G) * G }
+    p = clampRectToBounds(p, mSize, bounds)
+    if (!isValidLocal(p)) p = lastGoodLocal
+    return p
+  }
+  return {
+    bounds,
+    mSize,
+    sibRects,
+    toLocal,
+    toWorld,
+    isValidLocal,
+    dragBoundFuncLocal,
+    finalizeLocal,
+    get lastGoodLocal() {
+      return lastGoodLocal
+    }
+  }
+}

--- a/src/utils/innerAABB.js
+++ b/src/utils/innerAABB.js
@@ -1,0 +1,13 @@
+export function clampRectToBounds(pos, size, bounds) {
+  const x = Math.min(Math.max(pos.x, bounds.minX), bounds.maxX - size.w);
+  const y = Math.min(Math.max(pos.y, bounds.minY), bounds.maxY - size.h);
+  return { x, y };
+}
+export function overlap(a, b, eps = 0.5) {
+  return (
+    a.x + a.w - eps > b.x &&
+    b.x + b.w - eps > a.x &&
+    a.y + a.h - eps > b.y &&
+    b.y + b.h - eps > a.y
+  );
+}

--- a/src/utils/innerLocalCoords.js
+++ b/src/utils/innerLocalCoords.js
@@ -1,0 +1,25 @@
+// Coord. locales robustas: si hijos vienen absolutos resta origen del contenedor; si ya son locales, no-op
+export function toLocal(pos, parent) {
+  const px = pos?.x || 0,
+    py = pos?.y || 0;
+  const ox = parent?.posicion?.x || 0,
+    oy = parent?.posicion?.y || 0;
+  const looksLocal =
+    px >= -1 &&
+    py >= -1 &&
+    px <= (parent.__wPx || 1) + 1 &&
+    py <= (parent.__hPx || 1) + 1;
+  return looksLocal ? { x: px, y: py } : { x: px - ox, y: py - oy };
+}
+export function toWorld(pos, parent) {
+  const px = pos?.x || 0,
+    py = pos?.y || 0;
+  const ox = parent?.posicion?.x || 0,
+    oy = parent?.posicion?.y || 0;
+  const looksLocal =
+    px >= -1 &&
+    py >= -1 &&
+    px <= (parent.__wPx || 1) + 1 &&
+    py <= (parent.__hPx || 1) + 1;
+  return looksLocal ? { x: px, y: py } : { x: px + ox, y: py + oy };
+}

--- a/src/utils/innerViewDims.js
+++ b/src/utils/innerViewDims.js
@@ -1,0 +1,8 @@
+export function mapDimsByView(el, vista) {
+  const a = el?.dimensiones?.ancho || 0,
+    b = el?.dimensiones?.largo || 0,
+    h = el?.dimensiones?.alto || 0;
+  if (vista === 'XY') return { wCm: a, hCm: b };
+  if (vista === 'XZ') return { wCm: a, hCm: h };
+  return { wCm: b, hCm: h }; // ZY
+}


### PR DESCRIPTION
## Summary
- add utilities for local coords, view dims and AABB overlap
- implement inner session logic to clamp container moves and ensure no overlap
- wire CanvasView drag/drop to use inner session in drill-down
- basic vitest coverage for inner no-overlap session

## Testing
- `npm run test:unit` *(fails: expected 0 to be greater than or equal to 2.999999; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ade541ad108321814afe69f33cf6b3