### PR TITLE
feat: polygon boundary utilities

### DIFF
--- a/src/__tests__/drop-outside-polygon.spec.js
+++ b/src/__tests__/drop-outside-polygon.spec.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+vi.mock('@/utils/collision', () => ({
+  detectConflictsFor: vi.fn(() => [])
+}))
+
+import CanvasView from '@/components/CanvasView.vue'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  window.__toasts = { show: vi.fn() }
+})
+
+describe('drop outside polygon', () => {
+  it('rejects drop when outside active polygon', async () => {
+    mockStore = {
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      plantaActivaData: {
+        nombre: 'Planta',
+        dimensiones: { ancho: 100, largo: 100 },
+        poligono: [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+          { x: 0, y: 100 }
+        ]
+      },
+      elementosVisibles: [],
+      elementoSeleccionado: null,
+      agregarElemento: vi.fn(),
+      seleccionarElemento: vi.fn(),
+      estaEnElemento: false,
+      estaEnContenedor: false,
+      estaEnPlanta: true,
+      contextoActual: { tipo: 'plantas' },
+      vistaActiva: 'XY',
+      gridSize: 50,
+      canvasAdaptativo: { width: 100, height: 100 },
+      configurarZoom: vi.fn(),
+      configurarPan: vi.fn(),
+    }
+
+    const wrapper = mount(CanvasView)
+    wrapper.vm.containerRef = { getBoundingClientRect: () => ({ left: 0, top: 0 }) }
+    wrapper.vm.stageRef = { getNode: () => ({}) }
+
+    const data = { elemento: { dimensiones: { ancho: 20, largo: 20 }, tipo: 'elementos', forma: 'rectangular', color: '#f00' } }
+    const dropEvent = { clientX: 150, clientY: 50, preventDefault: () => {} }
+
+    wrapper.vm.createElementFromDrop(data, dropEvent)
+
+    expect(window.__toasts.show).toHaveBeenCalledWith('Fuera de los límites de la planta', { type: 'error', timeout: 4000 })
+    expect(mockStore.agregarElemento).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/fit-to-planta.spec.js
+++ b/src/__tests__/fit-to-planta.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+import CanvasView from '@/components/CanvasView.vue'
+
+describe('fitToPlanta', () => {
+  it('uses polygon bbox for zoom calculation', () => {
+    mockStore = {
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      plantaActivaData: {
+        nombre: 'Planta',
+        dimensiones: { ancho: 200, largo: 100 },
+        poligono: [
+          { x: 0, y: 0 },
+          { x: 200, y: 0 },
+          { x: 200, y: 100 },
+          { x: 0, y: 100 }
+        ]
+      },
+      elementosVisibles: [],
+      elementoSeleccionado: null,
+      agregarElemento: vi.fn(),
+      seleccionarElemento: vi.fn(),
+      estaEnElemento: false,
+      estaEnContenedor: false,
+      estaEnPlanta: true,
+      contextoActual: { tipo: 'plantas' },
+      vistaActiva: 'XY',
+      gridSize: 50,
+      canvasAdaptativo: { width: 400, height: 300 },
+      configurarZoom: vi.fn(),
+      configurarPan: vi.fn(),
+    }
+
+    const wrapper = mount(CanvasView)
+    wrapper.vm.stageRef = { getNode: () => ({}) }
+    wrapper.vm.stageSize = { width: 400, height: 400 }
+
+    wrapper.vm.fitToPlanta()
+
+    expect(mockStore.configurarZoom).toHaveBeenCalled()
+    const zoom = mockStore.configurarZoom.mock.calls[0][0]
+    expect(zoom).toBeCloseTo(1.6)
+  })
+})

--- a/src/__tests__/layer-order.spec.js
+++ b/src/__tests__/layer-order.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CanvasView from '@/components/CanvasView.vue'
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  mockStore = {
+    zoom: 1,
+    panX: 0,
+    panY: 0,
+    plantaActivaData: {
+      nombre: 'Planta',
+      dimensiones: { ancho: 100, largo: 100 },
+      poligono: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 }
+      ]
+    },
+    elementosVisibles: [],
+    elementoSeleccionado: null,
+    canvasAdaptativo: { width: 100, height: 100 },
+    gridSize: 50,
+    contextoActual: { tipo: 'plantas' },
+    estaEnPlanta: true,
+    estaEnElemento: false,
+    estaEnContenedor: false
+  }
+})
+
+describe('canvas layers order', () => {
+  it('background below content and overlays without clip', () => {
+    const wrapper = mount(CanvasView)
+    expect(wrapper.vm.backgroundLayerRef).toBeTruthy()
+    expect(wrapper.vm.layerRef).toBeTruthy()
+    expect(wrapper.vm.overlaysLayerRef).toBeTruthy()
+  })
+})

