### PR TITLE
feat: polygon inset clamp and layer separation

### DIFF
--- a/src/__tests__/drop-outside-polygon.spec.js
+++ b/src/__tests__/drop-outside-polygon.spec.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { pointInPolygon } from '@/utils/polygonBounds'
+
+vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+vi.mock('@/utils/collision', () => ({
+  detectConflictsFor: vi.fn(() => []),
+  throttle: (fn) => fn,
+}))
+
+import CanvasView from '@/components/CanvasView.vue'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  window.__toasts = { show: vi.fn() }
+})
+
+describe('drop outside polygon', () => {
+  it('clamps drop inside active polygon', async () => {
+    mockStore = {
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      plantaActivaData: {
+        nombre: 'Planta',
+        dimensiones: { ancho: 100, largo: 100 },
+        poligono: [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+          { x: 0, y: 100 }
+        ]
+      },
+      elementosVisibles: [],
+      elementoSeleccionado: null,
+      agregarElemento: vi.fn(),
+      seleccionarElemento: vi.fn(),
+      estaEnElemento: false,
+      estaEnContenedor: false,
+      estaEnPlanta: true,
+      contextoActual: { tipo: 'plantas' },
+      vistaActiva: 'XY',
+      gridSize: 50,
+      canvasAdaptativo: { width: 100, height: 100 },
+      configurarZoom: vi.fn(),
+      configurarPan: vi.fn(),
+    }
+
+    const wrapper = mount(CanvasView)
+    wrapper.vm.containerRef = { getBoundingClientRect: () => ({ left: 0, top: 0 }) }
+    wrapper.vm.stageRef = {
+      getNode: () => ({ x: () => 0, y: () => 0, scaleX: () => 1, scaleY: () => 1 })
+    }
+    wrapper.vm.stageSize.width = 100
+    wrapper.vm.stageSize.height = 100
+
+    const data = { elemento: { dimensiones: { ancho: 20, largo: 20 }, tipo: 'elementos', forma: 'rectangular', color: '#f00' } }
+    const dropEvent = { clientX: 150, clientY: 50, preventDefault: () => {} }
+
+    wrapper.vm.createElementFromDrop(data, dropEvent)
+
+    expect(window.__toasts.show).not.toHaveBeenCalled()
+    expect(mockStore.agregarElemento).toHaveBeenCalled()
+    const added = mockStore.agregarElemento.mock.calls[0][0]
+    const inside = pointInPolygon({ x: added.x, y: added.y }, mockStore.plantaActivaData.poligono)
+    expect(inside).toBe(true)
+  })
+})

--- a/src/__tests__/fit-to-planta.spec.js
+++ b/src/__tests__/fit-to-planta.spec.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+import CanvasView from '@/components/CanvasView.vue'
+
+describe('fitToPlanta', () => {
+  it('uses polygon bbox for zoom calculation', () => {
+    mockStore = {
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      plantaActivaData: {
+        nombre: 'Planta',
+        dimensiones: { ancho: 200, largo: 100 },
+        poligono: [
+          { x: 0, y: 0 },
+          { x: 200, y: 0 },
+          { x: 200, y: 100 },
+          { x: 0, y: 100 }
+        ]
+      },
+      elementosVisibles: [],
+      elementoSeleccionado: null,
+      agregarElemento: vi.fn(),
+      seleccionarElemento: vi.fn(),
+      estaEnElemento: false,
+      estaEnContenedor: false,
+      estaEnPlanta: true,
+      contextoActual: { tipo: 'plantas' },
+      vistaActiva: 'XY',
+      gridSize: 50,
+      canvasAdaptativo: { width: 400, height: 300 },
+      configurarZoom: vi.fn(),
+      configurarPan: vi.fn(),
+    }
+
+    const wrapper = mount(CanvasView)
+    wrapper.vm.stageRef = { getNode: () => ({}) }
+    // Ajustar tamaño del stage antes de llamar
+    wrapper.vm.stageSize.width = 400
+    wrapper.vm.stageSize.height = 400
+
+    wrapper.vm.fitToPlanta()
+
+    expect(mockStore.configurarZoom).toHaveBeenCalled()
+    const zoom = mockStore.configurarZoom.mock.calls[0][0]
+    const vw = Math.max(16, wrapper.vm.stageSize.width - 80)
+    const vh = Math.max(16, wrapper.vm.stageSize.height - 80)
+    const expected = Math.min(vw / 200, vh / 100)
+    expect(zoom).toBeCloseTo(expected)
+  })
+})

--- a/src/__tests__/innerNoOverlap.spec.js
+++ b/src/__tests__/innerNoOverlap.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { makeInnerSession } from '@/composables/useInnerNoOverlap'
+
+const CM = 1
+
+describe('makeInnerSession basic behaviours', () => {
+  let parent
+  beforeEach(() => {
+    parent = {
+      id: 'p',
+      dimensiones: { ancho: 20, largo: 20, alto: 20 },
+      posicion: { x: 0, y: 0 },
+      hijos: [],
+    }
+    global.window = { __GRID_SIZE_PX: 1 }
+  })
+
+  it('isValidLocal prevents overlap but allows touching', () => {
+    const moving = { id: 'm', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 5, y: 5 } }
+    const sibling = { id: 's', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 0, y: 0 } }
+    const sess = makeInnerSession({ parentEl: parent, movingEl: moving, siblings: [sibling], vista: 'XY', CM_TO_PX: CM })
+    expect(sess.isValidLocal({ x: 4, y: 0 })).toBe(false)
+    expect(sess.isValidLocal({ x: 5, y: 0 })).toBe(true)
+    expect(sess.isValidLocal({ x: 5, y: 15 })).toBe(true)
+  })
+
+  it('finalizeLocal snaps back to lastGood when invalid', () => {
+    const moving = { id: 'm', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 0, y: 0 } }
+    const sibling = { id: 's', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 5, y: 0 } }
+    const sess = makeInnerSession({ parentEl: parent, movingEl: moving, siblings: [sibling], vista: 'XY', CM_TO_PX: CM })
+    const bad = { x: 4, y: 0 }
+    const res = sess.finalizeLocal(bad)
+    expect(res).toEqual(sess.lastGoodLocal)
+    const good = { x: 10, y: 10 }
+    const res2 = sess.finalizeLocal(good)
+    expect(sess.isValidLocal(res2)).toBe(true)
+  })
+
+  it('dragBoundFuncLocal pushes against sibling without exiting bounds', () => {
+    const moving = { id: 'm', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 0, y: 0 } }
+    const sibling = { id: 's', dimensiones: { ancho: 5, largo: 5, alto: 5 }, posicion: { x: 5, y: 0 } }
+    const sess = makeInnerSession({ parentEl: parent, movingEl: moving, siblings: [sibling], vista: 'XY', CM_TO_PX: CM })
+    let next = sess.dragBoundFuncLocal({ x: 3, y: 0 }, { x: 5, y: 0 })
+    expect(next.x).toBe(0)
+    expect(next.y).toBe(0)
+    next = sess.dragBoundFuncLocal({ x: -2, y: 0 }, { x: -5, y: 0 })
+    expect(next.x).toBe(0)
+  })
+})

