### PR TITLE
feat: enforce wall placement rules with validations

### DIFF
--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -320,10 +320,22 @@
         </button>
         <button
           @click="deseleccionarElemento"
-          class="flex-1 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm"
+          :disabled="elementoSeleccionado?.ubicacion === 'Pared' && !wallFormValid"
+          :class="[
+            'flex-1 px-4 py-2 rounded-lg transition-colors text-sm',
+            elementoSeleccionado?.ubicacion === 'Pared' && !wallFormValid
+              ? 'bg-blue-400 text-white cursor-not-allowed opacity-60'
+              : 'bg-blue-500 text-white hover:bg-blue-600',
+          ]"
         >
-          Deseleccionar
+          Guardar
         </button>
+        <p
+          v-if="elementoSeleccionado?.ubicacion === 'Pared' && !wallFormValid"
+          class="text-xs text-yellow-600 mt-2 text-center"
+        >
+          Falta altura respecto al suelo (>0) y alto
+        </p>
       </div>
     </div>
   </div>
@@ -340,6 +352,7 @@ import { ref, watch, computed } from 'vue'
 import { useCanvasStore } from '@/composables/useCanvasStore.js'
 import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS } from '@/utils/constants'
 import { useDeleteElement } from '@/composables/useDeleteElement'
+import { isWallFormValid } from '@/utils/wallRules.js'
 import TagFilter from './TagFilter.vue'
 import CreateTagModal from './CreateTagModal.vue'
 
@@ -361,6 +374,11 @@ const elementoSeleccionado = computed(() => canvasStore.elementoSeleccionadoComp
 const isLockedSelected = computed(() => {
   const el = elementoSeleccionado.value
   return !!(el && (el.bloqueado === true || el.locked === true))
+})
+
+const wallFormValid = computed(() => {
+  const el = elementoSeleccionado.value
+  return isWallFormValid(el)
 })
 
 // Watchers

--- a/src/composables/useCanvasBuffer.js
+++ b/src/composables/useCanvasBuffer.js
@@ -13,6 +13,7 @@
 
 import { ref, computed } from 'vue'
 import { useCanvasStore } from './useCanvasStore'
+import { validateWallPlacement, isWallFormValid } from '@/utils/wallRules.js'
 
 // Estado global del buffer (singleton)
 const bufferItems = ref([])
@@ -231,16 +232,45 @@ export const useCanvasBuffer = () => {
       }
     }
 
-    // Agregar al canvas
-    canvasStore.agregarElemento(newElement)
+    if (newElement.ubicacion === 'Pared') {
+      if (!isWallFormValid(newElement)) {
+        const reason = 'Falta altura respecto al suelo (>0) y alto'
+        window.__toasts?.show?.(reason, { type: 'warn' }) ||
+          console.warn('[WALL_RULES]', reason, newElement)
+        return false
+      }
+      const all = canvasStore.elementos.filter(
+        (e) => e.plantaId === canvasStore.plantaActiva,
+      )
+      const bodegaH =
+        Number(canvasStore.plantaActivaData?.dimensiones?.alto) ||
+        Number(canvasStore.plantaActivaData?.altura) ||
+        0
+      const res = validateWallPlacement({
+        el: {
+          ...newElement,
+          alturaRespectoSuelo:
+            newElement.alturaRespectoSuelo ?? newElement?.elevacion?.zBase ?? 0,
+        },
+        all,
+        bodegaH,
+      })
+      if (!res.ok) {
+        window.__toasts?.show?.(res.reason, { type: 'warn' }) ||
+          console.warn('[WALL_RULES]', res.reason, newElement)
+        return false
+      }
+    }
+
+    const addedId = canvasStore.agregarElemento(newElement)
+    if (!addedId) return false
     console.log('📋 Elemento pegado desde buffer:', newElement.nombre)
 
-    // Si era un elemento movido (no copiado), remover del buffer
     if (bufferItem.sourceInfo.action === 'moved') {
       removeFromBuffer(bufferItemId)
     }
 
