### PR TITLE
feat: polygon-based canvas bounds

### DIFF
--- a/src/__tests__/drop-validation.spec.js
+++ b/src/__tests__/drop-validation.spec.js
@@ -100,6 +100,33 @@ describe('Drop Validation - Bug Fix: Drop que nace bloqueado', () => {
     }
   })
 
+  it('rechaza drop fuera del polígono activo', async () => {
+    wrapper.vm.canvasStore.plantaActivaData.poligono = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 },
+    ]
+
+    const dropData = {
+      tipo: 'elemento-catalogo',
+      elemento: { tipo: 'mesa', width: 40, height: 40, ubicacion: 'suelo' },
+    }
+    const dropEvent = {
+      preventDefault: vi.fn(),
+      dataTransfer: { getData: vi.fn().mockReturnValue(JSON.stringify(dropData)) },
+      clientX: 250,
+      clientY: 250,
+    }
+
+    await wrapper.vm.createElementFromDrop(dropData, dropEvent)
+    expect(window.__toasts.show).toHaveBeenCalledWith(
+      'Fuera de los límites de la planta',
+      { type: 'error', timeout: 4000 },
+    )
+    expect(wrapper.vm.canvasStore.agregarElemento).not.toHaveBeenCalled()
+  })
+
   describe('Test 1: Drop sobre suelo–suelo se rechaza o reubica sin quedar bloqueado', () => {
     it('debería rechazar drop cuando hay conflicto suelo-suelo y no hay espacio alternativo', async () => {
       // Preparar escenario con elemento existente que bloquea

--- a/src/__tests__/fit_to_planta.spec.js
+++ b/src/__tests__/fit_to_planta.spec.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-konva', () => ({
+  VueKonva: {},
+  default: { install: () => {} },
+}))
+
+let storeMock
+
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({
+    store: storeMock,
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+  }),
+}))
+
+import CanvasView from '@/components/CanvasView.vue'
+
+beforeEach(() => {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+})
+
+describe('fitToPlanta', () => {
+  it('usa bbox del polígono para ajustar zoom', async () => {
+    storeMock = {
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      plantaActivaData: {
+        nombre: 'Planta',
+        dimensiones: { ancho: 200, largo: 200 },
+        poligono: [
+          { x: 50, y: 50 },
+          { x: 150, y: 50 },
+          { x: 150, y: 150 },
+          { x: 50, y: 150 },
+        ],
+      },
+      elementosVisibles: [],
+      elementoSeleccionado: null,
+      configurarZoom: vi.fn(),
+      configurarPan: vi.fn(),
+    }
+
+    const wrapper = mount(CanvasView, {
+      global: { plugins: [createPinia()] },
+    })
+
+    wrapper.vm.stageRef = { value: { getNode: () => ({}) } }
+    wrapper.vm.stageSize.value = { width: 500, height: 500 }
+
+    wrapper.vm.fitToPlanta()
+
+    expect(storeMock.configurarZoom).toHaveBeenCalled()
+    const zoomValue = storeMock.configurarZoom.mock.calls[0][0]
+    expect(zoomValue).toBeGreaterThan(3)
+  })
+})

--- a/src/__tests__/polygon_bounds.spec.js
+++ b/src/__tests__/polygon_bounds.spec.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { pointInPolygon, clampRectToPolygon } from '@/utils/polygonBounds'
+
+describe('polygonBounds utilities', () => {
+  it('pointInPolygon works for convex and concave polygons', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ]
+    expect(pointInPolygon({ x: 5, y: 5 }, square)).toBe(true)
+    expect(pointInPolygon({ x: 15, y: 5 }, square)).toBe(false)
+
+    const concave = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 5, y: 5 },
+      { x: 0, y: 10 },
+    ]
+    expect(pointInPolygon({ x: 2, y: 2 }, concave)).toBe(true)
+    expect(pointInPolygon({ x: 7, y: 7 }, concave)).toBe(false)
+  })
+
+  it('clampRectToPolygon snaps rectangle to polygon edge', () => {
+    const poly = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 },
+    ]
+    const rect = { x: 95, y: 40, width: 20, height: 20 }
+    const clamped = clampRectToPolygon(rect, poly)
+    expect(clamped.x + clamped.width).toBeLessThanOrEqual(100)
+    expect(clamped.x).toBe(80)
+  })
+})

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -64,20 +64,6 @@
 
         <!-- Aquí podrías añadir v-circle, etc., si tienes otras formas -->
       </template>
