### PR TITLE
feat: polygon boundary utilities

### DIFF
--- a/src/__tests__/canvas-layers.spec.js
+++ b/src/__tests__/canvas-layers.spec.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, defineComponent } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+vi.mock('@/utils/collision', () => ({ detectConflictsFor: vi.fn(() => []) }))
+
+import CanvasView from '@/components/CanvasView.vue'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  global.ResizeObserver = class { observe(){} unobserve(){} disconnect(){} }
+  mockStore = {
+    zoom: 1,
+    panX: 0,
+    panY: 0,
+    plantaActivaData: {
+      nombre: 'Planta',
+      dimensiones: { ancho: 100, largo: 100 },
+      poligono: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 }
+      ]
+    },
+    elementosVisibles: [
+      { id: 'a', x: 10, y: 10, width: 10, height: 10, forma: 'rectangular', color: '#f00' }
+    ],
+    elementoSeleccionado: null,
+    agregarElemento: vi.fn(),
+    seleccionarElemento: vi.fn(),
+    estaEnElemento: false,
+    estaEnContenedor: false,
+    estaEnPlanta: true,
+    contextoActual: { tipo: 'plantas' },
+    vistaActiva: 'XY',
+    gridSize: 50,
+    canvasAdaptativo: { width: 100, height: 100 },
+    configurarZoom: vi.fn(),
+    configurarPan: vi.fn(),
+  }
+})
+
+describe('canvas layers', () => {
+  it('orders layers and applies clip only to content', () => {
+    const layerStub = defineComponent({
+      props: ['config', 'clipFunc'],
+      template:
+        '<div class="layer" :data-listening="config && config.listening" :data-clip="clipFunc ? true : undefined"><slot/></div>'
+    })
+    const stubs = {
+      'v-stage': { template: '<div class="stage"><slot/></div>' },
+      'v-layer': layerStub,
+      'v-rect': { template: '<div></div>' },
+      'v-circle': { template: '<div></div>' },
+      'v-text': { template: '<div></div>' },
+      'v-group': { template: '<div><slot/></div>' },
+      'v-line': { template: '<div></div>' },
+      'v-transformer': { template: '<div></div>' },
+    }
+
+    const wrapper = mount(CanvasView, { global: { stubs } })
+    const layers = wrapper.findAll('.layer')
+    expect(layers.length).toBe(3)
+    expect(layers[0].attributes('data-listening')).toBe('false')
+    expect(layers[1].attributes('data-clip')).toBe('true')
+    expect(layers[2].attributes('data-clip')).toBeUndefined()
+  })
+})

--- a/src/__tests__/context_menu.spec.js
+++ b/src/__tests__/context_menu.spec.js
@@ -46,6 +46,10 @@ const VLine = defineComponent({ name: 'VLine', setup: () => () => h('div') })
 const VText = defineComponent({ name: 'VText', setup: () => () => h('div') })
 const VTransformer = defineComponent({ name: 'VTransformer', setup: () => () => h('div') })
 