--- a/src/__tests__/layer-order.spec.js
+++ b/src/__tests__/layer-order.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CanvasView from '@/components/CanvasView.vue'
+
+let mockStore
+vi.mock('@/composables/useCanvasWithHistory', () => ({
+  useCanvasWithHistory: () => ({ store: mockStore })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  mockStore = {
+    zoom: 1,
+    panX: 0,
+    panY: 0,
+    plantaActivaData: {
+      nombre: 'Planta',
+      dimensiones: { ancho: 100, largo: 100 },
+      poligono: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 }
+      ]
+    },
+    elementosVisibles: [],
+    elementoSeleccionado: null,
+    canvasAdaptativo: { width: 100, height: 100 },
+    gridSize: 50,
+    contextoActual: { tipo: 'plantas' },
+    estaEnPlanta: true,
+    estaEnElemento: false,
+    estaEnContenedor: false
+  }
+})
+
+describe('canvas layers order', () => {
+  it('background below content and overlays without clip', () => {
+    const wrapper = mount(CanvasView)
+    expect(wrapper.vm.backgroundLayerRef).toBeTruthy()
+    expect(wrapper.vm.layerRef).toBeTruthy()
+    expect(wrapper.vm.overlaysLayerRef).toBeTruthy()
+  })
+})

--- a/src/__tests__/polygonBounds.spec.js
+++ b/src/__tests__/polygonBounds.spec.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { pointInPolygon, clampRectToPolygon } from '@/utils/polygonBounds'
+import { polygonInset } from '@/utils/polygonInset'
+
+describe('polygonBounds utils', () => {
+  it('pointInPolygon works with convex and concave polygons', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 }
+    ]
+    expect(pointInPolygon({ x: 5, y: 5 }, square)).toBe(true)
+    expect(pointInPolygon({ x: -1, y: 5 }, square)).toBe(false)
+
+    const concave = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 5, y: 5 },
+      { x: 0, y: 10 }
+    ]
+    expect(pointInPolygon({ x: 6, y: 6 }, concave)).toBe(true)
+    expect(pointInPolygon({ x: 4, y: 8 }, concave)).toBe(false)
+  })
+
+  it('clampRectToPolygon projects rectangle to nearest edge', () => {
+    const poly = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 }
+    ]
+    const rect = { x: -20, y: 10, width: 10, height: 10 }
+    const c = clampRectToPolygon(rect, poly)
+    expect(c.x).toBe(0)
+    expect(c.y).toBe(10)
+  })
+
+  it('polygonInset keeps dragged rect inside', () => {
+    const poly = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 }
+    ]
+    const inset = polygonInset(poly, 1)
+    const rect = { x: -5, y: 50, width: 10, height: 10 }
+    const c = clampRectToPolygon(rect, inset)
+    const inside = pointInPolygon({ x: c.x + 5, y: c.y + 5 }, inset)
+    expect(inside).toBe(true)
+  })
+})

--- a/src/__tests__/test-setup.js
+++ b/src/__tests__/test-setup.js
@@ -1,0 +1,32 @@
+import { vi } from 'vitest'
+
+// Stub vue-konva components globally
+vi.mock('vue-konva', () => ({
+  VueKonva: {},
+  default: { install: () => {} }
+}))
+
+import { config } from '@vue/test-utils'
+config.global.stubs = {
+  'v-stage': { template: '<div><slot /></div>' },
+  'v-layer': { template: '<div><slot /></div>', props: ['config'] },
+  'v-rect': true,
+  'v-circle': true,
+  'v-line': true,
+  'v-text': true,
+  'v-group': true,
+  'v-transformer': true,
+  'rulers-overlay': true
+}
+
+// Polyfill ResizeObserver for jsdom
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+if (typeof global !== 'undefined') {
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver
+}

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -422,6 +422,14 @@
       unit="m"
     />
 
+    <FloatingToolbar
+      :is-element-selected="canvasStore.elementoSeleccionado ? true : false"
+      :is-element-locked="selectedElementLocked"
+      :active-mode="isDragModeActive ? 'edit' : 'drag'"
+      @set-mode="toggleDragMode()"
+      @toggle-lock="toggleLockAndPreserveDrag(canvasStore.elementoSeleccionado)"
+    />
+
     <!-- Menú contextual -->
     <SpeedDialContext
       v-if="ctxVisible"
@@ -511,49 +519,6 @@
         </svg>
       </button>
 
-  <!-- Nuevo SpeedDial -->
-  <div class="relative">
-        <div class="relative">
-          <button @click="toggleSpeedDial" class="floating-btn btn-gear focus:outline-none" :class="{ 'ring-2 ring-blue-500': speedDialOpen }" title="Acciones del elemento">
-            <!-- Icono de acciones (tres puntos verticales) -->
-            <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <circle cx="12" cy="5" r="1.75" />
-              <circle cx="12" cy="12" r="1.75" />
-              <circle cx="12" cy="19" r="1.75" />
-            </svg>
-          </button>
-            <!-- Acciones -->
-          <transition-group name="fade-scale">
-            <!-- Acción Modo Arrastre (siempre visible cuando el speedDial está abierto) -->
-            <button
-              v-if="speedDialOpen"
-              key="hand"
-              @click="toggleDragMode"
-              class="speed-action"
-              :style="{ top: canvasStore.elementoSeleccionado ? '116px' : '60px' }"
-              :class="isDragModeActive ? 'bg-emerald-600': 'bg-white'"
-              :title="isDragModeActive ? 'Desactivar modo edición' : 'Activar modo edición'"
-            >
-              <svg class="w-5 h-5" :class="isDragModeActive ? 'text-white' : 'text-emerald-600'" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11V6a1 1 0 012 0v5m2-3V6a1 1 0 112 0v5m2-2V9a1 1 0 112 0v4.5c0 3.59-2.91 6.5-6.5 6.5h-.55A6.95 6.95 0 019 19" /></svg>
-            </button>
-            <!-- Acción Bloquear / Desbloquear solo si hay elemento seleccionado -->
-            <button
-              v-if="speedDialOpen && canvasStore.elementoSeleccionado"
-              key="lock"
-              @mousedown.stop.prevent
-              @click.stop="() => toggleLockAndPreserveDrag(canvasStore.elementoSeleccionado)"
-              class="speed-action group"
-              :class="selectedElementLocked ? 'bg-amber-500': 'bg-blue-500'"
-              style="top:60px;"
-              :title="selectedElementLocked ? 'Desbloquear' : 'Bloquear'"
-            >
-              <span class="sr-only">Bloquear</span>
-              <svg v-if="selectedElementLocked" class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M7 11V7a5 5 0 0110 0v4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" /><rect x="5" y="11" width="14" height="8" rx="2" stroke-width="2" class="fill-amber-400/40 stroke-white" /><circle cx="12" cy="15" r="2" fill="currentColor" /></svg>
-              <svg v-else class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M7 11V7a5 5 0 0110 0v2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" /><rect x="5" y="11" width="14" height="8" rx="2" stroke-width="2" class="fill-blue-400/20 stroke-white" /><circle cx="12" cy="15" r="2" fill="currentColor" /></svg>
-            </button>
-          </transition-group>
-        </div>
-      </div>
     </div>
   </div>
 </template>
@@ -590,6 +555,7 @@ import { resolveFinalByIntervals } from '@/utils/finalIntervals'
 import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
 import { makeInnerSession } from '@/composables/useInnerNoOverlap'
+import FloatingToolbar from './FloatingToolbar.vue'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -31,6 +31,41 @@
       @dragmove="handleStageDragMove"
       @dragend="handleStageDragEnd"
     >
+      <v-layer ref="backgroundLayerRef" :config="{ listening: false }">
+        <v-line
+          v-if="plantPolygon.length"
+          :config="{
+            points: plantPolygonFlat,
+            closed: true,
+            stroke: '#0ea5e9',
+            fill: 'rgba(14,165,233,0.08)',
+            strokeWidth: 2,
+            listening: false,
+          }"
+        />
+        <v-line
+          v-for="i in gridLines.vertical"
+          :key="`v-${i}`"
+          :config="{
+            points: [i, 0, i, floorBoundary.height],
+            stroke: '#e5e7eb',
+            strokeWidth: 1,
+            opacity: 0.5,
+            listening: false,
+          }"
+        />
+        <v-line
+          v-for="i in gridLines.horizontal"
+          :key="`h-${i}`"
+          :config="{
+            points: [0, i, floorBoundary.width, i],
+            stroke: '#e5e7eb',
+            strokeWidth: 1,
+            opacity: 0.5,
+            listening: false,
+          }"
+        />
+      </v-layer>
       <v-layer ref="layerRef">
         <template v-if="canvasStore.elementoAura">
         <v-rect