-    return newElement.id
+    return addedId
   }
 
   /**

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -17,6 +17,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
+import { validateWallPlacement, isWallFormValid } from '@/utils/wallRules.js'
 
 // Variable para evitar circular import - será inicializada por el composable de historial
 let historyComposable = null
@@ -200,6 +201,11 @@ export const useCanvasStore = defineStore('canvas', () => {
   const plantaActivaData = computed(() => {
     return plantas.value.find((planta) => planta.id === plantaActiva.value)
   })
+
+  const getBodegaAltura = () =>
+    Number(plantaActivaData.value?.dimensiones?.alto) ||
+    Number(plantaActivaData.value?.altura) ||
+    0
 
   const elementosEnPlanta = computed(() => (plantaId) => {
     return elementos.value.filter((el) => el.plantaId === plantaId)
@@ -579,30 +585,93 @@ export const useCanvasStore = defineStore('canvas', () => {
   const actualizarPosicion = (id, x, y) => {
     const elemento = elementos.value.find((el) => el.id === id)
     if (elemento) {
+      const elDraft = { ...elemento, x, y }
+      if (elDraft.ubicacion === 'Pared') {
+        if (!isWallFormValid(elDraft)) {
+          const reason = 'Falta altura respecto al suelo (>0) y alto'
+          window.__toasts?.show?.(reason, { type: 'warn' }) ||
+            console.warn('[WALL_RULES]', reason, elDraft)
+          return false
+        }
+        const all = elementos.value.filter((e) => e.plantaId === elDraft.plantaId)
+        const res = validateWallPlacement({
+          el: {
+            ...elDraft,
+            alturaRespectoSuelo:
+              elDraft.alturaRespectoSuelo ?? elDraft?.elevacion?.zBase ?? 0,
+          },
+          all,
+          bodegaH: getBodegaAltura(),
+        })
+        if (!res.ok) {
+          window.__toasts?.show?.(res.reason, { type: 'warn' }) ||
+            console.warn('[WALL_RULES]', res.reason, elDraft)
+          return false
+        }
+      }
       elemento.x = x
       elemento.y = y
+      return true
     }
+    return false
   }
 
   const actualizarElemento = (elementoId, propiedades) => {
     const elemento = elementos.value.find((el) => el.id === elementoId)
     if (elemento) {
+      const draft = JSON.parse(JSON.stringify(elemento))
       for (const key in propiedades) {
-        if (typeof propiedades[key] === 'object' && propiedades[key] !== null && !Array.isArray(propiedades[key])) {
-          // Si la propiedad es un objeto (como 'dimensiones'), la fusionamos recursivamente.
-          if (!elemento[key]) elemento[key] = {}
-          Object.assign(elemento[key], propiedades[key]);
+        if (
+          typeof propiedades[key] === 'object' &&
+          propiedades[key] !== null &&
+          !Array.isArray(propiedades[key])
+        ) {
+          if (!draft[key]) draft[key] = {}
+          Object.assign(draft[key], propiedades[key])
         } else {
-          // Si es un valor simple, lo asignamos directamente.
-          elemento[key] = propiedades[key];
+          draft[key] = propiedades[key]
         }
       }
 
-      // Correcciones en los datos de ancho y alto a base de las dimensiones
+      if (draft.ubicacion === 'Pared') {
+        if (!isWallFormValid(draft)) {
+          const reason = 'Falta altura respecto al suelo (>0) y alto'
+          window.__toasts?.show?.(reason, { type: 'warn' }) ||
+            console.warn('[WALL_RULES]', reason, draft)
+          return false
+        }
+        const all = elementos.value.filter((e) => e.plantaId === draft.plantaId)
+        const res = validateWallPlacement({
+          el: {
+            ...draft,
+            alturaRespectoSuelo:
+              draft.alturaRespectoSuelo ?? draft?.elevacion?.zBase ?? 0,
+          },
+          all,
+          bodegaH: getBodegaAltura(),
+        })
+        if (!res.ok) {
+          window.__toasts?.show?.(res.reason, { type: 'warn' }) ||
+            console.warn('[WALL_RULES]', res.reason, draft)
+          return false
+        }
+      }
+
+      for (const key in propiedades) {
+        if (
+          typeof propiedades[key] === 'object' &&
+          propiedades[key] !== null &&
+          !Array.isArray(propiedades[key])
+        ) {
+          if (!elemento[key]) elemento[key] = {}
+          Object.assign(elemento[key], propiedades[key])
+        } else {
+          elemento[key] = propiedades[key]
+        }
+      }
+
       if (propiedades.dimensiones) {
-        // Actualizar width/height dependiendo de la vista activa
         if (vistaActiva.value === 'XY') {
-          // En vista XY (superior): ancho->width, largo->height
           if (propiedades.dimensiones.ancho !== undefined) {
             elemento.width = elemento.dimensiones.ancho * CM_TO_PX
           }
@@ -610,17 +679,17 @@ export const useCanvasStore = defineStore('canvas', () => {
             elemento.height = elemento.dimensiones.largo * CM_TO_PX
           }
         } else if (vistaActiva.value === 'XZ') {
-          // En vista XZ (frontal): ancho->width, alto->height
           if (propiedades.dimensiones.ancho !== undefined) {
             elemento.width = elemento.dimensiones.ancho * CM_TO_PX
           }
           if (propiedades.dimensiones.alto !== undefined) {
             elemento.height = elemento.dimensiones.alto * CM_TO_PX
           }
-          // Nota: largo no afecta a width/height en vista XZ
         }
       }
+      return true
     }
+    return false
   }
 
   const configurarZoom = (nuevoZoom) => {
@@ -740,49 +809,78 @@ export const useCanvasStore = defineStore('canvas', () => {
       return null
     }
 
+    let elementoPadre = null
+    let planta = null
+
     // Si estamos dentro de un elemento o contenedor, el nuevo elemento es hijo
     if (
       contextoNavegacion.value.tipo === 'elementos' ||
       contextoNavegacion.value.tipo === 'contenedores'
     ) {
-      const elementoPadre = elementos.value.find((el) => el.id === contextoNavegacion.value.id)
+      elementoPadre = elementos.value.find(
+        (el) => el.id === contextoNavegacion.value.id,
+      )
       if (elementoPadre) {
-        // Agregar como hijo del elemento/contenedor actual
         nuevoElemento.padre = elementoPadre.id
         nuevoElemento.plantaId = elementoPadre.plantaId // Hereda la planta del padre
-
-        // Agregar el ID del hijo al array de hijos del padre
-        if (!elementoPadre.hijos) {
-          elementoPadre.hijos = []
-        }
-        elementoPadre.hijos.push(nuevoElemento.id)
-
-        console.log('Elemento agregado como hijo de:', {
-          padre: elementoPadre.nombre,
-          hijo: nuevoElemento.nombre,
-          tipoHijo: nuevoElemento.tipo,
-          hijosDelPadre: elementoPadre.hijos.length,
-        })
       }
     } else {
-      // Si estamos en una planta, agregar normalmente
+      // Si estamos en una planta, preparar datos
       nuevoElemento.plantaId = contextoNavegacion.value.id
-      nuevoElemento.padre = null;
-      nuevoElemento.etiquetas = []; // Sin etiquetas inicialmente
+      nuevoElemento.padre = null
+      nuevoElemento.etiquetas = []
+      planta = plantas.value.find((p) => p.id === contextoNavegacion.value.id)
+    }
 
-      // Actualizar el array de elementos en la planta
-      const planta = plantas.value.find((p) => p.id === contextoNavegacion.value.id)
-      if (planta) {
-        if (!planta.elementos) {
-          planta.elementos = []
-        }
-        planta.elementos.push(nuevoElemento.id)
-        console.log('Elemento agregado al array de elementos de la planta:', {
-          plantaId: planta.id,
-          elementoId: nuevoElemento.id,
-          totalElementosEnPlanta: planta.elementos.length,
-        })
+    if (nuevoElemento.ubicacion === 'Pared') {
+      if (!isWallFormValid(nuevoElemento)) {
+        const reason = 'Falta altura respecto al suelo (>0) y alto'
+        window.__toasts?.show?.(reason, { type: 'warn' }) ||
+          console.warn('[WALL_RULES]', reason, nuevoElemento)
+        return false
       }
+      const all = elementos.value.filter(
+        (e) => e.plantaId === nuevoElemento.plantaId,
+      )
+      const res = validateWallPlacement({
+        el: {
+          ...nuevoElemento,
+          alturaRespectoSuelo:
+            nuevoElemento.alturaRespectoSuelo ??
+            nuevoElemento?.elevacion?.zBase ??
+            0,
+        },
+        all,
+        bodegaH: getBodegaAltura(),
+      })
+      if (!res.ok) {
+        window.__toasts?.show?.(res.reason, { type: 'warn' }) ||
+          console.warn('[WALL_RULES]', res.reason, nuevoElemento)
+        return false
+      }
+    }
+
+    if (elementoPadre) {
+      if (!elementoPadre.hijos) {
+        elementoPadre.hijos = []
+      }
+      elementoPadre.hijos.push(nuevoElemento.id)
+      console.log('Elemento agregado como hijo de:', {
+        padre: elementoPadre.nombre,
+        hijo: nuevoElemento.nombre,
+        tipoHijo: nuevoElemento.tipo,
+        hijosDelPadre: elementoPadre.hijos.length,
+      })
+    } else if (planta) {
+      if (!planta.elementos) {
+        planta.elementos = []
+      }
+      planta.elementos.push(nuevoElemento.id)
+      console.log('Elemento agregado al array de elementos de la planta:', {
+        plantaId: planta.id,
+        elementoId: nuevoElemento.id,
+        totalElementosEnPlanta: planta.elementos.length,
+      })
     }
 
     elementos.value.push(nuevoElemento)
@@ -883,20 +981,23 @@ export const useCanvasStore = defineStore('canvas', () => {
    * Versiones con historial de las acciones principales
    */
   const actualizarElementoConHistorial = (elementoId, propiedades, description) => {
-    actualizarElemento(elementoId, propiedades)
+    const ok = actualizarElemento(elementoId, propiedades)
+    if (!ok) return false
 
     const descripcionAuto =
       description || `Propiedades actualizadas: ${Object.keys(propiedades).join(', ')}`
     saveToHistory(descripcionAuto)
+    return true
   }
 
   const actualizarPosicionConHistorial = (elementoId, x, y, description) => {
-    actualizarPosicion(elementoId, x, y)
+    const ok = actualizarPosicion(elementoId, x, y)
+    if (!ok) return false
 
-    // Solo guardar en historial al finalizar el arrastre, no en cada movimiento
     if (description) {
       saveToHistory(description)
     }
+    return true
   }
 
   const seleccionarPlantaConHistorial = (plantaId) => {

--- a/src/tests/wall_rules.spec.js
+++ b/src/tests/wall_rules.spec.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isWallFormValid,
+  wallZOk,
+  wallNoZOverlap,
+  wallVsFloorOk,
+  validateWallPlacement,
+} from '../utils/wallRules.js'
+
+describe('wallRules utilities', () => {
+  it('isWallFormValid', () => {
+    expect(
+      isWallFormValid({ ubicacion: 'Pared', alturaRespectoSuelo: 10, dimensiones: { alto: 20 } })
+    ).toBe(true)
+    expect(
+      isWallFormValid({ ubicacion: 'Pared', alturaRespectoSuelo: 0, dimensiones: { alto: 20 } })
+    ).toBe(false)
+    expect(isWallFormValid({ ubicacion: 'Suelo' })).toBe(true)
+  })
+
+  it('wallZOk with bodega 300cm', () => {
+    expect(
+      wallZOk({ ubicacion: 'Pared', alturaRespectoSuelo: 100, dimensiones: { alto: 100 } }, 300)
+    ).toBe(true)
+    expect(
+      wallZOk({ ubicacion: 'Pared', alturaRespectoSuelo: 250, dimensiones: { alto: 60 } }, 300)
+    ).toBe(false)
+  })
+
+  it('wallNoZOverlap', () => {
+    const a = { ubicacion: 'Pared', alturaRespectoSuelo: 0, dimensiones: { alto: 100 } }
+    const b = { ubicacion: 'Pared', alturaRespectoSuelo: 150, dimensiones: { alto: 50 } }
+    const c = { ubicacion: 'Pared', alturaRespectoSuelo: 50, dimensiones: { alto: 80 } }
+    expect(wallNoZOverlap(a, b)).toBe(true)
+    expect(wallNoZOverlap(a, c)).toBe(false)
+  })
+
+  it('wallVsFloorOk with high floor', () => {
+    const wall = { ubicacion: 'Pared', alturaRespectoSuelo: 50, dimensiones: { alto: 50 } }
+    const floor = { ubicacion: 'Suelo', dimensiones: { alto: 40 } }
+    const floorHigh = { ubicacion: 'Suelo', dimensiones: { alto: 60 } }
+    expect(wallVsFloorOk(wall, floor)).toBe(true)
+    expect(wallVsFloorOk(wall, floorHigh)).toBe(false)
+  })
+
+  it('validateWallPlacement ok and ko', () => {
+    const wall = { ubicacion: 'Pared', alturaRespectoSuelo: 10, dimensiones: { alto: 20 }, id: 'w1' }
+    const resOk = validateWallPlacement({ el: wall, all: [], bodegaH: 300 })
+    expect(resOk.ok).toBe(true)
+
+    const badForm = validateWallPlacement({
+      el: { ubicacion: 'Pared', alturaRespectoSuelo: 0, dimensiones: { alto: 20 }, id: 'w2' },
+      all: [],
+      bodegaH: 300,
+    })
+    expect(badForm.ok).toBe(false)
+
+    const overHeight = validateWallPlacement({
+      el: { ubicacion: 'Pared', alturaRespectoSuelo: 290, dimensiones: { alto: 20 }, id: 'w3' },
+      all: [],
+      bodegaH: 300,
+    })
+    expect(overHeight.ok).toBe(false)
+
+    const overlap = validateWallPlacement({
+      el: { ubicacion: 'Pared', alturaRespectoSuelo: 20, dimensiones: { alto: 40 }, id: 'w4' },
+      all: [wall],
+      bodegaH: 300,
+    })
+    expect(overlap.ok).toBe(false)
+
+    const floor = { ubicacion: 'Suelo', dimensiones: { alto: 60 }, id: 'f1' }
+    const floorHit = validateWallPlacement({
+      el: { ubicacion: 'Pared', alturaRespectoSuelo: 50, dimensiones: { alto: 50 }, id: 'w5' },
+      all: [floor],
+      bodegaH: 300,
+    })
+    expect(floorHit.ok).toBe(false)
+  })
+})