+beforeEach(() => {
+  global.ResizeObserver = class { observe(){} unobserve(){} disconnect(){} }
+})
+
 const mountCanvas = async () => {
   const pinia = createPinia()
   setActivePinia(pinia)

--- a/src/__tests__/drop-outside-polygon.spec.js
+++ b/src/__tests__/drop-outside-polygon.spec.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+vi.mock('@/utils/collision', () => ({
+  detectConflictsFor: vi.fn(() => [])
+}))
+
+import CanvasView from '@/components/CanvasView.vue'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  window.__toasts = { show: vi.fn() }
+})
+
+describe('drop outside polygon', () => {
+  it('rejects drop when outside active polygon', async () => {
+    mockStore = {
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      plantaActivaData: {
+        nombre: 'Planta',
+        dimensiones: { ancho: 100, largo: 100 },
+        poligono: [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+          { x: 0, y: 100 }
+        ]
+      },
+      elementosVisibles: [],
+      elementoSeleccionado: null,
+      agregarElemento: vi.fn(),
+      seleccionarElemento: vi.fn(),
+      estaEnElemento: false,
+      estaEnContenedor: false,
+      estaEnPlanta: true,
+      contextoActual: { tipo: 'plantas' },
+      vistaActiva: 'XY',
+      gridSize: 50,
+      canvasAdaptativo: { width: 100, height: 100 },
+      configurarZoom: vi.fn(),
+      configurarPan: vi.fn(),
+    }
+
+    const stubs = {
+      'v-stage': { template: '<div><slot/></div>' },
+      'v-layer': { props: ['config', 'clipFunc'], template: '<div><slot/></div>' },
+      'v-rect': { template: '<div></div>' },
+      'v-circle': { template: '<div></div>' },
+      'v-text': { template: '<div></div>' },
+      'v-group': { template: '<div><slot/></div>' },
+      'v-line': { template: '<div></div>' },
+      'v-transformer': { template: '<div></div>' }
+    }
+    const wrapper = mount(CanvasView, { global: { stubs } })
+    wrapper.vm.containerRef = { getBoundingClientRect: () => ({ left: 0, top: 0 }) }
+    wrapper.vm.stageRef = { getNode: () => ({}) }
+
+    const data = { elemento: { dimensiones: { ancho: 20, largo: 20 }, tipo: 'elementos', forma: 'rectangular', color: '#f00' } }
+    const dropEvent = { clientX: 150, clientY: 50, preventDefault: () => {} }
+
+    wrapper.vm.createElementFromDrop(data, dropEvent)
+
+    expect(window.__toasts.show).toHaveBeenCalledWith('Fuera de los límites de la planta', { type: 'error', timeout: 4000 })
+    expect(mockStore.agregarElemento).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/drop-validation.spec.js
+++ b/src/__tests__/drop-validation.spec.js
@@ -80,10 +80,23 @@ describe('Drop Validation - Bug Fix: Drop que nace bloqueado', () => {
   beforeEach(() => {
     pinia = createPinia()
     setActivePinia(pinia)
-    
+    global.ResizeObserver = class { observe(){} unobserve(){} disconnect(){} }
+
+    const stubs = {
+      'v-stage': { template: '<div><slot/></div>' },
+      'v-layer': { props: ['config', 'clipFunc'], template: '<div><slot/></div>' },
+      'v-rect': { template: '<div></div>' },
+      'v-circle': { template: '<div></div>' },
+      'v-text': { template: '<div></div>' },
+      'v-group': { template: '<div><slot/></div>' },
+      'v-line': { template: '<div></div>' },
+      'v-transformer': { template: '<div></div>' }
+    }
+
     wrapper = mount(CanvasView, {
       global: {
-        plugins: [pinia]
+        plugins: [pinia],
+        stubs
       }
     })
 

--- a/src/__tests__/fit-to-planta.spec.js
+++ b/src/__tests__/fit-to-planta.spec.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+
+import CanvasView from '@/components/CanvasView.vue'
+
+describe('fitToPlanta', () => {
+  it('uses polygon bbox for zoom calculation', () => {
+    mockStore = {
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      plantaActivaData: {
+        nombre: 'Planta',
+        dimensiones: { ancho: 200, largo: 100 },
+        poligono: [
+          { x: 0, y: 0 },
+          { x: 200, y: 0 },
+          { x: 200, y: 100 },
+          { x: 0, y: 100 }
+        ]
+      },
+      elementosVisibles: [],
+      elementoSeleccionado: null,
+      agregarElemento: vi.fn(),
+      seleccionarElemento: vi.fn(),
+      estaEnElemento: false,
+      estaEnContenedor: false,
+      estaEnPlanta: true,
+      contextoActual: { tipo: 'plantas' },
+      vistaActiva: 'XY',
+      gridSize: 50,
+      canvasAdaptativo: { width: 400, height: 300 },
+      configurarZoom: vi.fn(),
+      configurarPan: vi.fn(),
+    }
+
+    const stubs = {
+      'v-stage': { template: '<div><slot/></div>' },
+      'v-layer': { props: ['config', 'clipFunc'], template: '<div><slot/></div>' },
+      'v-rect': { template: '<div></div>' },
+      'v-circle': { template: '<div></div>' },
+      'v-text': { template: '<div></div>' },
+      'v-group': { template: '<div><slot/></div>' },
+      'v-line': { template: '<div></div>' },
+      'v-transformer': { template: '<div></div>' }
+    }
+    const wrapper = mount(CanvasView, { global: { stubs } })
+    wrapper.vm.stageRef = { getNode: () => ({}) }
+    wrapper.vm.stageSize = { width: 400, height: 400 }
+
+    wrapper.vm.fitToPlanta()
+
+    expect(mockStore.configurarZoom).toHaveBeenCalled()
+    const zoom = mockStore.configurarZoom.mock.calls[0][0]
+    expect(zoom).toBeCloseTo(1.6)
+  })
+})

--- a/src/__tests__/polygonBounds.spec.js
+++ b/src/__tests__/polygonBounds.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { pointInPolygon, clampRectToPolygon } from '@/utils/polygonBounds'
+import { polygonInset } from '@/utils/polygonInset'
+
+describe('polygonBounds utils', () => {
+  it('pointInPolygon works with convex and concave polygons', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 }
+    ]
+    expect(pointInPolygon({ x: 5, y: 5 }, square)).toBe(true)
+    expect(pointInPolygon({ x: -1, y: 5 }, square)).toBe(false)
+
+    const concave = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 5, y: 5 },
+      { x: 0, y: 10 }
+    ]
+    expect(pointInPolygon({ x: 6, y: 6 }, concave)).toBe(true)
+    expect(pointInPolygon({ x: 4, y: 8 }, concave)).toBe(false)
+  })
+
+  it('clampRectToPolygon projects rectangle to nearest edge', () => {
+    const poly = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 }
+    ]
+    const rect = { x: -20, y: 10, width: 10, height: 10 }
+    const c = clampRectToPolygon(rect, poly)
+    expect(c.x).toBe(0)
+    expect(c.y).toBe(10)
+  })
+
+  it('clampRectToPolygon with inset keeps rect inside', () => {
+    const poly = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 }
+    ]
+    const inset = polygonInset(poly, 1)
+    const rect = { x: 98, y: 98, width: 4, height: 4 }
+    const c = clampRectToPolygon(rect, inset)
+    const corners = [
+      { x: c.x, y: c.y },
+      { x: c.x + rect.width, y: c.y },
+      { x: c.x + rect.width, y: c.y + rect.height },
+      { x: c.x, y: c.y + rect.height }
+    ]
+    const allInside = corners.every(pt => pointInPolygon(pt, inset))
+    expect(allInside).toBe(true)
+  })
+})

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -31,7 +31,31 @@
       @dragmove="handleStageDragMove"
       @dragend="handleStageDragEnd"
     >