--- a/src/__tests__/polygonBounds.spec.js
+++ b/src/__tests__/polygonBounds.spec.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { pointInPolygon, clampRectToPolygon } from '@/utils/polygonBounds'
+
+describe('polygonBounds utils', () => {
+  it('pointInPolygon works with convex and concave polygons', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 }
+    ]
+    expect(pointInPolygon({ x: 5, y: 5 }, square)).toBe(true)
+    expect(pointInPolygon({ x: -1, y: 5 }, square)).toBe(false)
+
+    const concave = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 5, y: 5 },
+      { x: 0, y: 10 }
+    ]
+    expect(pointInPolygon({ x: 6, y: 6 }, concave)).toBe(true)
+    expect(pointInPolygon({ x: 4, y: 8 }, concave)).toBe(false)
+  })
+
+  it('clampRectToPolygon projects rectangle to nearest edge', () => {
+    const poly = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 }
+    ]
+    const rect = { x: -20, y: 10, width: 10, height: 10 }
+    const c = clampRectToPolygon(rect, poly)
+    expect(c.x).toBe(0)
+    expect(c.y).toBe(10)
+  })
+})

--- a/src/__tests__/polygonBounds.spec.js
+++ b/src/__tests__/polygonBounds.spec.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { pointInPolygon, clampRectToPolygon } from '@/utils/polygonBounds'
+import { polygonInset } from '@/utils/polygonInset'
 
 describe('polygonBounds utils', () => {
   it('pointInPolygon works with convex and concave polygons', () => {
@@ -34,5 +35,19 @@ describe('polygonBounds utils', () => {
     const c = clampRectToPolygon(rect, poly)
     expect(c.x).toBe(0)
     expect(c.y).toBe(10)
+  })
+
+  it('polygonInset keeps dragged rect inside', () => {
+    const poly = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 }
+    ]
+    const inset = polygonInset(poly, 1)
+    const rect = { x: -5, y: 50, width: 10, height: 10 }
+    const c = clampRectToPolygon(rect, inset)
+    const inside = pointInPolygon({ x: c.x + 5, y: c.y + 5 }, inset)
+    expect(inside).toBe(true)
   })
 })

--- a/src/__tests__/test-setup.js
+++ b/src/__tests__/test-setup.js
@@ -1,0 +1,32 @@
+import { vi } from 'vitest'
+
+// Stub vue-konva components globally
+vi.mock('vue-konva', () => ({
+  VueKonva: {},
+  default: { install: () => {} }
+}))
+
+import { config } from '@vue/test-utils'
+config.global.stubs = {
+  'v-stage': { template: '<div><slot /></div>' },
+  'v-layer': { template: '<div><slot /></div>', props: ['config'] },
+  'v-rect': true,
+  'v-circle': true,
+  'v-line': true,
+  'v-text': true,
+  'v-group': true,
+  'v-transformer': true,
+  'rulers-overlay': true
+}
+
+// Polyfill ResizeObserver for jsdom
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+if (typeof global !== 'undefined') {
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver
+}

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -64,24 +64,10 @@
 
         <!-- Aquí podrías añadir v-circle, etc., si tienes otras formas -->
       </template>
-        <!-- Fondo de la planta - área delimitada -->
-        <v-rect
-          :config="{
-            x: 0,
-            y: 0,
-            width: floorBoundary.width,
-            height: floorBoundary.height,
-            fill: 'rgba(14,165,233,0.08)',
-            stroke: '#3b82f6',
-            strokeWidth: 2,
-            opacity: 1,
-            listening: false,
-          }"
-        />
         <v-line