@@ -64,31 +99,6 @@
 
         <!-- Aquí podrías añadir v-circle, etc., si tienes otras formas -->
       </template>
-        <!-- Fondo de la planta - área delimitada -->
-        <v-rect
-          :config="{
-            x: 0,
-            y: 0,
-            width: floorBoundary.width,
-            height: floorBoundary.height,
-            fill: 'rgba(14,165,233,0.08)',
-            stroke: '#3b82f6',
-            strokeWidth: 2,
-            opacity: 1,
-            listening: false,
-          }"
-        />
-        <v-line
-          v-if="!canvasStore.estaEnElemento && !canvasStore.estaEnContenedor"
-          :config="{
-            points: floorBoundary.points,
-            closed: true,
-            stroke: '#0ea5e9',
-            fill: 'rgba(14,165,233,0.08)',
-            strokeWidth: 2,
-            listening: false,
-          }"
-        />
         <!-- Debug: mostrar información según el contexto -->
         <v-text
           :config="{
@@ -372,30 +382,8 @@
 
         <!-- Los contenedores se renderizan junto con los elementos en la sección principal -->
 
-        <!-- Grid de referencia de la planta -->
-        <v-line
-          v-for="i in gridLines.vertical"
-          :key="`v-${i}`"
-          :config="{
-            points: [i, 0, i, floorBoundary.height],
-            stroke: '#e5e7eb',
-            strokeWidth: 1,
-            opacity: 0.5,
-            listening: false,
-          }"
-        />
-        <v-line
-          v-for="i in gridLines.horizontal"
-          :key="`h-${i}`"
-          :config="{
-            points: [0, i, floorBoundary.width, i],
-            stroke: '#e5e7eb',
-            strokeWidth: 1,
-            opacity: 0.5,
-            listening: false,
-          }"
-        />
-        <!-- Transformer para modo edición -->
+      </v-layer>
+      <v-layer ref="overlaysLayerRef">
         <v-transformer
           v-if="isEditingSelected && canvasStore.elementoSeleccionado && !selectedElementLocked"
           ref="transformerRef"
@@ -574,12 +562,14 @@ import {
   projectMTDAgainstBoundary,
 } from '@/utils/collision'
 import {
-  rectInsidePolygon,
   clampRectToRect,
   snapToGrid,
   nudgePlace,
 } from '@/utils/geometry'
+import { clampRectToPolygon, pointInPolygon, clampPointToPolygon } from '@/utils/polygonBounds'
+import { polygonInset } from '@/utils/polygonInset'
 import { GRID_SIZE, CM_TO_PX } from '@/utils/constants'
+import { getActiveBounds } from '@/utils/activeBounds'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useDeleteElement } from '@/composables/useDeleteElement'
@@ -605,6 +595,8 @@ const emit = defineEmits(['select', 'drill-down'])
 const containerRef = ref(null)
 const stageRef = ref(null)
 const layerRef = ref(null)
+const backgroundLayerRef = ref(null)
+const overlaysLayerRef = ref(null)
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
@@ -696,6 +688,10 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
     const c = clampRectToRect(x, y, w, h, W, H)
     x = c.x
     y = c.y
+  } else if (boundary.type === 'polygon') {
+    const c = clampRectToPolygon({ x, y, width: w, height: h }, boundary.inset)
+    x = c.x
+    y = c.y
   }
 
   for (let iter = 0; iter < MAX_ITERS; iter++) {
@@ -732,7 +728,9 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
       x = c2.x
       y = c2.y
     } else if (boundary.type === 'polygon') {
-      // En polígono no hay clamp trivial; si sale, revertimos a última válida luego
+      const c2 = clampRectToPolygon({ x, y, width: w, height: h }, boundary.inset)
+      x = c2.x
+      y = c2.y
     }
 
     // Si la corrección fue nula, detener
@@ -742,11 +740,16 @@ const resolveAgainstBlockingObstacles = (candidateX, candidateY, elemento) => {
   // Validaciones finales: si aún hay colisión bloqueante o quedó fuera, volver a última válida
   const movingEnd = { ...elemento, x, y }
   const endConf = detectConflictsFor(movingEnd, all).filter((c) => c.bloqueante)
-  const outsideRect =
+  const outsideArea =
     boundary.type === 'rect'
       ? x < -1e-6 || y < -1e-6 || x + w > W + 1e-6 || y + h > H + 1e-6
-      : false
-  if (endConf.length > 0 || outsideRect) {
+      : !pointInPolygon({ x: x + w / 2, y: y + h / 2 }, boundary.points)
+  if (outsideArea) {
+    const cp = clampPointToPolygon({ x: x + w / 2, y: y + h / 2 }, boundary.inset)
+    x = cp.x - w / 2
+    y = cp.y - h / 2
+  }
+  if (endConf.length > 0 || outsideArea) {
     const prev = lastValidPositions.value.get(elemento.id) || { x: elemento.x, y: elemento.y }
     return { x: prev.x, y: prev.y, fellBack: true }
   }
@@ -778,29 +781,15 @@ const stageConfig = computed(() => {
   }
 })
 
-const floorBoundary = computed(() => {
-  // Empezamos con las dimensiones base del layer
-  let width = layerConfig.value.width
-  let height = layerConfig.value.height
-  let points = []
+const activeBounds = computed(() => getActiveBounds(canvasStore))
 
-  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
-    return { width, height, points }
-  }
+const plantPolygon = computed(() => activeBounds.value.polygonPx)
 
-  const poligono = canvasStore.plantaActivaData?.poligono
+const insetPoly = computed(() => polygonInset(plantPolygon.value, 1))
 
-  // Si hay un polígono, lo usamos para expandir los límites y obtener los puntos
-  if (poligono && Array.isArray(poligono) && poligono.length > 0) {
-    poligono.forEach((coord) => {
-      width = Math.max(coord.x, width)
-      height = Math.max(coord.y, height)
-    })
-    points = poligono.flatMap((p) => [p.x, p.y])
-  }
+const plantPolygonFlat = computed(() => plantPolygon.value.flatMap((p) => [p.x, p.y]))
 
-  return { width, height, points }
-})
+const floorBoundary = computed(() => activeBounds.value.boundsPx)
 
 // Configuración del layer - SIEMPRE USA CANVAS ADAPTATIVO
 const layerConfig = computed(() => {
@@ -837,22 +826,25 @@ const gridLines = computed(() => {
   return { vertical, horizontal }
 })
 
-// Obtiene el contorno de la planta activa como rect o polígono
+watch(
+  plantPolygon,
+  (poly) => {
+    const layer = layerRef.value?.getNode?.()
+    if (layer && poly?.length) {
+      layer.clipFunc((ctx) => {
+        ctx.beginPath()
+        poly.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)))
+        ctx.closePath()
+      })
+      layer.batchDraw?.()
+    }
+  },
+  { immediate: true },
+)
+
+// Contorno activo siempre expresado como polígono
 const computeBoundary = () => {
-  const W = layerConfig.value.width
-  const H = layerConfig.value.height
-
-  // Si estamos en un elemento o contenedor, usar todo el canvas adaptativo como boundary
-  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
-    return { type: 'rect', W, H }
-  }
-
-  // Si estamos en una planta, verificar si tiene polígono
-  const planta = canvasStore.plantaActivaData
-  if (planta?.poligono && Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
-    return { type: 'polygon', points: planta.poligono }
-  }
-  return { type: 'rect', W, H }
+  return { type: 'polygon', points: plantPolygon.value, inset: insetPoly.value }
 }
 
 // === FUNCIONES DE ZOOM ===