-        <!-- Fondo de la planta - área delimitada -->
-        <v-rect
-          :config="{
-            x: 0,
-            y: 0,
-            width: floorBoundary.width,
-            height: floorBoundary.height,
-            fill: 'rgba(14,165,233,0.08)',
-            stroke: '#3b82f6',
-            strokeWidth: 2,
-            opacity: 1,
-            listening: false,
-          }"
-        />
         <v-line
           v-if="!canvasStore.estaEnElemento && !canvasStore.estaEnContenedor"
           :config="{
@@ -573,18 +559,13 @@ import {
   computeMTD,
   projectMTDAgainstBoundary,
 } from '@/utils/collision'
-import {
-  rectInsidePolygon,
-  clampRectToRect,
-  snapToGrid,
-  nudgePlace,
-} from '@/utils/geometry'
+import { snapToGrid, nudgePlace } from '@/utils/geometry'
+import { pointInPolygon, clampRectToPolygon } from '@/utils/polygonBounds'
 import { GRID_SIZE, CM_TO_PX } from '@/utils/constants'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useDeleteElement } from '@/composables/useDeleteElement'
 import { useConfirmDialog } from '@/composables/useConfirmDialog'
-import { applyEdgeConstraint } from '@/utils/edgeConstraint'
 import { resetEdgeState } from '@/composables/useEdgeState'
 import { resolveFinalByIntervals } from '@/utils/finalIntervals'
 import { finalizePlacement } from '@/utils/finalizeDrag'
@@ -688,15 +669,10 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
   // Iterar para resolver múltiples colisiones respetando contorno
   const MAX_ITERS = 3
   const boundary = computeBoundary()
-  const W = boundary.type === 'rect' ? boundary.W : Infinity
-  const H = boundary.type === 'rect' ? boundary.H : Infinity
 
-  // Paso (1): clamp al área primero
-  if (boundary.type === 'rect') {
-    const c = clampRectToRect(x, y, w, h, W, H)
-    x = c.x
-    y = c.y
-  }
+  const c = clampRectToPolygon({ x, y, width: w, height: h }, boundary.points)
+  x = c.x
+  y = c.y
 
   for (let iter = 0; iter < MAX_ITERS; iter++) {
     const moving = { ...elemento, x, y }
@@ -727,13 +703,9 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
     x += accDx
     y += accDy
 
-    if (boundary.type === 'rect') {
-      const c2 = clampRectToRect(x, y, w, h, W, H)
-      x = c2.x
-      y = c2.y
-    } else if (boundary.type === 'polygon') {
-      // En polígono no hay clamp trivial; si sale, revertimos a última válida luego
-    }
+    const c2 = clampRectToPolygon({ x, y, width: w, height: h }, boundary.points)
+    x = c2.x
+    y = c2.y
 
     // Si la corrección fue nula, detener
     if (Math.abs(accDx) < 1e-6 && Math.abs(accDy) < 1e-6) break
@@ -779,37 +751,56 @@ const stageConfig = computed(() => {
 })
 
 const floorBoundary = computed(() => {
-  // Empezamos con las dimensiones base del layer
   let width = layerConfig.value.width
   let height = layerConfig.value.height
   let points = []
 
   if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
+    points = [0, 0, width, 0, width, height, 0, height]
     return { width, height, points }
   }
 
   const poligono = canvasStore.plantaActivaData?.poligono
-
-  // Si hay un polígono, lo usamos para expandir los límites y obtener los puntos
   if (poligono && Array.isArray(poligono) && poligono.length > 0) {
     poligono.forEach((coord) => {
       width = Math.max(coord.x, width)
       height = Math.max(coord.y, height)
     })
     points = poligono.flatMap((p) => [p.x, p.y])
+  } else {
+    points = [0, 0, width, 0, width, height, 0, height]
   }
 
   return { width, height, points }
 })
 
-// Configuración del layer - SIEMPRE USA CANVAS ADAPTATIVO
+// Configuración del layer - siempre usa canvas adaptativo y aplica clipFunc
 const layerConfig = computed(() => {
-  // Usar siempre canvasAdaptativo como fuente única de verdad
   return {
     width: canvasStore.canvasAdaptativo.width,
     height: canvasStore.canvasAdaptativo.height,
+    clipFunc: (ctx) => {
+      const pts = floorBoundary.value.points
+      if (pts.length >= 2) {
+        ctx.beginPath()
+        ctx.moveTo(pts[0], pts[1])
+        for (let i = 2; i < pts.length; i += 2) ctx.lineTo(pts[i], pts[i + 1])
+        ctx.closePath()
+      }
+    },
   }
 })