-      <v-layer ref="layerRef">
+      <v-layer ref="backgroundLayerRef" :config="{ listening: false }">
+        <v-line
+          v-for="i in gridLines.vertical"
+          :key="`v-${i}`"
+          :config="{
+            points: [i, 0, i, floorBoundary.height],
+            stroke: '#e5e7eb',
+            strokeWidth: 1,
+            opacity: 0.5,
+            listening: false,
+          }"
+        />
+        <v-line
+          v-for="i in gridLines.horizontal"
+          :key="`h-${i}`"
+          :config="{
+            points: [0, i, floorBoundary.width, i],
+            stroke: '#e5e7eb',
+            strokeWidth: 1,
+            opacity: 0.5,
+            listening: false,
+          }"
+        />
+      </v-layer>
+      <v-layer ref="contentLayerRef" :clipFunc="clipFunc">
         <template v-if="canvasStore.elementoAura">
         <v-rect
           v-if="canvasStore.elementoAura.forma === 'rectangular' || !canvasStore.elementoAura.forma"
@@ -64,31 +88,6 @@
 
         <!-- Aquí podrías añadir v-circle, etc., si tienes otras formas -->
       </template>
-        <!-- Fondo de la planta - área delimitada -->
-        <v-rect
-          :config="{
-            x: 0,
-            y: 0,
-            width: floorBoundary.width,
-            height: floorBoundary.height,
-            fill: 'rgba(14,165,233,0.08)',
-            stroke: '#3b82f6',
-            strokeWidth: 2,
-            opacity: 1,
-            listening: false,
-          }"
-        />
-        <v-line
-          v-if="!canvasStore.estaEnElemento && !canvasStore.estaEnContenedor"
-          :config="{
-            points: floorBoundary.points,
-            closed: true,
-            stroke: '#0ea5e9',
-            fill: 'rgba(14,165,233,0.08)',
-            strokeWidth: 2,
-            listening: false,
-          }"
-        />
         <!-- Debug: mostrar información según el contexto -->
         <v-text
           :config="{
