### PR TITLE
feat: add wall placement utilities

### DIFF
--- a/src/__tests__/wall-placement.spec.js
+++ b/src/__tests__/wall-placement.spec.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { isWallFormValid } from '@/utils/validation'
+import { isWallPlacementValid } from '@/utils/wallPlacement'
+import { attachToWall } from '@/utils/wallAttach'
+
+const poly = [
+  { x: 0, y: 0 },
+  { x: 100, y: 0 },
+  { x: 100, y: 100 },
+  { x: 0, y: 100 },
+]
+
+describe('wall placement utilities', () => {
+  it('formulario pared inválido si altura o alto son ≤0', () => {
+    expect(
+      isWallFormValid({ ubicacion: 'pared', alturaRespectoAlSuelo: 0, dimensiones: { alto: 10 } }),
+    ).toBe(false)
+    expect(
+      isWallFormValid({ ubicacion: 'pared', alturaRespectoAlSuelo: 10, dimensiones: { alto: 0 } }),
+    ).toBe(false)
+    expect(
+      isWallFormValid({ ubicacion: 'pared', alturaRespectoAlSuelo: 10, dimensiones: { alto: 5 } }),
+    ).toBe(true)
+  })
+
+  it('zTop debe estar bajo el techo', () => {
+    const size = { width: 10, height: 10 }
+    const pos = attachToWall({ x: 0, y: 0 }, size, poly)
+    const el = { ubicacion: 'pared', elevacion: { zBase: 50, altura: 200 }, tolerancias: { zEpsilon: 0.5 } }
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 300, el, vecinos: [] }),
+    ).toBe(true)
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 200, el, vecinos: [] }),
+    ).toBe(false)
+  })
+
+  it('pared/pared: solape Z bloquea, Z disjunto permite', () => {
+    const size = { width: 10, height: 10 }
+    const pos = attachToWall({ x: 0, y: 0 }, size, poly)
+    const el = { ubicacion: 'pared', x: pos.x, y: pos.y, width: 10, height: 10, elevacion: { zBase: 0, altura: 10 }, tolerancias: { zEpsilon: 0.5 } }
+    const solapa = { ubicacion: 'pared', x: 5, y: pos.y, width: 10, height: 10, elevacion: { zBase: 5, altura: 10 }, tolerancias: { zEpsilon: 0.5 } }
+    const disjunta = { ubicacion: 'pared', x: 5, y: pos.y, width: 10, height: 10, elevacion: { zBase: 20, altura: 10 }, tolerancias: { zEpsilon: 0.5 } }
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 100, el, vecinos: [solapa] }),
+    ).toBe(false)
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 100, el, vecinos: [disjunta] }),
+    ).toBe(true)
+  })
+
+  it('pared contra suelo sólo válido si zBase supera altura del suelo', () => {
+    const size = { width: 10, height: 10 }
+    const pos = attachToWall({ x: 0, y: 0 }, size, poly)
+    const suelo = { ubicacion: 'suelo', x: 0, y: 0, width: 20, height: 20, elevacion: { zBase: 0, altura: 10 }, tolerancias: { zEpsilon: 0.5 } }
+    const elOk = { ubicacion: 'pared', elevacion: { zBase: 11, altura: 10 }, tolerancias: { zEpsilon: 0.5 } }
+    const elBad = { ubicacion: 'pared', elevacion: { zBase: 9, altura: 10 }, tolerancias: { zEpsilon: 0.5 } }
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 100, el: elOk, vecinos: [suelo] }),
+    ).toBe(true)
+    expect(
+      isWallPlacementValid({ posXY: pos, size, plantaPoly: poly, bodegaAltura: 100, el: elBad, vecinos: [suelo] }),
+    ).toBe(false)
+  })
+
+  it('attachToWall lleva la posición al segmento más cercano', () => {
+    const size = { width: 10, height: 10 }
+    const pos = { x: 30, y: 40 }
+    const snapped = attachToWall(pos, size, poly)
+    expect(snapped.x).toBeCloseTo(0)
+    expect(snapped.y).toBeCloseTo(40)
+  })
+})

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -589,6 +589,9 @@ import { resetEdgeState } from '@/composables/useEdgeState'
 import { resolveFinalByIntervals } from '@/utils/finalIntervals'
 import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