--- a/src/utils/wallRules.js
+++ b/src/utils/wallRules.js
@@ -1,0 +1,43 @@
+export const isWallFormValid = (el) =>
+  el?.ubicacion === 'Pared'
+    ? Number(el?.alturaRespectoSuelo) > 0 && Number(el?.dimensiones?.alto) > 0
+    : true;
+
+export const wallZOk = (el, bodegaH, eps = 0.5) =>
+  el?.ubicacion !== 'Pared'
+    ? true
+    : Number(el.alturaRespectoSuelo) + Number(el?.dimensiones?.alto) <=
+        Number(bodegaH) + eps;
+
+export const wallNoZOverlap = (el, vec, eps = 0.5) => {
+  if (el?.ubicacion !== 'Pared' || vec?.ubicacion !== 'Pared') return true;
+  const a0 = Number(el.alturaRespectoSuelo);
+  const a1 = a0 + Number(el?.dimensiones?.alto);
+  const b0 = Number(vec.alturaRespectoSuelo);
+  const b1 = b0 + Number(vec?.dimensiones?.alto);
+  return a1 <= b0 + eps || b1 <= a0 + eps;
+};
+
+export const wallVsFloorOk = (el, vecSuelo, eps = 0.5) => {
+  if (el?.ubicacion !== 'Pared' || vecSuelo?.ubicacion !== 'Suelo') return true;
+  const sueloH = Number(vecSuelo?.dimensiones?.alto) || 0;
+  return Number(el.alturaRespectoSuelo) >= sueloH + eps;
+};
+
+export const validateWallPlacement = ({ el, all, bodegaH }) => {
+  if (!isWallFormValid(el))
+    return { ok: false, reason: 'Falta altura respecto al suelo (>0) y alto' };
+  if (!wallZOk(el, bodegaH))
+    return { ok: false, reason: 'Supera altura de bodega' };
+  for (const v of all) {
+    if (v.id === el.id) continue;
+    if (!wallNoZOverlap(el, v))
+      return { ok: false, reason: 'Solape vertical con otra pared' };
+    if (!wallVsFloorOk(el, v))
+      return {
+        ok: false,
+        reason: 'Choca con elemento de suelo (altura insuficiente)',
+      };
+  }
+  return { ok: true };
+};


### PR DESCRIPTION
## Summary
- add wall placement utility rules for wall elements
- guard canvas store operations to block invalid wall actions
- disable save in property panel when wall data incomplete and add tests for rules

## Testing
- `npm run test:unit` *(fails: many existing tests failing in repo)*
- `npx vitest run src/tests/wall_rules.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_68ae1c8935f083219512de75558fdacb