@@ -373,29 +372,9 @@
         <!-- Los contenedores se renderizan junto con los elementos en la sección principal -->
 
         <!-- Grid de referencia de la planta -->
-        <v-line
-          v-for="i in gridLines.vertical"
-          :key="`v-${i}`"
-          :config="{
-            points: [i, 0, i, floorBoundary.height],
-            stroke: '#e5e7eb',
-            strokeWidth: 1,
-            opacity: 0.5,
-            listening: false,
-          }"
-        />
-        <v-line
-          v-for="i in gridLines.horizontal"
-          :key="`h-${i}`"
-          :config="{
-            points: [0, i, floorBoundary.width, i],
-            stroke: '#e5e7eb',
-            strokeWidth: 1,
-            opacity: 0.5,
-            listening: false,
-          }"
-        />
-        <!-- Transformer para modo edición -->
+        <!-- Transformer se renderiza en overlaysLayer -->
+      </v-layer>
+      <v-layer ref="overlaysLayerRef">
         <v-transformer
           v-if="isEditingSelected && canvasStore.elementoSeleccionado && !selectedElementLocked"
           ref="transformerRef"
@@ -573,12 +552,13 @@ import {
   computeMTD,
   projectMTDAgainstBoundary,
 } from '@/utils/collision'
+import { clampRectToRect, snapToGrid, nudgePlace } from '@/utils/geometry'
 import {
-  rectInsidePolygon,
-  clampRectToRect,
-  snapToGrid,
-  nudgePlace,
-} from '@/utils/geometry'
+  clampRectToPolygon,
+  pointInPolygon,
+  clampPointToPolygon,
+} from '@/utils/polygonBounds'
+import { polygonInset } from '@/utils/polygonInset'
 import { GRID_SIZE, CM_TO_PX } from '@/utils/constants'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
 import { useContextMenu } from '@/composables/useContextMenu'
@@ -604,7 +584,9 @@ const emit = defineEmits(['select', 'drill-down'])
 // Referencias
 const containerRef = ref(null)
 const stageRef = ref(null)
-const layerRef = ref(null)
+const backgroundLayerRef = ref(null)
+const contentLayerRef = ref(null)
+const overlaysLayerRef = ref(null)
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
@@ -732,7 +714,15 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
       x = c2.x
       y = c2.y
     } else if (boundary.type === 'polygon') {
-      // En polígono no hay clamp trivial; si sale, revertimos a última válida luego
+      const centerInside = pointInPolygon(
+        { x: x + w / 2, y: y + h / 2 },
+        boundary.points,
+      )
+      if (!centerInside) {
+        const proj = clampPointToPolygon({ x, y }, boundary.inset)
+        x = proj.x
+        y = proj.y
+      }
     }
 
     // Si la corrección fue nula, detener
@@ -742,11 +732,13 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
   // Validaciones finales: si aún hay colisión bloqueante o quedó fuera, volver a última válida
   const movingEnd = { ...elemento, x, y }
   const endConf = detectConflictsFor(movingEnd, all).filter((c) => c.bloqueante)
-  const outsideRect =
+  const outsideArea =
     boundary.type === 'rect'
       ? x < -1e-6 || y < -1e-6 || x + w > W + 1e-6 || y + h > H + 1e-6
-      : false
-  if (endConf.length > 0 || outsideRect) {
+      : boundary.type === 'polygon'
+        ? !pointInPolygon({ x: x + w / 2, y: y + h / 2 }, boundary.points)
+        : false
+  if (endConf.length > 0 || outsideArea) {
     const prev = lastValidPositions.value.get(elemento.id) || { x: elemento.x, y: elemento.y }
     return { x: prev.x, y: prev.y, fellBack: true }
   }
@@ -778,28 +770,30 @@ const stageConfig = computed(() => {
   }
 })
 