@@ -979,14 +971,23 @@ const dragBoundForElement = (pos, elemento, forma = 'rect') => {
     const layerW = layerConfig.value.width
     const layerH = layerConfig.value.height
     const lp = toLayerCoords(pos)
-  if (forma === 'circular' || forma === 'circle') {
+    const boundary = computeBoundary()
+    if (forma === 'circular' || forma === 'circle') {
       const r = Math.min(elemento.width, elemento.height) / 2
       const cx = Math.max(r, Math.min(lp.x, layerW - r))
       const cy = Math.max(r, Math.min(lp.y, layerH - r))
       return toStageCoords({ x: cx, y: cy })
     } else {
-      const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
-      return toStageCoords(c)
+      if (boundary.type === 'polygon') {
+        const c = clampRectToPolygon(
+          { x: lp.x, y: lp.y, width: elemento.width, height: elemento.height },
+          boundary.inset,
+        )
+        return toStageCoords(c)
+      } else {
+        const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
+        return toStageCoords(c)
+      }
     }
   } catch {
     return pos
@@ -1592,7 +1593,16 @@ const createElementFromDrop = (data, dropEvent) => {
       candY = clamped.y
     }
   } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, finalWidth, finalHeight, boundary.points)
+    isInsideArea = pointInPolygon({
+      x: candX + finalWidth / 2,
+      y: candY + finalHeight / 2,
+    }, boundary.inset)
+    if (!isInsideArea) {
+      const clamped = clampRectToPolygon({ x: candX, y: candY, width: finalWidth, height: finalHeight }, boundary.inset)
+      candX = clamped.x
+      candY = clamped.y
+      isInsideArea = pointInPolygon({ x: candX + finalWidth / 2, y: candY + finalHeight / 2 }, boundary.inset)
+    }
   }
 
   // 6. Crear elemento temporal para detectar conflictos
@@ -1645,8 +1655,16 @@ const createElementFromDrop = (data, dropEvent) => {
 
   // 9. Si aún no hay posición válida, rechazar y mostrar toast
   if (!placementSuccessful) {
-    showToast('No hay espacio aquí para colocar el elemento', 'error')
+    showToast('Fuera de los límites de la planta', 'error')
     return // NO crear la instancia, NO comprometer historial
+  }
+
+  if (boundary.type === 'polygon') {
+    const c = clampRectToPolygon(
+      { x: finalPosition.x, y: finalPosition.y, width: finalWidth, height: finalHeight },
+      boundary.inset,
+    )
+    finalPosition = { x: c.x, y: c.y }
   }
 
   // 10. Crear el elemento solo si la validación fue exitosa
@@ -1870,7 +1888,13 @@ const createElementFromBuffer = (data, dropEvent) => {
       candY = clamped.y
     }
   } else if (boundary.type === 'polygon') {
-    isInsideArea = rectInsidePolygon(candX, candY, width, height, boundary.points)
+    isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.inset)
+    if (!isInsideArea) {
+      const clamped = clampRectToPolygon({ x: candX, y: candY, width, height }, boundary.inset)
+      candX = clamped.x
+      candY = clamped.y
+      isInsideArea = pointInPolygon({ x: candX + width / 2, y: candY + height / 2 }, boundary.inset)
+    }
   }
 
   // 5. Crear elemento temporal y detectar conflictos
@@ -1920,8 +1944,16 @@ const createElementFromBuffer = (data, dropEvent) => {
 
   // 7. Si no hay posición válida, rechazar
   if (!placementSuccessful) {
-    showToast('No hay espacio aquí para pegar el elemento', 'error')
+    showToast('Fuera de los límites de la planta', 'error')
     return // NO pegar, NO comprometer historial
+  }
+
+  if (boundary.type === 'polygon') {
+    const c = clampRectToPolygon(
+      { x: finalPosition.x, y: finalPosition.y, width, height },
+      boundary.inset,
+    )
+    finalPosition = { x: c.x, y: c.y }
   }
 
   // 8. Pegar elemento desde buffer en posición válida

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -164,9 +164,9 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id)"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => canDragElement(elemento.id) && onShapeDragStart(e, elemento)"
+            @dragmove="(e) => canDragElement(elemento.id) && onShapeDragMove(e, elemento)"
+            @dragend="(e) => canDragElement(elemento.id) && onShapeDragEnd(e, elemento)"
               @transformstart="(e) => handleTransformStart(e, elemento.id)"
               @transform="(e) => handleTransformMove(e, elemento.id, 'rectangular')"
               @transformend="(e) => handleTransformEnd(e, elemento.id, 'rectangular')"
@@ -234,9 +234,9 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id, 'circular')"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => canDragElement(elemento.id) && onShapeDragStart(e, elemento)"
+            @dragmove="(e) => canDragElement(elemento.id) && onShapeDragMove(e, elemento)"
+            @dragend="(e) => canDragElement(elemento.id) && onShapeDragEnd(e, elemento)"
             @transformstart="(e) => handleTransformStart(e, elemento.id)"
             @transform="(e) => handleTransformMove(e, elemento.id, 'circular')"
             @transformend="(e) => handleTransformEnd(e, elemento.id, 'circular')"
@@ -267,9 +267,9 @@
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
-            @dragstart="() => canDragElement(elemento.id) && startElementDrag(elemento.id)"
-            @dragmove="(e) => canDragElement(elemento.id) && updateElementPosition(e, elemento.id)"
-            @dragend="() => canDragElement(elemento.id) && endElementDrag(elemento.id)"
+            @dragstart="(e) => canDragElement(elemento.id) && onShapeDragStart(e, elemento)"
+            @dragmove="(e) => canDragElement(elemento.id) && onShapeDragMove(e, elemento)"
+            @dragend="(e) => canDragElement(elemento.id) && onShapeDragEnd(e, elemento)"
             @transformstart="(e) => handleTransformStart(e, elemento.id)"
             @transform="(e) => handleTransformMove(e, elemento.id, 'rectangular')"
             @transformend="(e) => handleTransformEnd(e, elemento.id, 'rectangular')"
@@ -589,6 +589,7 @@ import { resetEdgeState } from '@/composables/useEdgeState'
 import { resolveFinalByIntervals } from '@/utils/finalIntervals'
 import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
+import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -605,6 +606,20 @@ const emit = defineEmits(['select', 'drill-down'])
 const containerRef = ref(null)
 const stageRef = ref(null)
 const layerRef = ref(null)
+
+const innerSessions = new Map()
+let needsDraw = false
+let rafId = null
+function scheduleDraw() {
+  if (rafId) return
+  rafId = requestAnimationFrame(() => {
+    rafId = null
+    if (needsDraw) {
+      layerRef.value?.getNode()?.batchDraw()
+      needsDraw = false
+    }
+  })
+}
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
@@ -1573,6 +1588,34 @@ const createElementFromDrop = (data, dropEvent) => {
   candX = snapped.x
   candY = snapped.y
 
+  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
+    if (elemento.tipo === 'contenedores') {
+      const parent = canvasStore.elementoContenedorActual
+      const siblings = parent?.hijos?.map((id) => canvasStore.elementoPorId(id)).filter(Boolean) || []
+      const temp = {
+        id: '__temp',
+        dimensiones: { ancho: anchoCm, largo: largoCm, alto: altoCm },
+        posicion: { x: candX, y: candY },
+      }
+      const sess = makeInnerSession({
+        parentEl: parent,
+        movingEl: temp,
+        siblings,
+        vista: canvasStore.vistaActiva,
+        CM_TO_PX,
+      })
+      let local = sess.toLocal({ x: candX, y: candY }, parent)
+      local = sess.finalizeLocal(local)
+      if (!sess.isValidLocal(local)) {
+        showToast('No hay espacio aquí', 'error')
+        return
+      }
+      const world = sess.toWorld(local, parent)
+      candX = world.x
+      candY = world.y
+    }
+  }
+
   // 4. Calcular bbox candidato y verificar área
   const boundary = computeBoundary()
 
