### PR TITLE
feat: wall placement validation and geometry helpers

### DIFF
--- a/src/__tests__/wall_placement.spec.js
+++ b/src/__tests__/wall_placement.spec.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { isWallFormValid } from '@/utils/validation'
+import { attachToWall } from '@/utils/wallAttach'
+import { isWallPlacementValid } from '@/utils/wallPlacement'
+
+const poly = [
+  { x: 0, y: 0 },
+  { x: 200, y: 0 },
+  { x: 200, y: 200 },
+  { x: 0, y: 200 },
+]
+
+describe('validación de formularios de pared', () => {
+  it('guardar deshabilitado si alturaRespectoSuelo <= 0', () => {
+    const el = { ubicacion: 'pared', alturaRespectoSuelo: 0, dimensiones: { alto: 10 } }
+    expect(isWallFormValid(el)).toBe(false)
+    const ok = { ubicacion: 'pared', alturaRespectoSuelo: 5, dimensiones: { alto: 10 } }
+    expect(isWallFormValid(ok)).toBe(true)
+  })
+})
+
+describe('isWallPlacementValid reglas básicas', () => {
+  const baseEl = {
+    id: 'wall',
+    ubicacion: 'pared',
+    elevacion: { zBase: 10, altura: 50 },
+    tolerancias: { zEpsilon: 0.5 },
+  }
+  const size = { width: 20, height: 20 }
+  const pos = { x: 0, y: 90 } // near left wall
+
+  it('zTop ≤ bodegaAltura', () => {
+    const el = { ...baseEl, elevacion: { zBase: 260, altura: 50 } }
+    expect(isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 300, el, vecinos: [] })).toBe(false)
+    const okEl = { ...baseEl, elevacion: { zBase: 200, altura: 50 } }
+    expect(isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 300, el: okEl, vecinos: [] })).toBe(true)
+  })
+
+  it('pared/pared con solape Z bloquea', () => {
+    const vecino = {
+      id: 'v1',
+      x: 0,
+      y: 90,
+      width: 20,
+      height: 20,
+      ubicacion: 'pared',
+      elevacion: { zBase: 20, altura: 40 },
+      tolerancias: { zEpsilon: 0.5 },
+    }
+    const el = { ...baseEl, elevacion: { zBase: 30, altura: 40 } }
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 300, el, vecinos: [vecino] })
+    ).toBe(false)
+
+    const el2 = { ...baseEl, elevacion: { zBase: 70, altura: 20 } }
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 300, el: el2, vecinos: [vecino] })
+    ).toBe(true)
+  })
+
+  it('pared con elemento de suelo requiere zBase por encima del suelo', () => {
+    const suelo = {
+      id: 's1',
+      x: 0,
+      y: 90,
+      width: 20,
+      height: 20,
+      ubicacion: 'suelo',
+      elevacion: { zBase: 0, altura: 30 },
+      tolerancias: { zEpsilon: 0.5 },
+    }
+    const el = { ...baseEl, elevacion: { zBase: 20, altura: 20 } }
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 300, el, vecinos: [suelo] })
+    ).toBe(false)
+
+    const el2 = { ...baseEl, elevacion: { zBase: 40, altura: 20 } }
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 300, el: el2, vecinos: [suelo] })
+    ).toBe(true)
+  })
+})
+
+describe('attachToWall', () => {
+  it('pega al segmento más cercano', () => {
+    const pos = { x: 160, y: 20 }
+    const size = { width: 20, height: 20 }
+    const snapped = attachToWall(pos, size, poly)
+    expect(snapped.x).toBe(180)
+    expect(snapped.y).toBe(20)
+  })
+})

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -319,11 +319,24 @@
           Restablecer
         </button>
         <button
+          @click="guardarCambios"
+          :disabled="elementoSeleccionado.ubicacion === 'pared' && !wallFormOk"
+          class="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm disabled:opacity-50 cursor-pointer"
+        >
+          Guardar
+        </button>
+        <button
           @click="deseleccionarElemento"
           class="flex-1 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm"
         >
           Deseleccionar
         </button>
+      </div>
+      <div
+        v-if="elementoSeleccionado.ubicacion === 'pared' && !wallFormOk"
+        class="text-red-600 text-xs mt-2"
+      >
+        Define la altura respecto al suelo
       </div>
     </div>
   </div>