-const floorBoundary = computed(() => {
-  // Empezamos con las dimensiones base del layer
-  let width = layerConfig.value.width
-  let height = layerConfig.value.height
-  let points = []
-
-  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
-    return { width, height, points }
-  }
-
+const plantPolygon = computed(() => {
   const poligono = canvasStore.plantaActivaData?.poligono
+  if (poligono && Array.isArray(poligono) && poligono.length >= 3) return poligono
+  const w = canvasStore.plantaActivaData?.dimensiones?.ancho || layerConfig.value.width
+  const h = canvasStore.plantaActivaData?.dimensiones?.largo || layerConfig.value.height
+  return [
+    { x: 0, y: 0 },
+    { x: w, y: 0 },
+    { x: w, y: h },
+    { x: 0, y: h }
+  ]
+})
 
-  // Si hay un polígono, lo usamos para expandir los límites y obtener los puntos
-  if (poligono && Array.isArray(poligono) && poligono.length > 0) {
-    poligono.forEach((coord) => {
-      width = Math.max(coord.x, width)
-      height = Math.max(coord.y, height)
-    })
-    points = poligono.flatMap((p) => [p.x, p.y])
-  }
+const plantPolygonFlat = computed(() => plantPolygon.value.flatMap(p => [p.x, p.y]))
+const insetPlantPolygon = computed(() => polygonInset(plantPolygon.value, 1))
 
-  return { width, height, points }
+const floorBoundary = computed(() => {
+  const xs = plantPolygon.value.map(p => p.x)
+  const ys = plantPolygon.value.map(p => p.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+  return { width: maxX - minX, height: maxY - minY }
 })
 
 // Configuración del layer - SIEMPRE USA CANVAS ADAPTATIVO
@@ -837,6 +831,23 @@ const gridLines = computed(() => {
   return { vertical, horizontal }
 })
 
+const clipFunc = (ctx) => {
+  ctx.beginPath()
+  plantPolygon.value.forEach((p, i) =>
+    i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y),
+  )
+  ctx.closePath()
+}
+
+watch(
+  plantPolygon,
+  () => {
+    const layer = contentLayerRef.value?.getNode?.()
+    layer?.batchDraw?.()
+  },
+  { immediate: true },
+)
+
 // Obtiene el contorno de la planta activa como rect o polígono
 const computeBoundary = () => {
   const W = layerConfig.value.width
@@ -850,7 +861,7 @@ const computeBoundary = () => {
   // Si estamos en una planta, verificar si tiene polígono
   const planta = canvasStore.plantaActivaData
   if (planta?.poligono && Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
-    return { type: 'polygon', points: planta.poligono }
+    return { type: 'polygon', points: plantPolygon.value, inset: insetPlantPolygon.value }
   }
   return { type: 'rect', W, H }
 }
@@ -979,14 +990,23 @@ const dragBoundForElement = (pos, elemento, forma = 'rect') => {
     const layerW = layerConfig.value.width
     const layerH = layerConfig.value.height
     const lp = toLayerCoords(pos)
-  if (forma === 'circular' || forma === 'circle') {
+    const boundary = computeBoundary()
+    if (forma === 'circular' || forma === 'circle') {
       const r = Math.min(elemento.width, elemento.height) / 2
       const cx = Math.max(r, Math.min(lp.x, layerW - r))
       const cy = Math.max(r, Math.min(lp.y, layerH - r))
       return toStageCoords({ x: cx, y: cy })
     } else {
-      const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
-      return toStageCoords(c)
+      if (boundary.type === 'polygon') {
+        const c = clampRectToPolygon(
+          { x: lp.x, y: lp.y, width: elemento.width, height: elemento.height },
+          boundary.inset,
+        )
+        return toStageCoords(c)
+      } else {
+        const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
+        return toStageCoords(c)
+      }
     }
   } catch {
     return pos
@@ -1030,7 +1050,7 @@ const startElementDrag = (elementId) => {
   // Habilitar modo performance en layer y arrancar rAF loop
   try {
     const stage = stageRef.value.getNode()
-    const layer = layerRef.value.getNode()
+    const layer = contentLayerRef.value.getNode()
     const shape = stage.findOne(`#${elementId}`)
     if (layer && shape) {
       const ctx = enablePerfMode(layer, { shape })
@@ -1194,7 +1214,7 @@ const endElementDrag = async (elementId) => {
   // Ejecutar validación y finalización con nueva lógica
   try {
     const stage = stageRef.value.getNode()
-    const layer = layerRef.value.getNode()
+    const layer = contentLayerRef.value.getNode()
     const shape = stage.findOne(`#${elementId}`)
     if (shape && layer) {
       const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
@@ -1402,7 +1422,7 @@ const endElementDrag = async (elementId) => {
         console.debug('[finalize] final pos INVALID - reverting to last valid pos for', elementId, { finalX, finalY, revertPos })
         try {
           const stage2 = stageRef.value?.getNode?.()
-          const layer2 = layerRef.value?.getNode?.()
+          const layer2 = contentLayerRef.value?.getNode?.()
           const shape2 = stage2?.findOne?.(`#${elementId}`)
           if (shape2) {
             if (shape2.className === 'Circle' || storeEl.forma === 'circular') {
@@ -1585,14 +1605,25 @@ const createElementFromDrop = (data, dropEvent) => {
       candX + finalWidth <= boundary.W &&
       candY + finalHeight <= boundary.H
 
-    // Si está fuera, intentar clamp
     if (!isInsideArea) {
       const clamped = clampRectToRect(candX, candY, finalWidth, finalHeight, boundary.W, boundary.H)
       candX = clamped.x
       candY = clamped.y
     }
   } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, finalWidth, finalHeight, boundary.points)
+    isInsideArea = pointInPolygon({
+      x: candX + finalWidth / 2,
+      y: candY + finalHeight / 2,
+    }, boundary.inset)
+    if (!isInsideArea) {
+      const clamped = clampRectToPolygon(
+        { x: candX, y: candY, width: finalWidth, height: finalHeight },
+        boundary.inset,
+      )
+      candX = clamped.x
+      candY = clamped.y
+      isInsideArea = pointInPolygon({ x: candX + finalWidth / 2, y: candY + finalHeight / 2 }, boundary.inset)
+    }
   }
 
   // 6. Crear elemento temporal para detectar conflictos
@@ -1645,7 +1676,7 @@ const createElementFromDrop = (data, dropEvent) => {
 
   // 9. Si aún no hay posición válida, rechazar y mostrar toast
   if (!placementSuccessful) {
-    showToast('No hay espacio aquí para colocar el elemento', 'error')
+    showToast('Fuera de los límites de la planta', 'error')
     return // NO crear la instancia, NO comprometer historial
   }
 
@@ -1870,7 +1901,13 @@ const createElementFromBuffer = (data, dropEvent) => {
       candY = clamped.y
     }
   } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, width, height, boundary.points)
+    isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.inset)
+    if (!isInsideArea) {
+      const clamped = clampRectToPolygon({ x: candX, y: candY, width, height }, boundary.inset)
+      candX = clamped.x
+      candY = clamped.y
+      isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.inset)
+    }
   }
 
   // 5. Crear elemento temporal y detectar conflictos
@@ -1920,7 +1957,7 @@ const createElementFromBuffer = (data, dropEvent) => {
 
   // 7. Si no hay posición válida, rechazar
   if (!placementSuccessful) {
-    showToast('No hay espacio aquí para pegar el elemento', 'error')
+    showToast('Fuera de los límites de la planta', 'error')
     return // NO pegar, NO comprometer historial
   }
 
@@ -2104,7 +2141,7 @@ const handleTransformEnd = (e, elementId, forma) => {
         node.scaleX && node.scaleX(1); node.scaleY && node.scaleY(1)
         node.rotation && node.rotation(prev.rotation || 0)
         // Forzar repaint
-        const layer = layerRef.value?.getNode?.()
+        const layer = contentLayerRef.value?.getNode?.()
         layer?.batchDraw?.()
   } catch { /* ignore */ }
   console.debug('[transform-debug] reverted', elementId, prev)
@@ -2265,7 +2302,7 @@ function recomputeBoundsAndIndex() {
 }
 function forceRedraw() {
   try {
-    const layer = layerRef.value?.getNode?.()
+    const layer = contentLayerRef.value?.getNode?.()
     const stage = stageRef.value?.getNode?.()
     if (!layer || !stage) return
     try { layer.clearCache?.() } catch { /* ignore */ }

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,6 +1,8 @@
 // Geometry and containment helpers for 2D canvas (XY view)
 // Units: use canvas world units (same as layer coordinates, pixels tied to cm in UI)
 
+import { clampRectToPolygon } from './polygonBounds'
+
 export const EPSILON = 1e-6
 
 // Basic math helpers
@@ -332,40 +334,35 @@ export const nudgePlace = (
 ) => {
   // Función auxiliar para verificar si una posición es válida
   const isValidPosition = (testX, testY) => {
-    // Verificar que esté dentro del área
     if (boundary.type === 'rect') {
       if (testX < 0 || testY < 0 || testX + width > boundary.W || testY + height > boundary.H) {
-        return false
+        return { valid: false, x: testX, y: testY }
       }
     } else if (boundary.type === 'polygon') {
-      if (!rectInsidePolygon(testX, testY, width, height, boundary.points)) {
-        return false
-      }
+      const pts = boundary.inset || boundary.points
+      const clamped = clampRectToPolygon({ x: testX, y: testY, width, height }, pts)
+      testX = clamped.x
+      testY = clamped.y
+      const centerInside = pointInPolygon(
+        { x: testX + width / 2, y: testY + height / 2 },
+        pts,
+      )
+      if (!centerInside) return { valid: false, x: testX, y: testY }
     }
 
-    // Solo verificar conflictos si se proporciona la función
     if (detectConflictsFn) {
-      // Crear elemento temporal para verificar conflictos
-      const tempElement = {
-        ...elementToPlace,
-        x: testX,
-        y: testY,
-        width,
-        height,
-      }
-
+      const tempElement = { ...elementToPlace, x: testX, y: testY, width, height }
       const conflicts = detectConflictsFn(tempElement, allElements)
       const blockingConflicts = conflicts.filter((c) => c.bloqueante)
-
-      return blockingConflicts.length === 0
+      return { valid: blockingConflicts.length === 0, x: testX, y: testY }
     }
 
-    return true
+    return { valid: true, x: testX, y: testY }
   }
 
-  // Verificar posición inicial
-  if (isValidPosition(x, y)) {
-    return { x, y, found: true }
+  const initial = isValidPosition(x, y)
+  if (initial.valid) {
+    return { x: initial.x, y: initial.y, found: true }
   }
 
   // Búsqueda en espiral
@@ -395,8 +392,9 @@ export const nudgePlace = (
 
     // Probar cada punto en esta distancia
     for (const point of spiralPoints) {
-      if (isValidPosition(point.x, point.y)) {
-        return { x: point.x, y: point.y, found: true }
+      const res = isValidPosition(point.x, point.y)
+      if (res.valid) {
+        return { x: res.x, y: res.y, found: true }
       }
     }
   }

--- a/src/utils/polygonBounds.js
+++ b/src/utils/polygonBounds.js
@@ -1,0 +1,76 @@
+export function pointInPolygon(pt, poly) {
+  const x = pt.x ?? pt[0]
+  const y = pt.y ?? pt[1]
+  let inside = false
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i].x ?? poly[i][0]
+    const yi = poly[i].y ?? poly[i][1]
+    const xj = poly[j].x ?? poly[j][0]
+    const yj = poly[j].y ?? poly[j][1]
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / ((yj - yi) || 1e-12) + xi
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+export function nearestPointOnSegment(p, a, b) {
+  const px = p.x ?? p[0]
+  const py = p.y ?? p[1]
+  const ax = a.x ?? a[0]
+  const ay = a.y ?? a[1]
+  const bx = b.x ?? b[0]
+  const by = b.y ?? b[1]
+  const abx = bx - ax
+  const aby = by - ay
+  const apx = px - ax
+  const apy = py - ay
+  const ab2 = abx * abx + aby * aby
+  const t = ab2 === 0 ? 0 : (apx * abx + apy * aby) / ab2
+  const clampedT = Math.max(0, Math.min(1, t))
+  return { x: ax + abx * clampedT, y: ay + aby * clampedT }
+}
+
+export function clampPointToPolygon(p, poly) {
+  if (pointInPolygon(p, poly)) return { x: p.x ?? p[0], y: p.y ?? p[1] }
+  let best = { x: 0, y: 0, d: Infinity }
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    const np = nearestPointOnSegment(p, a, b)
+    const dx = (p.x ?? p[0]) - np.x
+    const dy = (p.y ?? p[1]) - np.y
+    const d = dx * dx + dy * dy
+    if (d < best.d) {
+      best = { x: np.x, y: np.y, d }
+    }
+  }
+  return { x: best.x, y: best.y }
+}
+
+export function clampRectToPolygon(rect, poly) {
+  const corners = [
+    { x: rect.x, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y + rect.height },
+    { x: rect.x, y: rect.y + rect.height }
+  ]
+  const deltas = []
+  for (const c of corners) {
+    if (!pointInPolygon(c, poly)) {
+      const clamped = clampPointToPolygon(c, poly)
+      deltas.push({ dx: clamped.x - c.x, dy: clamped.y - c.y })
+    }
+  }
+  if (deltas.length === 0) return { x: rect.x, y: rect.y }
+  // choose largest translation to cover all outside corners
+  let best = deltas[0]
+  let bestLen = best.dx * best.dx + best.dy * best.dy
+  for (const d of deltas.slice(1)) {
+    const len = d.dx * d.dx + d.dy * d.dy
+    if (len > bestLen) {
+      best = d
+      bestLen = len
+    }
+  }
+  return { x: rect.x + best.dx, y: rect.y + best.dy }
+}

--- a/src/utils/polygonInset.js
+++ b/src/utils/polygonInset.js
@@ -1,0 +1,51 @@
+export function polygonInset(poly, eps = 1) {
+  if (!Array.isArray(poly) || poly.length < 3) return []
+  // Determine orientation via signed area
+  let area = 0
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    area += (a.x ?? a[0]) * (b.y ?? b[1]) - (b.x ?? b[0]) * (a.y ?? a[1])
+  }
+  const ccw = area > 0
+
+  const normals = new Array(poly.length).fill(0).map(() => ({ x: 0, y: 0 }))
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    const ax = a.x ?? a[0]
+    const ay = a.y ?? a[1]
+    const bx = b.x ?? b[0]
+    const by = b.y ?? b[1]
+    const dx = bx - ax
+    const dy = by - ay
+    // Outward normal depends on orientation
+    let nx, ny
+    if (ccw) {
+      nx = -dy
+      ny = dx
+    } else {
+      nx = dy
+      ny = -dx
+    }
+    const len = Math.hypot(nx, ny) || 1
+    nx /= len
+    ny /= len
+    normals[i].x += nx
+    normals[i].y += ny
+    normals[(i + 1) % poly.length].x += nx
+    normals[(i + 1) % poly.length].y += ny
+  }
+
+  const inset = poly.map((p, i) => {
+    const nx = normals[i].x
+    const ny = normals[i].y
+    const len = Math.hypot(nx, ny) || 1
+    const ux = nx / len
+    const uy = ny / len
+    const x = (p.x ?? p[0]) + ux * eps
+    const y = (p.y ?? p[1]) + uy * eps
+    return { x, y }
+  })
+  return inset
+}


### PR DESCRIPTION
## Summary
- add polygon inset utility and use inset for drag/drop clamping
- split canvas into background, content and overlay layers with clipping
- add tests for polygon utilities and layer ordering

## Testing
- `npm run test:unit` *(fails: HTMLCanvasElement.prototype.getContext not implemented; multiple spec failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11e9449c8321acc2696d60d3f2e6