@@ -1735,6 +1778,83 @@ const createElementFromDrop = (data, dropEvent) => {
 
   // Seleccionar el elemento recién creado
   canvasStore.seleccionarElemento(nuevoElemento.id)
+}
+
+const onShapeDragStart = (e, el) => {
+  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
+    const shape = e.target
+    const parent =
+      canvasStore.elementoContenedorActual || canvasStore.elementoPorId(canvasStore.elementoSeleccionado)
+    const siblings = parent?.hijos?.map((id) => canvasStore.elementoPorId(id)).filter(Boolean) || []
+    const session = makeInnerSession({
+      parentEl: parent,
+      movingEl: el,
+      siblings,
+      vista: canvasStore.vistaActiva,
+      CM_TO_PX,
+    })
+    const pointer = e.evt ? { x: e.evt.clientX || 0, y: e.evt.clientY || 0 } : { x: 0, y: 0 }
+    innerSessions.set(el.id, {
+      session,
+      parent,
+      lastPointer: pointer,
+      initial: { x: el.posicion?.x ?? el.x ?? 0, y: el.posicion?.y ?? el.y ?? 0 },
+    })
+    isElementDragging.value = true
+    stageDragEnabled.value = false
+  } else {
+    startElementDrag(el.id)
+  }
+}
+
+const onShapeDragMove = (e, el) => {
+  const data = innerSessions.get(el.id)
+  if (data) {
+    const { session, parent } = data
+    const shape = e.target
+    const pointer = e.evt ? { x: e.evt.clientX || 0, y: e.evt.clientY || 0 } : { x: 0, y: 0 }
+    const vel = {
+      x: e.evt?.movementX ?? pointer.x - data.lastPointer.x,
+      y: e.evt?.movementY ?? pointer.y - data.lastPointer.y,
+    }
+    data.lastPointer = pointer
+    const posWorld = shape.position()
+    const posLocal = session.toLocal(posWorld, parent)
+    const nextLocal = session.dragBoundFuncLocal(posLocal, vel)
+    shape.position(session.toWorld(nextLocal, parent))
+    needsDraw = true
+    scheduleDraw()
+  } else {
+    updateElementPosition(e, el.id, el.forma === 'circular' ? 'circular' : 'rectangular')
+  }
+}
+
+const onShapeDragEnd = (e, el) => {
+  const data = innerSessions.get(el.id)
+  if (data) {
+    const { session, parent, initial } = data
+    innerSessions.delete(el.id)
+    isElementDragging.value = false
+    stageDragEnabled.value = true
+    const shape = e.target
+    let candLocal = session.toLocal(shape.position(), parent)
+    let finalLocal = session.finalizeLocal(candLocal)
+    const finalWorld = session.toWorld(finalLocal, parent)
+    shape.position(finalWorld)
+    needsDraw = true
+    scheduleDraw()
+    const changed =
+      Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
+    if (changed) {
+      canvasStore.actualizarElementoConHistorial(
+        el.id,
+        { posicion: { x: finalWorld.x, y: finalWorld.y }, x: finalWorld.x, y: finalWorld.y },
+        `Elemento movido: ${el.id}`,
+      )
+    }
+  } else {
+    endElementDrag(el.id)
+  }
 }
 
 const getElementShadow = (elemento) => {

--- a/src/components/FloatingToolbar.vue
+++ b/src/components/FloatingToolbar.vue
@@ -1,0 +1,88 @@
+<!-- components/FloatingToolbar.vue -->
+<template>
+  <div
+    class="fixed bottom-5 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 rounded-full bg-gray-900/70 p-2 shadow-lg backdrop-blur-sm"
+  >
+
+    <!-- Switch de Modo Edición / Arrastre -->
+    <div class="relative flex items-center rounded-full bg-gray-700/50 p-1">
+      <div
+        class="absolute left-1 top-1 h-10 w-10 rounded-full bg-blue-600 shadow-md transition-transform duration-300 ease-in-out"
+        :style="{ transform: activeMode === 'edit' ? 'translateX(100%)' : 'translateX(0)' }"
+      ></div>
+      <button
+        @click.stop="$emit('set-mode', 'drag')"
+        class="relative z-10 flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-200;
+"
+        title="Modo Arrastre (Mover el lienzo)"
+      >
+        <!-- Icono de Mano (Arrastre) -->
+        <svg
+          class="h-6 w-6"
+          :class="activeMode === 'drag' ? 'fill-white' : 'fill-gray-300'"
+          viewBox="0 0 24 24"
+        >
+        <path 
+            d="M21 7C21 5.62 19.88 4.5 18.5 4.5C18.33 4.5 18.16 4.5 18 4.55V4C18 2.62 16.88 1.5 15.5 1.5C15.27 1.5 15.04 1.53 14.83 1.59C14.46 .66 13.56 0 12.5 0C11.27 0 10.25 .89 10.04 2.06C9.87 2 9.69 2 9.5 2C8.12 2 7 3.12 7 4.5V10.39C6.66 10.08 6.24 9.85 5.78 9.73L5 9.5C4.18 9.29 3.31 9.61 2.82 10.35C2.44 10.92 2.42 11.66 2.67 12.3L5.23 18.73C6.5 21.91 9.57 24 13 24C17.42 24 21 20.42 21 16V7M19 16C19 19.31 16.31 22 13 22C10.39 22 8.05 20.41 7.09 18L4.5 11.45L5 11.59C5.5 11.71 5.85 12.05 6 12.5L7 15H9V4.5C9 4.22 9.22 4 9.5 4S10 4.22 10 4.5V12H12V2.5C12 2.22 12.22 2 12.5 2S13 2.22 13 2.5V12H15V4C15 3.72 15.22 3.5 15.5 3.5S16 3.72 16 4V12H18V7C18 6.72 18.22 6.5 18.5 6.5S19 6.72 19 7V16Z" />
+            />
+        </svg>
+      </button>
+      <button
+        @click.stop="$emit('set-mode', 'edit')"
+        class="relative z-10 flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-200"
+        title="Modo Edición (Seleccionar y mover elementos)"
+      >
+        <!-- Icono de Puntero (Edición) -->
+        <svg
+          class="h-6 w-6"
+          :class="activeMode === 'edit' ? 'fill-white' : 'fill-gray-300'"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M13.64,21.97C13.14,22.21 12.54,22 12.31,21.5L10.13,16.76L7.62,18.78C7.45,18.92 7.24,19 7,19A1,1 0 0,1 6,18V3A1,1 0 0,1 7,2C7.24,2 7.47,2.09 7.64,2.23L7.65,2.22L19.14,11.86C19.57,12.22 19.62,12.85 19.27,13.27C19.12,13.45 18.91,13.57 18.7,13.61L15.54,14.23L17.74,18.96C18,19.46 17.76,20.05 17.26,20.28L13.64,21.97Z"
+          />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Separador y Bloqueo -->
+    <template v-if="isElementSelected">
+      <div class="h-6 w-px bg-gray-100/70"></div>
+      <button @click.stop="$emit('toggle-lock')" 
+        class="flex h-12 w-12 items-center justify-center rounded-full transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-40" 
+        :class="`${isElementLocked ? 'bg-amber-600 hover:bg-amber-500' : 'hover:bg-gray-700/80'}`"
+        :title="isElementLocked ? 'Desbloquear' : 'Bloquear'">
+        <svg 
+          v-if="isElementLocked" 
+          class="h-6 w-6 text-white" 
+          fill="currentColor" 
+          viewBox="0 0 24 24"
+        >
+          <path 
+            d="M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z" 
+          />
+        </svg>
+        <svg 
+          v-else 
+          class="h-6 w-6 text-gray-300" 
+          fill="currentColor" 
+          viewBox="0 0 24 24">
+          <path 
+            d="M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V10A2,2 0 0,1 6,8H15V6A3,3 0 0,0 12,3A3,3 0 0,0 9,6H7A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,17A2,2 0 0,0 14,15A2,2 0 0,0 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17Z" 
+          />
+        </svg>
+      </button>
+    </template>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  activeMode: { type: String, default: 'drag' },
+  isElementSelected: { type: Boolean, default: false },
+  isElementLocked: { type: Boolean, default: false },
+})
+
+defineEmits(['set-mode', 'toggle-lock'])
+</script>
+

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -234,6 +234,18 @@
             placeholder="Ej: 100"
           />
         </div>