-          v-if="!canvasStore.estaEnElemento && !canvasStore.estaEnContenedor"
+          v-if="plantPolygon.length"
           :config="{
-            points: floorBoundary.points,
+            points: plantPolygonFlat,
             closed: true,
             stroke: '#0ea5e9',
             fill: 'rgba(14,165,233,0.08)',
@@ -574,11 +560,11 @@ import {
   projectMTDAgainstBoundary,
 } from '@/utils/collision'
 import {
-  rectInsidePolygon,
   clampRectToRect,
   snapToGrid,
   nudgePlace,
 } from '@/utils/geometry'
+import { clampRectToPolygon, pointInPolygon } from '@/utils/polygonBounds'
 import { GRID_SIZE, CM_TO_PX } from '@/utils/constants'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
 import { useContextMenu } from '@/composables/useContextMenu'
@@ -778,28 +764,29 @@ const stageConfig = computed(() => {
   }
 })
 
-const floorBoundary = computed(() => {
-  // Empezamos con las dimensiones base del layer
-  let width = layerConfig.value.width
-  let height = layerConfig.value.height
-  let points = []
-
-  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
-    return { width, height, points }
-  }
-
+const plantPolygon = computed(() => {
   const poligono = canvasStore.plantaActivaData?.poligono
+  if (poligono && Array.isArray(poligono) && poligono.length >= 3) return poligono
+  const w = canvasStore.plantaActivaData?.dimensiones?.ancho || layerConfig.value.width
+  const h = canvasStore.plantaActivaData?.dimensiones?.largo || layerConfig.value.height
+  return [
+    { x: 0, y: 0 },
+    { x: w, y: 0 },
+    { x: w, y: h },
+    { x: 0, y: h }
+  ]
+})
 
-  // Si hay un polígono, lo usamos para expandir los límites y obtener los puntos
-  if (poligono && Array.isArray(poligono) && poligono.length > 0) {
-    poligono.forEach((coord) => {
-      width = Math.max(coord.x, width)
-      height = Math.max(coord.y, height)
-    })
-    points = poligono.flatMap((p) => [p.x, p.y])
-  }
+const plantPolygonFlat = computed(() => plantPolygon.value.flatMap(p => [p.x, p.y]))
 
-  return { width, height, points }
+const floorBoundary = computed(() => {
+  const xs = plantPolygon.value.map(p => p.x)
+  const ys = plantPolygon.value.map(p => p.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+  return { width: maxX - minX, height: maxY - minY }
 })
 
 // Configuración del layer - SIEMPRE USA CANVAS ADAPTATIVO
@@ -836,6 +823,22 @@ const gridLines = computed(() => {
 
   return { vertical, horizontal }
 })
+
+watch(
+  plantPolygon,
+  (poly) => {
+    const layer = layerRef.value?.getNode?.()
+    if (layer && poly?.length) {
+      layer.clipFunc((ctx) => {
+        ctx.beginPath()
+        poly.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)))
+        ctx.closePath()
+      })
+      layer.batchDraw?.()
+    }
+  },
+  { immediate: true },
+)
 
 // Obtiene el contorno de la planta activa como rect o polígono
 const computeBoundary = () => {
@@ -979,14 +982,23 @@ const dragBoundForElement = (pos, elemento, forma = 'rect') => {
     const layerW = layerConfig.value.width
     const layerH = layerConfig.value.height
     const lp = toLayerCoords(pos)
-  if (forma === 'circular' || forma === 'circle') {
+    const boundary = computeBoundary()
+    if (forma === 'circular' || forma === 'circle') {
       const r = Math.min(elemento.width, elemento.height) / 2
       const cx = Math.max(r, Math.min(lp.x, layerW - r))
       const cy = Math.max(r, Math.min(lp.y, layerH - r))
       return toStageCoords({ x: cx, y: cy })
     } else {
-      const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
-      return toStageCoords(c)
+      if (boundary.type === 'polygon') {
+        const c = clampRectToPolygon(
+          { x: lp.x, y: lp.y, width: elemento.width, height: elemento.height },
+          boundary.points,
+        )
+        return toStageCoords(c)
+      } else {
+        const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
+        return toStageCoords(c)
+      }
     }
   } catch {
     return pos
@@ -1592,7 +1604,16 @@ const createElementFromDrop = (data, dropEvent) => {
       candY = clamped.y
     }
   } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, finalWidth, finalHeight, boundary.points)
+    isInsideArea = pointInPolygon({
+      x: candX + finalWidth / 2,
+      y: candY + finalHeight / 2,
+    }, boundary.points)
+    if (!isInsideArea) {
+      const clamped = clampRectToPolygon({ x: candX, y: candY, width: finalWidth, height: finalHeight }, boundary.points)
+      candX = clamped.x
+      candY = clamped.y
+      isInsideArea = pointInPolygon({ x: candX + finalWidth / 2, y: candY + finalHeight / 2 }, boundary.points)
+    }
   }
 
   // 6. Crear elemento temporal para detectar conflictos