@@ -342,6 +355,7 @@ import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS } from '@/utils/constants'
 import { useDeleteElement } from '@/composables/useDeleteElement'
 import TagFilter from './TagFilter.vue'
 import CreateTagModal from './CreateTagModal.vue'
+import { isWallFormValid } from '@/utils/validation'
 
 // Store
 const canvasStore = useCanvasStore()
@@ -362,6 +376,8 @@ const isLockedSelected = computed(() => {
   const el = elementoSeleccionado.value
   return !!(el && (el.bloqueado === true || el.locked === true))
 })
+
+const wallFormOk = computed(() => isWallFormValid(elementoSeleccionado.value))
 
 // Watchers
 watch(
@@ -419,6 +435,10 @@ const resetearPropiedades = () => {
 
 const deseleccionarElemento = () => {
   canvasStore.seleccionarElemento(null)
+}
+
+const guardarCambios = () => {
+  // Cambios aplicados en tiempo real; esta función actúa como placeholder
 }
 
 const onDeleteClick = () => {

--- a/src/utils/serialization.js
+++ b/src/utils/serialization.js
@@ -21,16 +21,16 @@
  * @returns {string} JSON serializado del estado
  */
 export function serializeCanvas(canvasState) {
-  // TODO: Implementar serialización del canvas
-  // - Convertir estado a formato JSON
-  // - Manejar referencias circulares
-  // - Incluir metadatos (versión, timestamp)
-  // - Validar integridad antes de serializar
+  // Normalizar elementos de pared antes de serializar
+  const clone = structuredClone(canvasState)
+  if (Array.isArray(clone?.elementos)) {
+    clone.elementos = clone.elementos.map((el) => ensureWallDefaults(structuredClone(el)))
+  }
 
   return JSON.stringify({
     version: '1.0.0',
     timestamp: new Date().toISOString(),
-    data: canvasState,
+    data: clone,
   })
 }
 
@@ -48,11 +48,28 @@ export function deserializeCanvas(jsonData) {
 
   try {
     const parsed = JSON.parse(jsonData)
+    if (Array.isArray(parsed?.data?.elementos)) {
+      parsed.data.elementos = parsed.data.elementos.map((el) => ensureWallDefaults(el))
+    }
     return parsed.data
   } catch (error) {
     console.error('Error deserializando canvas:', error)
     throw new Error('Formato de archivo inválido')
   }
+}
+
+// --- Helpers ---
+export function ensureWallDefaults(el) {
+  if (el && el.ubicacion === 'pared') {
+    const zBase = Number(el.alturaRespectoSuelo ?? el.alturaRespectoAlSuelo ?? el.elevacion?.zBase ?? 0)
+    const alto = Number(el.dimensiones?.alto ?? el.elevacion?.altura ?? 0)
+    el.elevacion = el.elevacion || {}
+    if (el.elevacion.zBase === undefined) el.elevacion.zBase = zBase
+    if (el.elevacion.altura === undefined) el.elevacion.altura = alto
+    el.tolerancias = el.tolerancias || {}
+    if (el.tolerancias.zEpsilon === undefined) el.tolerancias.zEpsilon = 0.5
+  }
+  return el
 }
 
 /**

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,8 @@
+export function isWallFormValid(el) {
+  if (!el || el.ubicacion !== 'pared') return true
+  const altura = Number(el.alturaRespectoSuelo ?? el.alturaRespectoAlSuelo)
+  const alto = Number(el.dimensiones?.alto)
+  return altura > 0 && !Number.isNaN(altura) && alto > 0 && !Number.isNaN(alto)
+}
+
+export default { isWallFormValid }

--- a/src/utils/wallAttach.js
+++ b/src/utils/wallAttach.js
@@ -1,0 +1,38 @@
+import { clamp } from './geometry'
+
+export function nearestWallPoint(poly, p) {
+  if (!Array.isArray(poly) || poly.length < 2) return { point: { ...p }, dist: 0, segmentIndex: -1 }
+  let best = null
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    const abx = b.x - a.x
+    const aby = b.y - a.y
+    const abLenSq = abx * abx + aby * aby || 1
+    let t = ((p.x - a.x) * abx + (p.y - a.y) * aby) / abLenSq
+    t = clamp(t, 0, 1)
+    const proj = { x: a.x + t * abx, y: a.y + t * aby }
+    const dx = p.x - proj.x
+    const dy = p.y - proj.y
+    const dist = Math.hypot(dx, dy)
+    if (!best || dist < best.dist) {
+      best = { point: proj, dist, segmentIndex: i }
+    }
+  }
+  return best || { point: { ...p }, dist: 0, segmentIndex: -1 }
+}
+
+export function attachToWall(pos, size, poly) {
+  const center = { x: pos.x + size.width / 2, y: pos.y + size.height / 2 }
+  const { point } = nearestWallPoint(poly, center)
+  const dx = center.x - point.x
+  const dy = center.y - point.y
+  const len = Math.hypot(dx, dy) || 1
+  const nx = dx / len
+  const ny = dy / len
+  const offset = Math.abs(nx) > Math.abs(ny) ? size.width / 2 : size.height / 2
+  const newCenter = { x: point.x + nx * offset, y: point.y + ny * offset }
+  return { x: newCenter.x - size.width / 2, y: newCenter.y - size.height / 2 }
+}
+
+export default { nearestWallPoint, attachToWall }

--- a/src/utils/wallPlacement.js
+++ b/src/utils/wallPlacement.js
@@ -1,0 +1,50 @@
+import { SNAP_EPS } from './constants'
+import { nearestWallPoint } from './wallAttach'
+
+function overlapXY(pos, size, other) {
+  return !(pos.x + size.width <= other.x || other.x + other.width <= pos.x || pos.y + size.height <= other.y || other.y + other.height <= pos.y)
+}
+
+export function isWallPlacementValid({ posXY, size, plantaPoly, bodegaAltura, el, vecinos = [], eps = 0.5, snapPx = SNAP_EPS }) {
+  if (!posXY || !size || !plantaPoly || !el) return false
+  // a) pegado a pared
+  const center = { x: posXY.x + size.width / 2, y: posXY.y + size.height / 2 }
+  const { point, dist } = nearestWallPoint(plantaPoly, center)
+  const dx = center.x - point.x
+  const dy = center.y - point.y
+  const len = Math.hypot(dx, dy) || 1
+  const nx = dx / len
+  const ny = dy / len
+  const offset = Math.abs(nx) > Math.abs(ny) ? size.width / 2 : size.height / 2
+  const edgeDist = Math.abs(dist - offset)
+  if (edgeDist > snapPx + eps) return false
+
+  // b) altura techo
+  const elev = el.elevacion || { zBase: 0, altura: 0 }
+  const zTop = (elev.zBase || 0) + (elev.altura || 0)
+  if (bodegaAltura !== undefined && zTop > bodegaAltura + eps) return false
+
+  const zEpsSelf = el.tolerancias?.zEpsilon ?? eps
+  for (const v of vecinos) {
+    const vElev = v.elevacion || { zBase: 0, altura: 0 }
+    const vZBase = vElev.zBase || 0
+    const vZTop = vZBase + (vElev.altura || 0)
+    const zEps = Math.max(zEpsSelf, v.tolerancias?.zEpsilon ?? eps)
+    if (v.ubicacion === 'pared') {
+      if (overlapXY(posXY, size, v)) {
+        const zBase = elev.zBase || 0
+        if (!(zTop <= vZBase + zEps || vZTop <= zBase + zEps)) return false
+      }
+    } else if ((v.ubicacion || 'suelo') === 'suelo') {
+      if (overlapXY(posXY, size, v)) {
+        const zBase = elev.zBase || 0
+        const floorTop = vZTop
+        if (zBase < floorTop + zEps) return false
+      }
+    }
+  }
+
+  return true
+}
+
+export default { isWallPlacementValid }


### PR DESCRIPTION
## Summary
- add form validation helper for wall elements and wire it to properties panel
- ensure wall elements have elevation and tolerance defaults when serialized
- add wall geometry helpers for attaching to walls and placement validation
- provide unit tests covering wall placement scenarios

## Testing
- `npm run test:unit` *(fails: TypeError 'set' on proxy: trap returned falsish for property 'vistaActiva')*


------
https://chatgpt.com/codex/tasks/task_e_68ae15412130832183557d69e99239ad