+        <div class="grid grid-cols-2 items-center">
+          <label for="prop-volumen-max" class="text-sm text-gray-500">Volumen (m³)</label>
+          <input
+            id="prop-volumen-max"
+            type="number"
+            :value="volumen"
+            disabled
+            @change="actualizarPropiedadSimple('pesoMaximo', $event.target.value)"
+            class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Ej: 100"
+          />
+        </div>
       </div>
     </div>
 
@@ -313,10 +325,10 @@
       </div>
       <div class="flex gap-2">
         <button
-          @click="resetearPropiedades"
+          @click="cambiarBloqueo"
           class="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm"
         >
-          Restablecer
+        {{ elementoSeleccionado.bloqueado ? 'Desploquear' : 'Bloquear' }}
         </button>
         <button
           @click="deseleccionarElemento"
@@ -362,6 +374,15 @@ const isLockedSelected = computed(() => {
   const el = elementoSeleccionado.value
   return !!(el && (el.bloqueado === true || el.locked === true))
 })
+
+
+const volumen = computed(() => {
+  const ancho = elementoSeleccionado.value.dimensiones?.ancho;
+  const alto = elementoSeleccionado.value.dimensiones?.alto;
+  const largo = elementoSeleccionado.value.dimensiones?.largo;
+  const v = ancho * alto * largo;
+  return (v / 1000000).toFixed(2);
+});
 
 // Watchers
 watch(
@@ -415,6 +436,10 @@ const resetearPropiedades = () => {
 
   propiedadesEditables.value = { ...propiedadesOriginales }
   canvasStore.actualizarElemento(elementoSeleccionado.value.id, propiedadesOriginales)
+}
+
+const cambiarBloqueo = () => {
+  canvasStore.actualizarElemento(elementoSeleccionado.value.id, { bloqueado: !elementoSeleccionado.value.bloqueado })
 }
 
 const deseleccionarElemento = () => {

--- a/src/components/TagFilter.vue
+++ b/src/components/TagFilter.vue
@@ -16,7 +16,7 @@
         <span>{{ etiqueta.texto }}</span>
         <button
           @click.stop="onRemoveTag(etiqueta.id)"
-          class="w-4 h-4 flex items-center justify-center rounded-full opacity-70 hover:opacity-100"
+          class="px-2 py-1 flex items-center justify-center rounded-full opacity-70 hover:opacity-100"
           :style="{ backgroundColor: 'rgba(0,0,0,0.1)' }"
           title="Eliminar etiqueta"
         >

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -90,6 +90,7 @@ export const useCanvasStore = defineStore('canvas', () => {
   const idsElementosFiltrados = ref(null);
   const elementoAura = ref(null);
 
+  const isDraggable = ref(true);
   // Configuración de grilla y snap
   const gridSize = ref(50) // px entre líneas de grilla
   const snapGridEps = ref(6) // px de proximidad para aplicar snap al soltar
@@ -1415,6 +1416,10 @@ export const useCanvasStore = defineStore('canvas', () => {
     idsElementosFiltrados.value = ids
   }
 
+  const setDraggableMode = (mode) => {
+    this.isDraggable = mode;
+  };
+
   // Watcher para recalcular canvas adaptativo cuando cambia el contexto
   watch(
     () => [contextoNavegacion.value.tipo, contextoNavegacion.value.id],
@@ -1462,6 +1467,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     elementoDestacadoId,
     idsElementosFiltrados,
     elementoAura,
+    isDraggable,
 
     // Getters
     elementosVisibles,
@@ -1546,5 +1552,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     // == Destacar
     destacarElemento,
     actualizarIdsFiltrados,
+
+    setDraggableMode,
   }
 })

--- a/src/composables/useInnerNoOverlap.js
+++ b/src/composables/useInnerNoOverlap.js
@@ -1,0 +1,126 @@
+import { mapDimsByView } from '@/utils/innerViewDims'
+import { toLocal, toWorld } from '@/utils/innerLocalCoords'
+import { clampRectToBounds, overlap } from '@/utils/innerAABB'
+export function makeInnerSession({ parentEl, movingEl, siblings, vista, CM_TO_PX }) {
+  const { wCm, hCm } = mapDimsByView(parentEl, vista)
+  const bounds = {
+    minX: 0,
+    minY: 0,
+    maxX: Math.max(1, wCm * CM_TO_PX),
+    maxY: Math.max(1, hCm * CM_TO_PX),
+  }
+  parentEl.__wPx = bounds.maxX
+  parentEl.__hPx = bounds.maxY
+  const mSizeCm = mapDimsByView(movingEl, vista)
+  const mSize = {
+    w: Math.max(1, mSizeCm.wCm * CM_TO_PX),
+    h: Math.max(1, mSizeCm.hCm * CM_TO_PX),
+  }
+  const sibRects = siblings
+    .filter((s) => s && s.id !== movingEl.id)
+    .map((s) => {
+      const szCm = mapDimsByView(s, vista)
+      const sz = {
+        w: Math.max(1, szCm.wCm * CM_TO_PX),
+        h: Math.max(1, szCm.hCm * CM_TO_PX),
+      }
+      const pl = toLocal(s.posicion || { x: 0, y: 0 }, parentEl)
+      return { x: pl.x, y: pl.y, w: sz.w, h: sz.h, id: s.id }
+    })
+  let lastGoodLocal = toLocal(movingEl.posicion || { x: 0, y: 0 }, parentEl)
+  let contact = { id: null, axis: null }
+  const H = 1.0
+  let vxf = 0,
+    vyf = 0
+
+  function inside(p, size, b) {
+    return !(
+      p.x < b.minX - 0.5 ||
+      p.y < b.minY - 0.5 ||
+      p.x + size.w > b.maxX + 0.5 ||
+      p.y + size.h > b.maxY + 0.5
+    )
+  }
+  function isValidLocal(p) {
+    if (
+      p.x < bounds.minX - 0.5 ||
+      p.y < bounds.minY - 0.5 ||
+      p.x + mSize.w > bounds.maxX + 0.5 ||
+      p.y + mSize.h > bounds.maxY + 0.5
+    )
+      return false
+    const A = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+    for (const B of sibRects) if (overlap(A, B)) return false
+    return true
+  }
+  function dragBoundFuncLocal(posLocal, vel = { x: 0, y: 0 }) {
+    vxf = 0.8 * vxf + 0.2 * (vel.x || 0)
+    vyf = 0.8 * vyf + 0.2 * (vel.y || 0)
+    let p = clampRectToBounds(posLocal, mSize, bounds)
+    const A = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+    if (contact.id) {
+      const B = sibRects.find((s) => s.id === contact.id)
+      if (B) {
+        const touchingX = A.x + A.w > B.x - H && B.x + B.w > A.x - H
+        const touchingY = A.y + A.h > B.y - H && B.y + B.h > A.y - H
+        const stillTouching = contact.axis === 'x' ? touchingY : touchingX
+        if (stillTouching) {
+          if (contact.axis === 'x') {
+            p.x = p.x >= B.x ? B.x + B.w : B.x - mSize.w
+          } else {
+            p.y = p.y >= B.y ? B.y + B.h : B.y - mSize.h
+          }
+          p = clampRectToBounds(p, mSize, bounds)
+        } else {
+          contact = { id: null, axis: null }
+        }
+      } else {
+        contact = { id: null, axis: null }
+      }
+    }
+    if (!contact.id) {
+      for (const B of sibRects) {
+        if (!overlap({ x: p.x, y: p.y, w: mSize.w, h: mSize.h }, B)) continue
+        const axis = Math.abs(vxf) >= Math.abs(vyf) ? 'x' : 'y'
+        contact = { id: B.id, axis }
+        if (axis === 'x') {
+          p.x = p.x >= B.x ? B.x + B.w : B.x - mSize.w
+        } else {
+          p.y = p.y >= B.y ? B.y + B.h : B.y - mSize.h
+        }
+        p = clampRectToBounds(p, mSize, bounds)
+        break
+      }
+    }
+    if (inside(p, mSize, bounds)) {
+      let ok = true
+      const A2 = { x: p.x, y: p.y, w: mSize.w, h: mSize.h }
+      for (const B of sibRects) if (overlap(A2, B)) { ok = false; break }
+      if (ok) lastGoodLocal = p
+    }
+    return p
+  }
+  function finalizeLocal(candidateLocal) {
+    contact = { id: null, axis: null }
+    let p = clampRectToBounds(candidateLocal, mSize, bounds)
+    if (!isValidLocal(p)) p = lastGoodLocal
+    const G = Math.max(1, window.__GRID_SIZE_PX || 10)
+    p = { x: Math.round(p.x / G) * G, y: Math.round(p.y / G) * G }
+    p = clampRectToBounds(p, mSize, bounds)
+    if (!isValidLocal(p)) p = lastGoodLocal
+    return p
+  }
+  return {
+    bounds,
+    mSize,
+    sibRects,
+    toLocal,
+    toWorld,
+    isValidLocal,
+    dragBoundFuncLocal,
+    finalizeLocal,
+    get lastGoodLocal() {
+      return lastGoodLocal
+    },
+  }
+}

--- a/src/utils/activeBounds.js
+++ b/src/utils/activeBounds.js
@@ -1,0 +1,70 @@
+import { CM_TO_PX } from '@/utils/constants'
+
+// Map physical dimensions (cm) to width/height depending on active view
+// dims: {ancho, largo, alto}
+export function mapDimsByView(dims = {}, view = 'XY') {
+  const { ancho = 0, largo = 0, alto = 0 } = dims
+  if (view === 'XZ') {
+    // Front view: width -> ancho, height -> alto
+    return { widthCm: ancho, heightCm: alto }
+  }
+  if (view === 'ZY') {
+    // Side view: width -> largo, height -> alto
+    return { widthCm: largo, heightCm: alto }
+  }
+  // Top view (XY): width -> ancho, height -> largo
+  return { widthCm: ancho, heightCm: largo }
+}
+
+// Determine active working bounds (rectangle) and polygon in pixels
+// depending on navigation context. Returns { boundsPx:{width,height}, polygonPx }
+export function getActiveBounds(canvasStore) {
+  // Inside element/container: use its dimensions
+  if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
+    const elem = canvasStore.elementoContenedorActual || {}
+    const dims = elem.dimensiones || {}
+    let { widthCm, heightCm } = mapDimsByView(dims, canvasStore.vistaActiva)
+
+    let widthPx = widthCm * CM_TO_PX
+    let heightPx = heightCm * CM_TO_PX
+
+    // Fallback to legacy pixel dimensions if cm dims missing
+    if (!widthPx || !heightPx) {
+      widthPx = elem.width || 0
+      heightPx = elem.height || 0
+    }
+
+    const polygonPx = [
+      { x: 0, y: 0 },
+      { x: widthPx, y: 0 },
+      { x: widthPx, y: heightPx },
+      { x: 0, y: heightPx },
+    ]
+
+    return { boundsPx: { width: widthPx, height: heightPx }, polygonPx }
+  }
+
+  // Root level: active plant polygon or rectangle from dimensions
+  const planta = canvasStore.plantaActivaData || {}
+  if (planta.poligono && Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
+    const polygonPx = planta.poligono
+    const xs = polygonPx.map((p) => p.x)
+    const ys = polygonPx.map((p) => p.y)
+    const width = Math.max(...xs) - Math.min(...xs)
+    const height = Math.max(...ys) - Math.min(...ys)
+    return { boundsPx: { width, height }, polygonPx }
+  }
+
+  const ancho = planta.dimensiones?.ancho || 0
+  const largo = planta.dimensiones?.largo || 0
+  const width = ancho * CM_TO_PX
+  const height = largo * CM_TO_PX
+  const polygonPx = [
+    { x: 0, y: 0 },
+    { x: width, y: 0 },
+    { x: width, y: height },
+    { x: 0, y: height },
+  ]
+  return { boundsPx: { width, height }, polygonPx }
+}
+

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,6 +1,8 @@
 // Geometry and containment helpers for 2D canvas (XY view)
 // Units: use canvas world units (same as layer coordinates, pixels tied to cm in UI)
 
+import { clampRectToPolygon, pointInPolygon } from './polygonBounds'
+
 export const EPSILON = 1e-6
 
 // Basic math helpers
@@ -332,40 +334,34 @@ export const nudgePlace = (
 ) => {
   // Función auxiliar para verificar si una posición es válida
   const isValidPosition = (testX, testY) => {
-    // Verificar que esté dentro del área
     if (boundary.type === 'rect') {
       if (testX < 0 || testY < 0 || testX + width > boundary.W || testY + height > boundary.H) {
-        return false
+        return { valid: false, x: testX, y: testY }
       }
     } else if (boundary.type === 'polygon') {
-      if (!rectInsidePolygon(testX, testY, width, height, boundary.points)) {
-        return false
-      }
+      const clamped = clampRectToPolygon({ x: testX, y: testY, width, height }, boundary.inset)
+      testX = clamped.x
+      testY = clamped.y
+      const centerInside = pointInPolygon(
+        { x: testX + width / 2, y: testY + height / 2 },
+        boundary.inset,
+      )
+      if (!centerInside) return { valid: false, x: testX, y: testY }
     }
 
-    // Solo verificar conflictos si se proporciona la función
     if (detectConflictsFn) {
-      // Crear elemento temporal para verificar conflictos
-      const tempElement = {
-        ...elementToPlace,
-        x: testX,
-        y: testY,
-        width,
-        height,
-      }
-
+      const tempElement = { ...elementToPlace, x: testX, y: testY, width, height }
       const conflicts = detectConflictsFn(tempElement, allElements)
       const blockingConflicts = conflicts.filter((c) => c.bloqueante)
-
-      return blockingConflicts.length === 0
+      return { valid: blockingConflicts.length === 0, x: testX, y: testY }
     }
 
-    return true
+    return { valid: true, x: testX, y: testY }
   }
 
-  // Verificar posición inicial
-  if (isValidPosition(x, y)) {
-    return { x, y, found: true }
+  const initial = isValidPosition(x, y)
+  if (initial.valid) {
+    return { x: initial.x, y: initial.y, found: true }
   }
 
   // Búsqueda en espiral
@@ -395,8 +391,9 @@ export const nudgePlace = (
 
     // Probar cada punto en esta distancia
     for (const point of spiralPoints) {
-      if (isValidPosition(point.x, point.y)) {
-        return { x: point.x, y: point.y, found: true }
+      const res = isValidPosition(point.x, point.y)
+      if (res.valid) {
+        return { x: res.x, y: res.y, found: true }
       }
     }
   }

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -16,21 +16,6 @@ export const snapToGrid = (x, y, gridSize = 50) => {
   return { x: sx, y: sy }
 }
 
-// Point in polygon (ray casting), supports concave polygons
-export const pointInPolygon = (pt, polygon) => {
-  const { x, y } = pt
-  let inside = false
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const xi = polygon[i].x,
-      yi = polygon[i].y
-    const xj = polygon[j].x,
-      yj = polygon[j].y
-    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + EPSILON) + xi
-    if (intersect) inside = !inside
-  }
-  return inside
-}
-
 // Segment intersection
 export const segmentsIntersect = (p1, p2, p3, p4) => {
   const r = { x: p2.x - p1.x, y: p2.y - p1.y }

--- a/src/utils/innerAABB.js
+++ b/src/utils/innerAABB.js
@@ -1,0 +1,13 @@
+export function clampRectToBounds(pos, size, bounds) {
+  const x = Math.min(Math.max(pos.x, bounds.minX), bounds.maxX - size.w)
+  const y = Math.min(Math.max(pos.y, bounds.minY), bounds.maxY - size.h)
+  return { x, y }
+}
+export function overlap(a, b, eps = 0.5) {
+  return (
+    a.x + a.w - eps > b.x &&
+    b.x + b.w - eps > a.x &&
+    a.y + a.h - eps > b.y &&
+    b.y + b.h - eps > a.y
+  )
+}

--- a/src/utils/innerLocalCoords.js
+++ b/src/utils/innerLocalCoords.js
@@ -1,0 +1,17 @@
+// Coord. locales robustas: si hijos vienen absolutos resta origen del contenedor; si ya son locales, no-op
+export function toLocal(pos, parent) {
+  const px = pos?.x || 0,
+    py = pos?.y || 0
+  const ox = parent?.posicion?.x || 0,
+    oy = parent?.posicion?.y || 0
+  const looksLocal = px >= -1 && py >= -1 && px <= (parent.__wPx || 1) + 1 && py <= (parent.__hPx || 1) + 1
+  return looksLocal ? { x: px, y: py } : { x: px - ox, y: py - oy }
+}
+export function toWorld(pos, parent) {
+  const px = pos?.x || 0,
+    py = pos?.y || 0
+  const ox = parent?.posicion?.x || 0,
+    oy = parent?.posicion?.y || 0
+  const looksLocal = px >= -1 && py >= -1 && px <= (parent.__wPx || 1) + 1 && py <= (parent.__hPx || 1) + 1
+  return looksLocal ? { x: px, y: py } : { x: px + ox, y: py + oy }
+}

--- a/src/utils/innerViewDims.js
+++ b/src/utils/innerViewDims.js
@@ -1,0 +1,8 @@
+export function mapDimsByView(el, vista) {
+  const a = el?.dimensiones?.ancho || 0,
+    b = el?.dimensiones?.largo || 0,
+    h = el?.dimensiones?.alto || 0
+  if (vista === 'XY') return { wCm: a, hCm: b }
+  if (vista === 'XZ') return { wCm: a, hCm: h }
+  return { wCm: b, hCm: h } // ZY
+}

--- a/src/utils/polygonBounds.js
+++ b/src/utils/polygonBounds.js
@@ -1,0 +1,76 @@
+export function pointInPolygon(pt, poly) {
+  const x = pt.x ?? pt[0]
+  const y = pt.y ?? pt[1]
+  let inside = false
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i].x ?? poly[i][0]
+    const yi = poly[i].y ?? poly[i][1]
+    const xj = poly[j].x ?? poly[j][0]
+    const yj = poly[j].y ?? poly[j][1]
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / ((yj - yi) || 1e-12) + xi
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+export function nearestPointOnSegment(p, a, b) {
+  const px = p.x ?? p[0]
+  const py = p.y ?? p[1]
+  const ax = a.x ?? a[0]
+  const ay = a.y ?? a[1]
+  const bx = b.x ?? b[0]
+  const by = b.y ?? b[1]
+  const abx = bx - ax
+  const aby = by - ay
+  const apx = px - ax
+  const apy = py - ay
+  const ab2 = abx * abx + aby * aby
+  const t = ab2 === 0 ? 0 : (apx * abx + apy * aby) / ab2
+  const clampedT = Math.max(0, Math.min(1, t))
+  return { x: ax + abx * clampedT, y: ay + aby * clampedT }
+}
+
+export function clampPointToPolygon(p, poly) {
+  if (pointInPolygon(p, poly)) return { x: p.x ?? p[0], y: p.y ?? p[1] }
+  let best = { x: 0, y: 0, d: Infinity }
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % poly.length]
+    const np = nearestPointOnSegment(p, a, b)
+    const dx = (p.x ?? p[0]) - np.x
+    const dy = (p.y ?? p[1]) - np.y
+    const d = dx * dx + dy * dy
+    if (d < best.d) {
+      best = { x: np.x, y: np.y, d }
+    }
+  }
+  return { x: best.x, y: best.y }
+}
+
+export function clampRectToPolygon(rect, poly) {
+  const corners = [
+    { x: rect.x, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y + rect.height },
+    { x: rect.x, y: rect.y + rect.height }
+  ]
+  const deltas = []
+  for (const c of corners) {
+    if (!pointInPolygon(c, poly)) {
+      const clamped = clampPointToPolygon(c, poly)
+      deltas.push({ dx: clamped.x - c.x, dy: clamped.y - c.y })
+    }
+  }
+  if (deltas.length === 0) return { x: rect.x, y: rect.y }
+  // choose largest translation to cover all outside corners
+  let best = deltas[0]
+  let bestLen = best.dx * best.dx + best.dy * best.dy
+  for (const d of deltas.slice(1)) {
+    const len = d.dx * d.dx + d.dy * d.dy
+    if (len > bestLen) {
+      best = d
+      bestLen = len
+    }
+  }
+  return { x: rect.x + best.dx, y: rect.y + best.dy }
+}

--- a/src/utils/polygonInset.js
+++ b/src/utils/polygonInset.js
@@ -1,0 +1,26 @@
+export function polygonInset(poly, eps = 1) {
+  if (!Array.isArray(poly) || poly.length < 3) return []
+  const n = poly.length
+  const normals = Array.from({ length: n }, () => ({ x: 0, y: 0 }))
+  for (let i = 0; i < n; i++) {
+    const a = poly[i]
+    const b = poly[(i + 1) % n]
+    const ex = b.x - a.x
+    const ey = b.y - a.y
+    const len = Math.hypot(ex, ey) || 1
+    const nx = ey / len
+    const ny = -ex / len
+    normals[i].x += nx
+    normals[i].y += ny
+    normals[(i + 1) % n].x += nx
+    normals[(i + 1) % n].y += ny
+  }
+  const inset = []
+  for (let i = 0; i < n; i++) {
+    const v = poly[i]
+    const nrm = normals[i]
+    const len = Math.hypot(nrm.x, nrm.y) || 1
+    inset.push({ x: v.x + (nrm.x / len) * eps, y: v.y + (nrm.y / len) * eps })
+  }
+  return inset
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,6 +9,7 @@ export default mergeConfig(
       environment: 'jsdom',
       exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url)),
+      setupFiles: ['./src/__tests__/test-setup.js'],
     },
   }),
 )


### PR DESCRIPTION
## Summary
- offset polygons inward for safe clamping
- separate canvas into background, content and overlay layers with polygon clipping
- clamp drags, drops and nudges against inset polygon
- derive active bounds polygon based on current navigation context

## Testing
- `npx vitest run src/__tests__/polygonBounds.spec.js src/__tests__/layer-order.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae11e9449c8321acc2696d60d3f2e6