@@ -1645,7 +1666,7 @@ const createElementFromDrop = (data, dropEvent) => {
 
   // 9. Si aún no hay posición válida, rechazar y mostrar toast
   if (!placementSuccessful) {
-    showToast('No hay espacio aquí para colocar el elemento', 'error')
+    showToast('Fuera de los límites de la planta', 'error')
     return // NO crear la instancia, NO comprometer historial
   }
 
@@ -1870,7 +1891,13 @@ const createElementFromBuffer = (data, dropEvent) => {
       candY = clamped.y
     }
   } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, width, height, boundary.points)
+    isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.points)
+    if (!isInsideArea) {
+      const clamped = clampRectToPolygon({ x: candX, y: candY, width, height }, boundary.points)
+      candX = clamped.x
+      candY = clamped.y
+      isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.points)
+    }
   }
 
   // 5. Crear elemento temporal y detectar conflictos
@@ -1920,7 +1947,7 @@ const createElementFromBuffer = (data, dropEvent) => {
 
   // 7. Si no hay posición válida, rechazar
   if (!placementSuccessful) {
-    showToast('No hay espacio aquí para pegar el elemento', 'error')
+    showToast('Fuera de los límites de la planta', 'error')
     return // NO pegar, NO comprometer historial
   }
 

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -31,6 +31,41 @@
       @dragmove="handleStageDragMove"
       @dragend="handleStageDragEnd"
     >
+      <v-layer ref="backgroundLayerRef" :config="{ listening: false }">
+        <v-line
+          v-if="plantPolygon.length"
+          :config="{
+            points: plantPolygonFlat,
+            closed: true,
+            stroke: '#0ea5e9',
+            fill: 'rgba(14,165,233,0.08)',
+            strokeWidth: 2,
+            listening: false,
+          }"
+        />
+        <v-line
+          v-for="i in gridLines.vertical"
+          :key="`v-${i}`"
+          :config="{
+            points: [i, 0, i, floorBoundary.height],
+            stroke: '#e5e7eb',
+            strokeWidth: 1,
+            opacity: 0.5,
+            listening: false,
+          }"
+        />
+        <v-line
+          v-for="i in gridLines.horizontal"
+          :key="`h-${i}`"
+          :config="{
+            points: [0, i, floorBoundary.width, i],
+            stroke: '#e5e7eb',
+            strokeWidth: 1,
+            opacity: 0.5,
+            listening: false,
+          }"
+        />
+      </v-layer>
       <v-layer ref="layerRef">
         <template v-if="canvasStore.elementoAura">
         <v-rect
@@ -64,17 +99,6 @@
 
         <!-- Aquí podrías añadir v-circle, etc., si tienes otras formas -->
       </template>
-        <v-line
-          v-if="plantPolygon.length"
-          :config="{
-            points: plantPolygonFlat,
-            closed: true,
-            stroke: '#0ea5e9',
-            fill: 'rgba(14,165,233,0.08)',
-            strokeWidth: 2,
-            listening: false,
-          }"
-        />
         <!-- Debug: mostrar información según el contexto -->
         <v-text
           :config="{
@@ -358,30 +382,8 @@
 
         <!-- Los contenedores se renderizan junto con los elementos en la sección principal -->
 