+import { isWallPlacementValid } from '@/utils/wallPlacement'
+import { attachToWall } from '@/utils/wallAttach'
+import { isWallFormValid } from '@/utils/validation'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -655,6 +658,35 @@ const getElementPixelDimensions = (elemento) => {
   return { width: 100, height: 60 }
 }
 const conflictsApi = useConflicts()
+
+function areaBoundsToPoly(bounds) {
+  if (!bounds) return []
+  return [
+    { x: bounds.minX, y: bounds.minY },
+    { x: bounds.maxX, y: bounds.minY },
+    { x: bounds.maxX, y: bounds.maxY },
+    { x: bounds.minX, y: bounds.maxY },
+  ]
+}
+
+function isValidPlacementWrapper(params) {
+  const { pos, movingEl, neighbors, areaBounds, CM_TO_PX: CM } = params
+  void CM
+  if (movingEl?.ubicacion === 'pared') {
+    const planta = canvasStore.plantaActivaData
+    const poly = planta?.poligono || areaBoundsToPoly(areaBounds)
+    const bAlt = planta?.dimensiones?.alto
+    return isWallPlacementValid({
+      posXY: pos,
+      size: { width: movingEl.width, height: movingEl.height },
+      plantaPoly: poly,
+      bodegaAltura: bAlt,
+      el: movingEl,
+      vecinos: neighbors,
+    })
+  }
+    return isPlacementValid(params)
+  }
 
 // === BLOQUEO DE ELEMENTOS ===
 const isElementLocked = (elementId) => {
@@ -1066,7 +1098,7 @@ const startElementDrag = (elementId) => {
           ubicacion: elemento.ubicacion || 'suelo',
         }
         const neighbors = canvasStore.elementosVisibles.filter((e) => e.id !== elementId)
-        const isOk = isPlacementValid({
+        const isOk = isValidPlacementWrapper({
           pos: { x: bbox.x, y: bbox.y },
           movingEl: moving,
           neighbors,
@@ -1125,7 +1157,7 @@ const startElementDrag = (elementId) => {
         if (!elemento) return false
         const neighbors = canvasStore.elementosVisibles.filter((e) => e.id !== elementId)
         const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
-        return isPlacementValid({ pos, movingEl: elemento, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+        return isValidPlacementWrapper({ pos, movingEl: elemento, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
       }
 
       const ctrl = setupRafDrag({
@@ -1158,6 +1190,10 @@ const updateElementPosition = (e, elementId, forma = 'rectangular') => {
   }
   const elemento = canvasStore.elementosVisibles.find((el) => el.id === elementId)
   if (!elemento) return
+  if (elemento.ubicacion === 'pared' && !isWallFormValid(elemento)) {
+    console.warn('Define la altura respecto al suelo')
+    return
+  }
 
   // Actualizar lastVelocity respecto a la última pos deseada conocida
   const prev = lastDesiredPosMap.value.get(elementId) || { x: elemento.x, y: elemento.y }
@@ -1242,8 +1278,8 @@ const endElementDrag = async (elementId) => {
           lastVelocity: lastVel,
         })
 
-        // 2. Verificar validez final con el MISMO predicado isPlacementValid (modelo puro)
-        const finalIsValid = isPlacementValid({
+        // 2. Verificar validez final con el predicado de colocación correspondiente
+        const finalIsValid = isValidPlacementWrapper({
           pos: { x: solved.x, y: solved.y },
           movingEl: elementoActual,
           neighbors,
@@ -1253,6 +1289,22 @@ const endElementDrag = async (elementId) => {
         })
 
         let finalPosition = { x: solved.x, y: solved.y }
+        if (elementoActual.ubicacion === 'pared') {
+          const planta = canvasStore.plantaActivaData
+          const poly = planta?.poligono || areaBoundsToPoly(areaBounds)
+          finalPosition = attachToWall(finalPosition, { width: elementoActual.width, height: elementoActual.height }, poly)
+          const snapValid = isValidPlacementWrapper({
+            pos: finalPosition,
+            movingEl: elementoActual,
+            neighbors,
+            areaBounds,
+            CM_TO_PX,
+            epsPx: 0.5,
+          })
+          if (!snapValid) {
+            finalPosition = { x: solved.x, y: solved.y }
+          }
+        }
         let fallbackUsed = false
 
         // 3. Si la posición final no es válida, usar lastGoodPos o lastValidPos
@@ -1284,7 +1336,7 @@ const endElementDrag = async (elementId) => {
           })
 
           // Validar el resultado del re-clamp
-          const reclampIsValid = isPlacementValid({
+          const reclampIsValid = isValidPlacementWrapper({
             pos: { x: reclampResult.x, y: reclampResult.y },
             movingEl: elementoActual,
             neighbors,
@@ -1383,7 +1435,7 @@ const endElementDrag = async (elementId) => {
       // Validar que la posición final está dentro del área y es válida según el validador común
       const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
       const neighbors = canvasStore.elementosVisibles.filter((e) => e.id !== elementId)
-      const isValidNow = isPlacementValid({ pos: { x: finalX, y: finalY }, movingEl: storeEl, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+      const isValidNow = isValidPlacementWrapper({ pos: { x: finalX, y: finalY }, movingEl: storeEl, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
 
       if (isValidNow) {
         // Persistir posición final con historial
@@ -2079,10 +2131,10 @@ const handleTransformEnd = (e, elementId, forma) => {
     const elemento = canvasStore.elementosVisibles.find(e => e.id === elementId)
     if (!elemento) return
 
-    // Validar con isPlacementValid contra vecinos y área
+    // Validar placement contra vecinos y área
     const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)
     const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
-    const isValidNow = isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+    const isValidNow = isValidPlacementWrapper({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
 
   console.debug('[transform-debug] end', elementId, { prev: transformInitialState.get(elementId), new: { x, y, width, height, rotation }, isValidNow })
   if (!isValidNow) {
@@ -2170,7 +2222,7 @@ const handleTransformMove = (e, elementId, forma) => {
 
     const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)
     const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
-    const valid = isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+    const valid = isValidPlacementWrapper({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
 
     // Aplicar stroke rojo si inválido, volver al color habitual si válido
     try {

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -311,12 +311,25 @@
           Eliminar
         </button>
       </div>
+      <p
+        v-if="elementoSeleccionado.ubicacion === 'pared' && !wallFormOk"
+        class="text-xs text-red-500 mb-2"
+      >
+        Define la altura y el alto antes de guardar
+      </p>
       <div class="flex gap-2">
         <button
           @click="resetearPropiedades"
           class="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm"
         >
           Restablecer
+        </button>
+        <button
+          @click="guardarPropiedades"
+          :disabled="elementoSeleccionado.ubicacion === 'pared' && !wallFormOk"
+          class="flex-1 px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors text-sm disabled:opacity-50"
+        >
+          Guardar
         </button>
         <button
           @click="deseleccionarElemento"
@@ -342,6 +355,8 @@ import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS } from '@/utils/constants'
 import { useDeleteElement } from '@/composables/useDeleteElement'
 import TagFilter from './TagFilter.vue'
 import CreateTagModal from './CreateTagModal.vue'
+import { isWallFormValid } from '@/utils/validation'
+import { isWallPlacementValid } from '@/utils/wallPlacement'
 
 // Store
 const canvasStore = useCanvasStore()
@@ -362,6 +377,7 @@ const isLockedSelected = computed(() => {
   const el = elementoSeleccionado.value
   return !!(el && (el.bloqueado === true || el.locked === true))
 })
+const wallFormOk = computed(() => isWallFormValid(elementoSeleccionado.value))
 
 // Watchers
 watch(
@@ -421,6 +437,11 @@ const deseleccionarElemento = () => {
   canvasStore.seleccionarElemento(null)
 }
 
+const guardarPropiedades = () => {
+  // Las propiedades ya se guardan reactivamente; este método es un placeholder
+  deseleccionarElemento()
+}
+
 const onDeleteClick = () => {
   deleteSelected({ withConfirm: true })
 }
@@ -456,6 +477,23 @@ const actualizarDimension = (dimension, valor) => {
   if (!elementoSeleccionado.value) return
   const valorNumerico = parseFloat(valor)
   if (isNaN(valorNumerico)) return // Evitar enviar valores no numéricos
+
+  const el = elementoSeleccionado.value
+  if (el.ubicacion === 'pared' && dimension === 'alto') {
+    const planta = canvasStore.plantaActivaData
+    const poly = planta?.poligono || []
+    const vecinos = canvasStore.elementosVisibles.filter(e => e.id !== el.id)
+    const candidate = { ...el, elevacion: { ...(el.elevacion || {}), altura: valorNumerico } }
+    const valid = isWallPlacementValid({
+      posXY: { x: el.x, y: el.y },
+      size: { width: el.width, height: el.height },
+      plantaPoly: poly,
+      bodegaAltura: planta?.dimensiones?.alto,
+      el: candidate,
+      vecinos,
+    })
+    if (!valid) return
+  }
 
   // Actualizar la dimensión en cm
   canvasStore.actualizarElemento(elementoSeleccionado.value.id, {
@@ -496,6 +534,23 @@ const actualizarPropiedadSimple = (propiedad, valor) => {
   if (!elementoSeleccionado.value) return
   const valorNumerico = parseFloat(valor)
   if (isNaN(valorNumerico)) return
+
+  const el = elementoSeleccionado.value
+  if (el.ubicacion === 'pared' && propiedad === 'alturaRespectoAlSuelo') {
+    const planta = canvasStore.plantaActivaData
+    const poly = planta?.poligono || []
+    const vecinos = canvasStore.elementosVisibles.filter(e => e.id !== el.id)
+    const candidate = { ...el, alturaRespectoAlSuelo: valorNumerico, elevacion: { ...(el.elevacion || {}), zBase: valorNumerico } }
+    const valid = isWallPlacementValid({
+      posXY: { x: el.x, y: el.y },
+      size: { width: el.width, height: el.height },
+      plantaPoly: poly,
+      bodegaAltura: planta?.dimensiones?.alto,
+      el: candidate,
+      vecinos,
+    })
+    if (!valid) return
+  }
 
   canvasStore.actualizarElemento(elementoSeleccionado.value.id, {
     [propiedad]: valorNumerico,

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -969,12 +969,33 @@ export const useCanvasStore = defineStore('canvas', () => {
       // Estado de elementos con propiedades estáticas y personalizadas
       elementos: elementos.value.map((elemento) => ({
         // Elevación y tolerancias
-        elevacion: elemento.elevacion || {
-          zBase: 0,
-          altura: elemento.dimensiones?.alto || elemento.alto || 0,
-          espesor: elemento.elevacion?.espesor || 0,
-        },
-        tolerancias: elemento.tolerancias || { junta: 0, paralelismo: 0, zEpsilon: 0 },
+        elevacion: (() => {
+          if (elemento.ubicacion === 'pared') {
+            const zBase = Number.isFinite(elemento.alturaRespectoAlSuelo)
+              ? elemento.alturaRespectoAlSuelo
+              : elemento.elevacion?.zBase || 0
+            const altura = Number.isFinite(elemento.dimensiones?.alto)
+              ? elemento.dimensiones.alto
+              : elemento.elevacion?.altura || 0
+            return { zBase, altura, espesor: elemento.elevacion?.espesor || 0 }
+          }
+          return (
+            elemento.elevacion || {
+              zBase: 0,
+              altura: elemento.dimensiones?.alto || elemento.alto || 0,
+              espesor: elemento.elevacion?.espesor || 0,
+            }
+          )
+        })(),
+        tolerancias: (() => {
+          const base = elemento.tolerancias || { junta: 0, paralelismo: 0 }
+          if (elemento.ubicacion === 'pared') {
+            return { ...base, zEpsilon: base.zEpsilon ?? 0.5 }
+          }
+          return { ...base, zEpsilon: base.zEpsilon ?? 0 }
+        })(),
+        alturaRespectoAlSuelo:
+          elemento.alturaRespectoAlSuelo || elemento.elevacion?.zBase || 0,
         id: elemento.id,
         nombre: elemento.nombre,
         tipo: elemento.tipo,
@@ -1121,6 +1142,32 @@ export const useCanvasStore = defineStore('canvas', () => {
         const width = elementoData.dimensiones?.ancho || 100
         const height = elementoData.dimensiones?.largo || 60
 
+        const ubicacion = elementoData.propiedades?.ubicacion || 'suelo'
+        const alturaSuelo = elementoData.alturaRespectoAlSuelo ?? elementoData.elevacion?.zBase ?? 0
+        const elevacion = (() => {
+          const base = elementoData.elevacion || {}
+          if (ubicacion === 'pared') {
+            return {
+              zBase: base.zBase ?? alturaSuelo,
+              altura: base.altura ?? (elementoData.dimensiones?.alto || 0),
+              espesor: base.espesor || 0,
+            }
+          }
+          return {
+            zBase: base.zBase ?? (elementoData.posicion?.z || 0),
+            altura: base.altura ?? (elementoData.dimensiones?.alto || 0),
+            espesor: base.espesor || 0,
+          }
+        })()
+
+        const tolerancias = (() => {
+          const base = elementoData.tolerancias || { junta: 0, paralelismo: 0 }
+          if (ubicacion === 'pared') {
+            return { ...base, zEpsilon: base.zEpsilon ?? 0.5 }
+          }
+          return { ...base, zEpsilon: base.zEpsilon ?? 0 }
+        })()
+
         elementos.value.push({
           id: elementoData.id,
           nombre: elementoData.nombre,
@@ -1128,12 +1175,8 @@ export const useCanvasStore = defineStore('canvas', () => {
           categoria: elementoData.categoria,
           plantaId: elementoData.plantaId,
 
-          elevacion: elementoData.elevacion || {
-            zBase: elementoData.posicion?.z || 0,
-            altura: elementoData.dimensiones?.alto || 0,
-            espesor: 0,
-          },
-          tolerancias: elementoData.tolerancias || { junta: 0, paralelismo: 0, zEpsilon: 0 },
+          elevacion,
+          tolerancias,
 
           // Propiedades físicas (estructura nueva)
           dimensiones: {
@@ -1146,7 +1189,7 @@ export const useCanvasStore = defineStore('canvas', () => {
           posicion: {
             x: posX,
             y: posY,
-            z: elementoData.posicion?.z || 0,
+            z: elevacion.zBase,
             rotation: elementoData.posicion?.rotation || 0,
           },
 
@@ -1164,8 +1207,10 @@ export const useCanvasStore = defineStore('canvas', () => {
 
           // Propiedades funcionales
           pesoMaximo: elementoData.propiedades?.pesoMaximo || 0,
-          ubicacion: elementoData.propiedades?.ubicacion || 'suelo',
+          ubicacion,
           descripcion: elementoData.propiedades?.descripcion || '',
+
+          alturaRespectoAlSuelo: alturaSuelo,
 
           // Jerarquía
           padre: elementoData.jerarquia?.padre || null,

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,10 @@
+export function isWallFormValid(el) {
+  if (!el || el.ubicacion !== 'pared') return true
+  const zBase = Number(el.alturaRespectoAlSuelo)
+  const alto = Number(el?.dimensiones?.alto)
+  if (!Number.isFinite(zBase) || zBase <= 0) return false
+  if (!Number.isFinite(alto) || alto <= 0) return false
+  return true
+}
+
+export default { isWallFormValid }

--- a/src/utils/wallAttach.js
+++ b/src/utils/wallAttach.js
@@ -1,0 +1,52 @@
+/**
+ * Calcula el punto del segmento de pared más cercano a p.
+ * @param {Array<{x:number,y:number}>} poly - Polígono de la planta.
+ * @param {{x:number,y:number}} p - Punto a proyectar.
+ * @returns {{x:number,y:number,segment:number}}
+ */
+export function nearestWallPoint(poly = [], p = { x: 0, y: 0 }) {
+  if (!Array.isArray(poly) || poly.length < 2) return { x: p.x, y: p.y, segment: -1 }
+  let best = { x: p.x, y: p.y, segment: 0 }
+  let minDist = Infinity
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    const apx = p.x - a.x
+    const apy = p.y - a.y
+    const abx = b.x - a.x
+    const aby = b.y - a.y
+    const ab2 = abx * abx + aby * aby || 1
+    const t = Math.max(0, Math.min(1, (apx * abx + apy * aby) / ab2))
+    const proj = { x: a.x + abx * t, y: a.y + aby * t }
+    const d = (proj.x - p.x) ** 2 + (proj.y - p.y) ** 2
+    if (d < minDist) {
+      minDist = d
+      best = { x: proj.x, y: proj.y, segment: i }
+    }
+  }
+  return best
+}
+
+/**
+ * Snapea una posición para que quede pegada a la pared más cercana.
+ * @param {{x:number,y:number}} pos - Top-left del elemento.
+ * @param {{width:number,height:number}} size - Tamaño del elemento.
+ * @param {Array<{x:number,y:number}>} poly - Polígono de la planta.
+ * @returns {{x:number,y:number}}
+ */
+export function attachToWall(pos, size, poly = []) {
+  if (!pos || !size) return pos
+  const center = { x: pos.x + size.width / 2, y: pos.y + size.height / 2 }
+  const closest = nearestWallPoint(poly, center)
+  const dir = { x: center.x - closest.x, y: center.y - closest.y }
+  const len = Math.hypot(dir.x, dir.y) || 1
+  const nx = dir.x / len
+  const ny = dir.y / len
+  const newCenter = {
+    x: closest.x + nx * (size.width / 2),
+    y: closest.y + ny * (size.height / 2),
+  }
+  return { x: newCenter.x - size.width / 2, y: newCenter.y - size.height / 2 }
+}
+
+export default { nearestWallPoint, attachToWall }

--- a/src/utils/wallPlacement.js
+++ b/src/utils/wallPlacement.js
@@ -1,0 +1,51 @@
+import { attachToWall as attachHelper } from './wallAttach.js'
+
+function rectsOverlap(aPos, aSize, bPos, bSize, eps = 0) {
+  return !(
+    aPos.x + aSize.width <= bPos.x + eps ||
+    bPos.x + bSize.width <= aPos.x + eps ||
+    aPos.y + aSize.height <= bPos.y + eps ||
+    bPos.y + bSize.height <= aPos.y + eps
+  )
+}
+
+/**
+ * Valida la colocación de un elemento de pared en el plano.
+ * @param {Object} params
+ */
+export function isWallPlacementValid({
+  posXY,
+  size,
+  plantaPoly,
+  bodegaAltura,
+  el,
+  vecinos = [],
+  eps = 0.5,
+}) {
+  if (!posXY || !size || !plantaPoly || !el) return false
+  const snapped = attachHelper(posXY, size, plantaPoly)
+  const dist = Math.hypot(snapped.x - posXY.x, snapped.y - posXY.y)
+  if (dist > eps) return false
+
+  const zBase = el.elevacion?.zBase || 0
+  const zTop = zBase + (el.elevacion?.altura || 0)
+  if (Number.isFinite(bodegaAltura) && zTop > bodegaAltura + eps) return false
+
+  for (const v of vecinos) {
+    if (!rectsOverlap(posXY, size, { x: v.x, y: v.y }, { width: v.width, height: v.height }, eps)) continue
+    const vzBase = v.elevacion?.zBase || 0
+    const vzTop = vzBase + (v.elevacion?.altura || 0)
+    const zEps = Math.max(el.tolerancias?.zEpsilon ?? eps, v.tolerancias?.zEpsilon ?? eps)
+    if (v.ubicacion === 'pared') {
+      const overlapZ = zBase < vzTop - zEps && vzBase < zTop - zEps
+      if (overlapZ) return false
+    } else if (v.ubicacion === 'suelo') {
+      const floorTop = vzTop
+      if (zBase < floorTop + zEps) return false
+    }
+  }
+
+  return true
+}
+
+export default { isWallPlacementValid }


### PR DESCRIPTION
## Summary
- add wall form validation and integrate guard in property panel
- introduce wall attach and placement helpers with serialization defaults for wall elements
- wire CanvasView to use new wall placement logic and add wall-specific tests

## Testing
- `npm run test:unit -- --run` *(fails: Vue component resolution/Pinia/ResizeObserver errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae15412130832183557d69e99239ad