+
+watch(
+  () => canvasStore.plantaActivaData?.poligono,
+  () => {
+    resetEdgeState()
+    nextTick(() => {
+      fitToPlanta()
+      stageRef.value?.getNode?.()?.batchDraw?.()
+    })
+  },
+)
 
 // Elementos visibles en el canvas (excluye elementos ocultos)
 const elementosVisiblesEnCanvas = computed(() => {
@@ -844,15 +835,30 @@ const computeBoundary = () => {
 
   // Si estamos en un elemento o contenedor, usar todo el canvas adaptativo como boundary
   if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
-    return { type: 'rect', W, H }
+    return {
+      type: 'polygon',
+      points: [
+        { x: 0, y: 0 },
+        { x: W, y: 0 },
+        { x: W, y: H },
+        { x: 0, y: H },
+      ],
+    }
   }
 
-  // Si estamos en una planta, verificar si tiene polígono
   const planta = canvasStore.plantaActivaData
   if (planta?.poligono && Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
     return { type: 'polygon', points: planta.poligono }
   }
-  return { type: 'rect', W, H }
+  return {
+    type: 'polygon',
+    points: [
+      { x: 0, y: 0 },
+      { x: W, y: 0 },
+      { x: W, y: H },
+      { x: 0, y: H },
+    ],
+  }
 }
 
 // === FUNCIONES DE ZOOM ===
@@ -976,18 +982,13 @@ const toStageCoords = (pos) => {
 // Drag bound para cada elemento y forma (clamp mínimo al contorno)
 const dragBoundForElement = (pos, elemento, forma = 'rect') => {
   try {
-    const layerW = layerConfig.value.width
-    const layerH = layerConfig.value.height
     const lp = toLayerCoords(pos)
-  if (forma === 'circular' || forma === 'circle') {
-      const r = Math.min(elemento.width, elemento.height) / 2
-      const cx = Math.max(r, Math.min(lp.x, layerW - r))
-      const cy = Math.max(r, Math.min(lp.y, layerH - r))
-      return toStageCoords({ x: cx, y: cy })
-    } else {
-      const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
-      return toStageCoords(c)
-    }
+    const boundary = computeBoundary()
+    const c = clampRectToPolygon(
+      { x: lp.x, y: lp.y, width: elemento.width, height: elemento.height },
+      boundary.points,
+    )
+    return toStageCoords(c)
   } catch {
     return pos
   }
@@ -1089,20 +1090,20 @@ const startElementDrag = (elementId) => {
         if (!shape) return
         const elemento = canvasStore.elementosVisibles.find((el) => el.id === elementId)
         if (!elemento) return
-        const W = layerConfig.value.width
-        const H = layerConfig.value.height
-        const areaBounds = { minX: 0, minY: 0, maxX: W, maxY: H }
-
         // Para círculos, desiredPos ya es top-left (convertido en updateElementPosition)
         const asRect = elemento.forma === 'circular'
           ? { ...elemento, width: Math.min(elemento.width, elemento.height), height: Math.min(elemento.width, elemento.height) }
           : elemento
 
-        const { pos } = applyEdgeConstraint({ x: desiredPos.x, y: desiredPos.y }, asRect, areaBounds)
+        const boundary = computeBoundary()
+        const clamped = clampRectToPolygon(
+          { x: desiredPos.x, y: desiredPos.y, width: asRect.width, height: asRect.height },
+          boundary.points,
+        )
 
         // Resolver colisiones después del clamp a borde
-        let x = pos.x
-        let y = pos.y
+        let x = clamped.x
+        let y = clamped.y
         const res = resolveAgainstBlockingObstacles(x, y, asRect)
         x = res.x
         y = res.y
@@ -1575,24 +1576,21 @@ const createElementFromDrop = (data, dropEvent) => {
 
   // 4. Calcular bbox candidato y verificar área
   const boundary = computeBoundary()
-
-  // 5. Verificar que esté dentro del área (clampToArea)
-  let isInsideArea = true
-  if (boundary.type === 'rect') {
-    isInsideArea =
-      candX >= 0 &&
-      candY >= 0 &&
-      candX + finalWidth <= boundary.W &&
-      candY + finalHeight <= boundary.H
-
-    // Si está fuera, intentar clamp
-    if (!isInsideArea) {
-      const clamped = clampRectToRect(candX, candY, finalWidth, finalHeight, boundary.W, boundary.H)
-      candX = clamped.x
-      candY = clamped.y
-    }
-  } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, finalWidth, finalHeight, boundary.points)
+  const center = { x: candX + finalWidth / 2, y: candY + finalHeight / 2 }
+  let isInsideArea = pointInPolygon(center, boundary.points)
+  if (!isInsideArea) {
+    const clamped = clampRectToPolygon(
+      { x: candX, y: candY, width: finalWidth, height: finalHeight },
+      boundary.points,
+    )
+    candX = clamped.x
+    candY = clamped.y
+    const newCenter = { x: candX + finalWidth / 2, y: candY + finalHeight / 2 }
+    isInsideArea = pointInPolygon(newCenter, boundary.points)
+  }
+  if (!isInsideArea) {
+    showToast('Fuera de los límites de la planta', 'error')
+    return
   }
 
   // 6. Crear elemento temporal para detectar conflictos
@@ -1614,7 +1612,7 @@ const createElementFromDrop = (data, dropEvent) => {
 
   // 8. Si hay conflicto BLOQUEANTE o queda fuera de área, intentar nudgePlace
   let finalPosition = { x: candX, y: candY }
-  let placementSuccessful = blockingConflicts.length === 0 && isInsideArea
+  let placementSuccessful = blockingConflicts.length === 0
 
   if (!placementSuccessful) {
     console.log(
@@ -1858,19 +1856,21 @@ const createElementFromBuffer = (data, dropEvent) => {
 
   // 4. Verificar área y conflictos
   const boundary = computeBoundary()
-
-  let isInsideArea = true
-  if (boundary.type === 'rect') {
-    isInsideArea =
-      candX >= 0 && candY >= 0 && candX + width <= boundary.W && candY + height <= boundary.H
-
-    if (!isInsideArea) {
-      const clamped = clampRectToRect(candX, candY, width, height, boundary.W, boundary.H)
-      candX = clamped.x
-      candY = clamped.y
-    }
-  } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, width, height, boundary.points)
+  const center = { x: candX + width / 2, y: candY + height / 2 }
+  let isInsideArea = pointInPolygon(center, boundary.points)
+  if (!isInsideArea) {
+    const clamped = clampRectToPolygon(
+      { x: candX, y: candY, width, height },
+      boundary.points,
+    )
+    candX = clamped.x
+    candY = clamped.y
+    const newCenter = { x: candX + width / 2, y: candY + height / 2 }
+    isInsideArea = pointInPolygon(newCenter, boundary.points)
+  }
+  if (!isInsideArea) {
+    showToast('Fuera de los límites de la planta', 'error')
+    return
   }
 
   // 5. Crear elemento temporal y detectar conflictos
@@ -1891,7 +1891,7 @@ const createElementFromBuffer = (data, dropEvent) => {
 
   // 6. Si hay conflictos o está fuera de área, intentar nudgePlace
   let finalPosition = { x: candX, y: candY }
-  let placementSuccessful = blockingConflicts.length === 0 && isInsideArea
+  let placementSuccessful = blockingConflicts.length === 0
 
   if (!placementSuccessful) {
     console.log('🔍 Elemento del buffer tiene conflictos, intentando nudgePlace...')

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,6 +1,8 @@
 // Geometry and containment helpers for 2D canvas (XY view)
 // Units: use canvas world units (same as layer coordinates, pixels tied to cm in UI)
 
+import { pointInPolygon, clampRectToPolygon } from './polygonBounds'
+
 export const EPSILON = 1e-6
 
 // Basic math helpers
@@ -12,21 +14,6 @@ export const snapToGrid = (x, y, gridSize = 50) => {
   const sx = Math.round(x / gridSize) * gridSize
   const sy = Math.round(y / gridSize) * gridSize
   return { x: sx, y: sy }
-}
-
-// Point in polygon (ray casting), supports concave polygons
-export const pointInPolygon = (pt, polygon) => {
-  const { x, y } = pt
-  let inside = false
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const xi = polygon[i].x,
-      yi = polygon[i].y
-    const xj = polygon[j].x,
-      yj = polygon[j].y
-    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + EPSILON) + xi
-    if (intersect) inside = !inside
-  }
-  return inside
 }
 
 // Segment intersection
@@ -186,7 +173,16 @@ export const snapRectElementInside = (elem, boundary, gridSize = null) => {
     }
     return clampRectToRect(nx, ny, elem.width, elem.height, boundary.W, boundary.H)
   }
-  // For polygons, snapping is non-trivial; return null to signal unsupported
+  if (boundary.type === 'polygon') {
+    let nx = elem.x
+    let ny = elem.y
+    if (gridSize) {
+      const s = snapToGrid(nx, ny, gridSize)
+      nx = s.x
+      ny = s.y
+    }
+    return clampRectToPolygon({ x: nx, y: ny, width: elem.width, height: elem.height }, boundary.points)
+  }
   return null
 }
 
@@ -246,8 +242,13 @@ export const boundedRectDrag = (candidateX, candidateY, w, h, boundary, snapEps 
     return { x, y, atEdge, snapped, inside }
   }
   if (boundary.type === 'polygon') {
-    const inside = rectInsidePolygon(candidateX, candidateY, w, h, boundary.points)
-    return { x: candidateX, y: candidateY, atEdge: false, snapped: false, inside }
+    const clamped = clampRectToPolygon(
+      { x: candidateX, y: candidateY, width: w, height: h },
+      boundary.points,
+    )
+    const atEdge = clamped.x !== candidateX || clamped.y !== candidateY
+    const inside = pointInPolygon({ x: clamped.x + w / 2, y: clamped.y + h / 2 }, boundary.points)
+    return { x: clamped.x, y: clamped.y, atEdge, snapped: false, inside }
   }
   return { x: candidateX, y: candidateY, atEdge: false, snapped: false, inside: true }
 }

--- a/src/utils/polygonBounds.js
+++ b/src/utils/polygonBounds.js
@@ -1,0 +1,69 @@
+// Utility functions for polygonal bounds operations
+// pointInPolygon(pt, poly): pt {x,y}, poly array of {x,y}
+// nearestPointOnSegment(p,a,b): p {x,y} to segment ab {x,y}
+// clampPointToPolygon(p, poly): project point p to nearest point on polygon
+// clampRectToPolygon(rect, poly): rect {x,y,width,height}
+
+export function pointInPolygon(pt, poly) {
+  let inside = false
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i].x, yi = poly[i].y
+    const xj = poly[j].x, yj = poly[j].y
+    const intersect = (yi > pt.y) !== (yj > pt.y) &&
+      pt.x < ((xj - xi) * (pt.y - yi)) / (yj - yi) + xi
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+export function nearestPointOnSegment(p, a, b) {
+  const abx = b.x - a.x
+  const aby = b.y - a.y
+  const t = ((p.x - a.x) * abx + (p.y - a.y) * aby) / (abx * abx + aby * aby)
+  const clampedT = Math.max(0, Math.min(1, t))
+  return { x: a.x + abx * clampedT, y: a.y + aby * clampedT }
+}
+
+export function clampPointToPolygon(p, poly) {
+  if (pointInPolygon(p, poly)) return { ...p }
+  let closest = null
+  let minDist = Infinity
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    const q = nearestPointOnSegment(p, a, b)
+    const dx = p.x - q.x
+    const dy = p.y - q.y
+    const dist = dx * dx + dy * dy
+    if (dist < minDist) {
+      minDist = dist
+      closest = q
+    }
+  }
+  return closest || { ...p }
+}
+
+export function clampRectToPolygon(rect, poly) {
+  const { x, y, width, height } = rect
+  const corners = [
+    { x, y },
+    { x: x + width, y },
+    { x: x + width, y: y + height },
+    { x, y: y + height }
+  ]
+  let maxDx = 0
+  let maxDy = 0
+  let changed = false
+  for (const c of corners) {
+    const q = clampPointToPolygon(c, poly)
+    const dx = q.x - c.x
+    const dy = q.y - c.y
+    if (dx !== 0 || dy !== 0) {
+      changed = true
+      if (Math.abs(dx) > Math.abs(maxDx)) maxDx = dx
+      if (Math.abs(dy) > Math.abs(maxDy)) maxDy = dy
+    }
+  }
+  if (!changed) return { x, y, width, height }
+  return { x: x + maxDx, y: y + maxDy, width, height }
+}


### PR DESCRIPTION
## Summary
- add polygonBounds utilities for point and rect clamping
- clip canvas layer and drag/drop logic to active polygon
- cover polygon behaviours with new tests

## Testing
- `npm run test:unit` *(fails: Failed Tests 25, ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11e9449c8321acc2696d60d3f2e6