-        <!-- Grid de referencia de la planta -->
-        <v-line
-          v-for="i in gridLines.vertical"
-          :key="`v-${i}`"
-          :config="{
-            points: [i, 0, i, floorBoundary.height],
-            stroke: '#e5e7eb',
-            strokeWidth: 1,
-            opacity: 0.5,
-            listening: false,
-          }"
-        />
-        <v-line
-          v-for="i in gridLines.horizontal"
-          :key="`h-${i}`"
-          :config="{
-            points: [0, i, floorBoundary.width, i],
-            stroke: '#e5e7eb',
-            strokeWidth: 1,
-            opacity: 0.5,
-            listening: false,
-          }"
-        />
-        <!-- Transformer para modo edición -->
+      </v-layer>
+      <v-layer ref="overlaysLayerRef">
         <v-transformer
           v-if="isEditingSelected && canvasStore.elementoSeleccionado && !selectedElementLocked"
           ref="transformerRef"
@@ -564,7 +566,8 @@ import {
   snapToGrid,
   nudgePlace,
 } from '@/utils/geometry'
-import { clampRectToPolygon, pointInPolygon } from '@/utils/polygonBounds'
+import { clampRectToPolygon, pointInPolygon, clampPointToPolygon } from '@/utils/polygonBounds'
+import { polygonInset } from '@/utils/polygonInset'
 import { GRID_SIZE, CM_TO_PX } from '@/utils/constants'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
 import { useContextMenu } from '@/composables/useContextMenu'
@@ -591,6 +594,8 @@ const emit = defineEmits(['select', 'drill-down'])
 const containerRef = ref(null)
 const stageRef = ref(null)
 const layerRef = ref(null)
+const backgroundLayerRef = ref(null)
+const overlaysLayerRef = ref(null)
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
@@ -682,6 +687,10 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
     const c = clampRectToRect(x, y, w, h, W, H)
     x = c.x
     y = c.y
+  } else if (boundary.type === 'polygon') {
+    const c = clampRectToPolygon({ x, y, width: w, height: h }, boundary.inset)
+    x = c.x
+    y = c.y
   }
 
   for (let iter = 0; iter < MAX_ITERS; iter++) {
@@ -718,7 +727,9 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
       x = c2.x
       y = c2.y
     } else if (boundary.type === 'polygon') {
-      // En polígono no hay clamp trivial; si sale, revertimos a última válida luego
+      const c2 = clampRectToPolygon({ x, y, width: w, height: h }, boundary.inset)
+      x = c2.x
+      y = c2.y
     }
 
     // Si la corrección fue nula, detener
@@ -728,11 +739,16 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
   // Validaciones finales: si aún hay colisión bloqueante o quedó fuera, volver a última válida
   const movingEnd = { ...elemento, x, y }
   const endConf = detectConflictsFor(movingEnd, all).filter((c) => c.bloqueante)
-  const outsideRect =
+  const outsideArea =
     boundary.type === 'rect'
       ? x < -1e-6 || y < -1e-6 || x + w > W + 1e-6 || y + h > H + 1e-6
-      : false
-  if (endConf.length > 0 || outsideRect) {
+      : !pointInPolygon({ x: x + w / 2, y: y + h / 2 }, boundary.points)
+  if (outsideArea) {
+    const cp = clampPointToPolygon({ x: x + w / 2, y: y + h / 2 }, boundary.inset)
+    x = cp.x - w / 2
+    y = cp.y - h / 2
+  }
+  if (endConf.length > 0 || outsideArea) {
     const prev = lastValidPositions.value.get(elemento.id) || { x: elemento.x, y: elemento.y }
     return { x: prev.x, y: prev.y, fellBack: true }
   }
@@ -776,6 +792,8 @@ const plantPolygon = computed(() => {
     { x: 0, y: h }
   ]
 })
+
+const insetPoly = computed(() => polygonInset(plantPolygon.value, 1))
 
 const plantPolygonFlat = computed(() => plantPolygon.value.flatMap(p => [p.x, p.y]))
 
@@ -853,7 +871,7 @@ const computeBoundary = () => {
   // Si estamos en una planta, verificar si tiene polígono
   const planta = canvasStore.plantaActivaData
   if (planta?.poligono && Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
-    return { type: 'polygon', points: planta.poligono }
+    return { type: 'polygon', points: plantPolygon.value, inset: insetPoly.value }
   }
   return { type: 'rect', W, H }
 }
@@ -992,7 +1010,7 @@ const dragBoundForElement = (pos, elemento, forma = 'rect') => {
       if (boundary.type === 'polygon') {
         const c = clampRectToPolygon(
           { x: lp.x, y: lp.y, width: elemento.width, height: elemento.height },
-          boundary.points,
+          boundary.inset,
         )
         return toStageCoords(c)
       } else {
@@ -1607,12 +1625,12 @@ const createElementFromDrop = (data, dropEvent) => {
     isInsideArea = pointInPolygon({
       x: candX + finalWidth / 2,
       y: candY + finalHeight / 2,
-    }, boundary.points)
+    }, boundary.inset)
     if (!isInsideArea) {
-      const clamped = clampRectToPolygon({ x: candX, y: candY, width: finalWidth, height: finalHeight }, boundary.points)
+      const clamped = clampRectToPolygon({ x: candX, y: candY, width: finalWidth, height: finalHeight }, boundary.inset)
       candX = clamped.x
       candY = clamped.y
-      isInsideArea = pointInPolygon({ x: candX + finalWidth / 2, y: candY + finalHeight / 2 }, boundary.points)
+      isInsideArea = pointInPolygon({ x: candX + finalWidth / 2, y: candY + finalHeight / 2 }, boundary.inset)
     }
   }
 
@@ -1668,6 +1686,14 @@ const createElementFromDrop = (data, dropEvent) => {
   if (!placementSuccessful) {
     showToast('Fuera de los límites de la planta', 'error')
     return // NO crear la instancia, NO comprometer historial
+  }
+
+  if (boundary.type === 'polygon') {
+    const c = clampRectToPolygon(
+      { x: finalPosition.x, y: finalPosition.y, width: finalWidth, height: finalHeight },
+      boundary.inset,
+    )
+    finalPosition = { x: c.x, y: c.y }
   }
 
   // 10. Crear el elemento solo si la validación fue exitosa
@@ -1891,12 +1917,12 @@ const createElementFromBuffer = (data, dropEvent) => {
       candY = clamped.y
     }
   } else if (boundary.type === 'polygon') {
-    isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.points)
+    isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.inset)
     if (!isInsideArea) {
-      const clamped = clampRectToPolygon({ x: candX, y: candY, width, height }, boundary.points)
+      const clamped = clampRectToPolygon({ x: candX, y: candY, width, height }, boundary.inset)
       candX = clamped.x
       candY = clamped.y
-      isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.points)
+      isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.inset)
     }
   }
 
@@ -1949,6 +1975,14 @@ const createElementFromBuffer = (data, dropEvent) => {
   if (!placementSuccessful) {
     showToast('Fuera de los límites de la planta', 'error')
     return // NO pegar, NO comprometer historial
+  }
+
+  if (boundary.type === 'polygon') {
+    const c = clampRectToPolygon(
+      { x: finalPosition.x, y: finalPosition.y, width, height },
+      boundary.inset,
+    )
+    finalPosition = { x: c.x, y: c.y }
   }
 
   // 8. Pegar elemento desde buffer en posición válida

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,7 +1,7 @@
 // Geometry and containment helpers for 2D canvas (XY view)
 // Units: use canvas world units (same as layer coordinates, pixels tied to cm in UI)
 
-import { clampRectToPolygon } from './polygonBounds'
+import { clampRectToPolygon, pointInPolygon } from './polygonBounds'
 
 export const EPSILON = 1e-6
 
@@ -339,12 +339,12 @@ export const nudgePlace = (
         return { valid: false, x: testX, y: testY }
       }
     } else if (boundary.type === 'polygon') {
-      const clamped = clampRectToPolygon({ x: testX, y: testY, width, height }, boundary.points)
+      const clamped = clampRectToPolygon({ x: testX, y: testY, width, height }, boundary.inset)
       testX = clamped.x
       testY = clamped.y
       const centerInside = pointInPolygon(
         { x: testX + width / 2, y: testY + height / 2 },
-        boundary.points,
+        boundary.inset,
       )
       if (!centerInside) return { valid: false, x: testX, y: testY }
     }

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,6 +1,8 @@
 // Geometry and containment helpers for 2D canvas (XY view)
 // Units: use canvas world units (same as layer coordinates, pixels tied to cm in UI)
 
+import { clampRectToPolygon } from './polygonBounds'
+
 export const EPSILON = 1e-6
 
 // Basic math helpers
@@ -332,40 +334,34 @@ export const nudgePlace = (
 ) => {
   // Función auxiliar para verificar si una posición es válida
   const isValidPosition = (testX, testY) => {
-    // Verificar que esté dentro del área
     if (boundary.type === 'rect') {
       if (testX < 0 || testY < 0 || testX + width > boundary.W || testY + height > boundary.H) {
-        return false
+        return { valid: false, x: testX, y: testY }
       }
     } else if (boundary.type === 'polygon') {
-      if (!rectInsidePolygon(testX, testY, width, height, boundary.points)) {
-        return false
-      }
+      const clamped = clampRectToPolygon({ x: testX, y: testY, width, height }, boundary.points)
+      testX = clamped.x
+      testY = clamped.y
+      const centerInside = pointInPolygon(
+        { x: testX + width / 2, y: testY + height / 2 },
+        boundary.points,
+      )
+      if (!centerInside) return { valid: false, x: testX, y: testY }
     }
 
-    // Solo verificar conflictos si se proporciona la función
     if (detectConflictsFn) {
-      // Crear elemento temporal para verificar conflictos
-      const tempElement = {
-        ...elementToPlace,
-        x: testX,
-        y: testY,
-        width,
-        height,
-      }
-
+      const tempElement = { ...elementToPlace, x: testX, y: testY, width, height }
       const conflicts = detectConflictsFn(tempElement, allElements)
       const blockingConflicts = conflicts.filter((c) => c.bloqueante)
-
-      return blockingConflicts.length === 0
+      return { valid: blockingConflicts.length === 0, x: testX, y: testY }
     }
 
-    return true
+    return { valid: true, x: testX, y: testY }
   }
 
-  // Verificar posición inicial
-  if (isValidPosition(x, y)) {
-    return { x, y, found: true }
+  const initial = isValidPosition(x, y)
+  if (initial.valid) {
+    return { x: initial.x, y: initial.y, found: true }
   }
 
   // Búsqueda en espiral
@@ -395,8 +391,9 @@ export const nudgePlace = (
 
     // Probar cada punto en esta distancia
     for (const point of spiralPoints) {
-      if (isValidPosition(point.x, point.y)) {
-        return { x: point.x, y: point.y, found: true }
+      const res = isValidPosition(point.x, point.y)
+      if (res.valid) {
+        return { x: res.x, y: res.y, found: true }
       }
     }
   }

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -16,21 +16,6 @@ export const snapToGrid = (x, y, gridSize = 50) => {
   return { x: sx, y: sy }
 }
 
-// Point in polygon (ray casting), supports concave polygons
-export const pointInPolygon = (pt, polygon) => {
-  const { x, y } = pt
-  let inside = false
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const xi = polygon[i].x,
-      yi = polygon[i].y
-    const xj = polygon[j].x,
-      yj = polygon[j].y
-    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + EPSILON) + xi
-    if (intersect) inside = !inside
-  }
-  return inside
-}
-
 // Segment intersection
 export const segmentsIntersect = (p1, p2, p3, p4) => {
   const r = { x: p2.x - p1.x, y: p2.y - p1.y }

--- a/src/utils/polygonBounds.js
+++ b/src/utils/polygonBounds.js
@@ -1,0 +1,76 @@
+export function pointInPolygon(pt, poly) {
+  const x = pt.x ?? pt[0]
+  const y = pt.y ?? pt[1]
+  let inside = false
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i].x ?? poly[i][0]
+    const yi = poly[i].y ?? poly[i][1]
+    const xj = poly[j].x ?? poly[j][0]
+    const yj = poly[j].y ?? poly[j][1]
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / ((yj - yi) || 1e-12) + xi
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+export function nearestPointOnSegment(p, a, b) {
+  const px = p.x ?? p[0]
+  const py = p.y ?? p[1]
+  const ax = a.x ?? a[0]
+  const ay = a.y ?? a[1]
+  const bx = b.x ?? b[0]
+  const by = b.y ?? b[1]
+  const abx = bx - ax
+  const aby = by - ay
+  const apx = px - ax
+  const apy = py - ay
+  const ab2 = abx * abx + aby * aby
+  const t = ab2 === 0 ? 0 : (apx * abx + apy * aby) / ab2
+  const clampedT = Math.max(0, Math.min(1, t))
+  return { x: ax + abx * clampedT, y: ay + aby * clampedT }
+}
+
+export function clampPointToPolygon(p, poly) {
+  if (pointInPolygon(p, poly)) return { x: p.x ?? p[0], y: p.y ?? p[1] }
+  let best = { x: 0, y: 0, d: Infinity }
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    const np = nearestPointOnSegment(p, a, b)
+    const dx = (p.x ?? p[0]) - np.x
+    const dy = (p.y ?? p[1]) - np.y
+    const d = dx * dx + dy * dy
+    if (d < best.d) {
+      best = { x: np.x, y: np.y, d }
+    }
+  }
+  return { x: best.x, y: best.y }
+}
+
+export function clampRectToPolygon(rect, poly) {
+  const corners = [
+    { x: rect.x, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y + rect.height },
+    { x: rect.x, y: rect.y + rect.height }
+  ]
+  const deltas = []
+  for (const c of corners) {
+    if (!pointInPolygon(c, poly)) {
+      const clamped = clampPointToPolygon(c, poly)
+      deltas.push({ dx: clamped.x - c.x, dy: clamped.y - c.y })
+    }
+  }
+  if (deltas.length === 0) return { x: rect.x, y: rect.y }
+  // choose largest translation to cover all outside corners
+  let best = deltas[0]
+  let bestLen = best.dx * best.dx + best.dy * best.dy
+  for (const d of deltas.slice(1)) {
+    const len = d.dx * d.dx + d.dy * d.dy
+    if (len > bestLen) {
+      best = d
+      bestLen = len
+    }
+  }
+  return { x: rect.x + best.dx, y: rect.y + best.dy }
+}

--- a/src/utils/polygonInset.js
+++ b/src/utils/polygonInset.js
@@ -1,0 +1,26 @@
+export function polygonInset(poly, eps = 1) {
+  if (!Array.isArray(poly) || poly.length < 3) return []
+  const n = poly.length
+  const normals = Array.from({ length: n }, () => ({ x: 0, y: 0 }))
+  for (let i = 0; i < n; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % n]
+    const ex = b.x - a.x
+    const ey = b.y - a.y
+    const len = Math.hypot(ex, ey) || 1
+    const nx = ey / len
+    const ny = -ex / len
+    normals[i].x += nx
+    normals[i].y += ny
+    normals[(i + 1) % n].x += nx
+    normals[(i + 1) % n].y += ny
+  }
+  const inset = []
+  for (let i = 0; i < n; i++) {
+    const v = poly[i]
+    const nrm = normals[i]
+    const len = Math.hypot(nrm.x, nrm.y) || 1
+    inset.push({ x: v.x + (nrm.x / len) * eps, y: v.y + (nrm.y / len) * eps })
+  }
+  return inset
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,6 +9,7 @@ export default mergeConfig(
       environment: 'jsdom',
       exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url)),
+      setupFiles: ['./src/__tests__/test-setup.js'],
     },
   }),
 )


### PR DESCRIPTION
## Summary
- add polygonBounds utilities for point inclusion and clamping
- render plant area using polygon with layer clipping
- clamp drags and drops to polygon bounds
- tests for polygon helpers and behaviors

## Testing
- `npm run test:unit` *(fails: Failed to resolve component: v-rect, v-circle, etc.; Drop Validation tests failing, ReferenceError: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11e9449c8321acc2696d60d3f2e6