### PR TITLE
feat: enforce wall placement rules

### DIFF
--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -313,6 +313,14 @@
       </div>
       <div class="flex gap-2">
         <button
+          @click="guardarCambios"
+          class="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm"
+          :disabled="!canSave"
+          :class="{ 'opacity-50 cursor-not-allowed': !canSave }"
+        >
+          Guardar
+        </button>
+        <button
           @click="resetearPropiedades"
           class="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm"
         >
@@ -325,6 +333,9 @@
           Deseleccionar
         </button>
       </div>
+      <p v-if="wallHint" class="text-xs text-red-500 mt-2">
+        Falta altura respecto al suelo (>0) y alto
+      </p>
     </div>
   </div>
   <CreateTagModal
@@ -338,10 +349,11 @@
 <script setup>
 import { ref, watch, computed } from 'vue'
 import { useCanvasStore } from '@/composables/useCanvasStore.js'
-import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS } from '@/utils/constants'
+import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS, CM_TO_PX } from '@/utils/constants'
 import { useDeleteElement } from '@/composables/useDeleteElement'
 import TagFilter from './TagFilter.vue'
 import CreateTagModal from './CreateTagModal.vue'
+import { isWallFormValid } from '@/utils/wallRules'
 
 // Store
 const canvasStore = useCanvasStore()
@@ -362,6 +374,22 @@ const isLockedSelected = computed(() => {
   const el = elementoSeleccionado.value
   return !!(el && (el.bloqueado === true || el.locked === true))
 })
+
+const wallHint = computed(() => {
+  const el = elementoSeleccionado.value
+  if (!el) return false
+  const ubic = (el.ubicacion ?? el.metadata?.ubicacion ?? '')
+    .toString()
+    .toLowerCase()
+  const bHcm = Number(
+    canvasStore.plantaActivaData?.dimensiones?.alto ||
+      canvasStore.plantaActivaData?.altura ||
+      0,
+  )
+  return ubic === 'pared' && !isWallFormValid(el, bHcm, CM_TO_PX)
+})
+
+const canSave = computed(() => !wallHint.value)
 
 // Watchers
 watch(
@@ -419,6 +447,15 @@ const resetearPropiedades = () => {
 
 const deseleccionarElemento = () => {
   canvasStore.seleccionarElemento(null)
+}
+
+const guardarCambios = () => {
+  if (!elementoSeleccionado.value) return
+  canvasStore.saveToHistory(
+    `Propiedades guardadas: ${
+      elementoSeleccionado.value.nombre || elementoSeleccionado.value.id
+    }`,
+  )
 }
 
 const onDeleteClick = () => {

--- a/src/composables/useCanvasBuffer.js
+++ b/src/composables/useCanvasBuffer.js
@@ -13,6 +13,8 @@
 
 import { ref, computed } from 'vue'
 import { useCanvasStore } from './useCanvasStore'
+import { validateWallPlacement, isWallFormValid, debugWall } from '@/utils/wallRules'
+import { CM_TO_PX } from '@/utils/constants'
 
 // Estado global del buffer (singleton)
 const bufferItems = ref([])
@@ -231,8 +233,46 @@ export const useCanvasBuffer = () => {
       }
     }
 
+    const ubic = (newElement.ubicacion ?? newElement.metadata?.ubicacion ?? '')
+      .toString()
+      .toLowerCase()
+    if (ubic === 'pared') {
+      const bH =
+        Number(
+          canvasStore.plantaActivaData?.dimensiones?.alto ??
+            canvasStore.plantaActivaData?.altura ??
+            0,
+        )
+      if (!isWallFormValid(newElement, bH, CM_TO_PX)) {
+        window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+          type: 'warn',
+        }) ??
+          console.warn(
+            '[WALL_RULES]',
+            'Falta altura respecto al suelo (>0) y alto',
+            debugWall(newElement, bH, CM_TO_PX),
+          )
+        return false
+      }
+      if (import.meta.env.DEV)
+        console.debug('[WALL_RULES:CM]', debugWall(newElement, bH, CM_TO_PX))
+      const all = canvasStore.elementosEnPlanta(canvasStore.plantaActiva)
+      const res = validateWallPlacement({
+        el: newElement,
+        all,
+        bodegaH: bH,
+        CM_TO_PX,
+      })
+      if (!res.ok) {
+        window.__toasts?.show?.(`${res.reason}`, { type: 'warn' }) ??
+          console.warn('[WALL_RULES]', res.reason, debugWall(newElement, bH, CM_TO_PX))
+        return false
+      }
+    }
+
     // Agregar al canvas
-    canvasStore.agregarElemento(newElement)
+    const newId = canvasStore.agregarElemento(newElement)
+    if (!newId) return false
     console.log('📋 Elemento pegado desde buffer:', newElement.nombre)
 
     // Si era un elemento movido (no copiado), remover del buffer
@@ -240,7 +280,7 @@ export const useCanvasBuffer = () => {
       removeFromBuffer(bufferItemId)
     }
 
-    return newElement.id
+    return newId
   }
 
   /**

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -17,6 +17,8 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
+import { validateWallPlacement, isWallFormValid, debugWall } from '@/utils/wallRules'
+import { toCmSmart } from '@/utils/units'
 
 // Variable para evitar circular import - será inicializada por el composable de historial
 let historyComposable = null
@@ -579,14 +581,94 @@ export const useCanvasStore = defineStore('canvas', () => {
   const actualizarPosicion = (id, x, y) => {
     const elemento = elementos.value.find((el) => el.id === id)
     if (elemento) {
+      const ubic = (elemento.ubicacion ?? elemento.metadata?.ubicacion ?? '')
+        .toString()
+        .toLowerCase()
+      if (ubic === 'pared') {
+        const bH =
+          Number(
+            plantaActivaData.value?.dimensiones?.alto ??
+              plantaActivaData.value?.altura ??
+              0,
+          )
+        const all = elementos.value.filter((el) => el.plantaId === elemento.plantaId)
+        const el = { ...elemento, x, y }
+        if (!isWallFormValid(el, bH, CM_TO_PX)) {
+          window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+            type: 'warn',
+          }) ??
+            console.warn(
+              '[WALL_RULES]',
+              'Falta altura respecto al suelo (>0) y alto',
+              debugWall(el, bH, CM_TO_PX),
+            )
+          return false
+        }
+        if (import.meta.env.DEV)
+          console.debug('[WALL_RULES:CM]', debugWall(el, bH, CM_TO_PX))
+        const res = validateWallPlacement({
+          el,
+          all,
+          bodegaH: bH,
+          CM_TO_PX,
+        })
+        if (!res.ok) {
+          window.__toasts?.show?.(res.reason, { type: 'warn' }) ??
+            console.warn('[WALL_RULES]', res.reason, debugWall(el, bH, CM_TO_PX))
+          return false
+        }
+      }
       elemento.x = x
       elemento.y = y
+      return true
     }
+    return false
   }
 
   const actualizarElemento = (elementoId, propiedades) => {
     const elemento = elementos.value.find((el) => el.id === elementoId)
     if (elemento) {
+      const candidato = {
+        ...elemento,
+        ...propiedades,
+        dimensiones: { ...elemento.dimensiones, ...propiedades.dimensiones },
+      }
+      const ubic = (candidato.ubicacion ?? candidato.metadata?.ubicacion ?? '')
+        .toString()
+        .toLowerCase()
+      if (ubic === 'pared') {
+        const bH =
+          Number(
+            plantaActivaData.value?.dimensiones?.alto ??
+              plantaActivaData.value?.altura ??
+              0,
+          )
+        const all = elementos.value.filter((el) => el.plantaId === candidato.plantaId)
+        if (!isWallFormValid(candidato, bH, CM_TO_PX)) {
+          window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+            type: 'warn',
+          }) ??
+            console.warn(
+              '[WALL_RULES]',
+              'Falta altura respecto al suelo (>0) y alto',
+              debugWall(candidato, bH, CM_TO_PX),
+            )
+          return false
+        }
+        if (import.meta.env.DEV)
+          console.debug('[WALL_RULES:CM]', debugWall(candidato, bH, CM_TO_PX))
+        const res = validateWallPlacement({
+          el: candidato,
+          all,
+          bodegaH: bH,
+          CM_TO_PX,
+        })
+        if (!res.ok) {
+          window.__toasts?.show?.(res.reason, { type: 'warn' }) ??
+            console.warn('[WALL_RULES]', res.reason, debugWall(candidato, bH, CM_TO_PX))
+          return false
+        }
+      }
       for (const key in propiedades) {
         if (typeof propiedades[key] === 'object' && propiedades[key] !== null && !Array.isArray(propiedades[key])) {
           // Si la propiedad es un objeto (como 'dimensiones'), la fusionamos recursivamente.
@@ -620,7 +702,9 @@ export const useCanvasStore = defineStore('canvas', () => {
           // Nota: largo no afecta a width/height en vista XZ
         }
       }
+      return true
     }
+    return false
   }
 
   const configurarZoom = (nuevoZoom) => {
@@ -738,6 +822,45 @@ export const useCanvasStore = defineStore('canvas', () => {
     ) {
       console.error('En contenedores solo se pueden agregar elementos u otros contenedores')
       return null
+    }
+
+    const ubic = (nuevoElemento.ubicacion ?? nuevoElemento.metadata?.ubicacion ?? '')
+      .toString()
+      .toLowerCase()
+    if (ubic === 'pared') {
+      const bH =
+        Number(
+          plantaActivaData.value?.dimensiones?.alto ??
+            plantaActivaData.value?.altura ??
+            0,
+        )
+      if (!isWallFormValid(nuevoElemento, bH, CM_TO_PX)) {
+        window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+          type: 'warn',
+        }) ??
+          console.warn(
+            '[WALL_RULES]',
+            'Falta altura respecto al suelo (>0) y alto',
+            debugWall(nuevoElemento, bH, CM_TO_PX),
+          )
+        return false
+      }
+      if (import.meta.env.DEV)
+        console.debug('[WALL_RULES:CM]', debugWall(nuevoElemento, bH, CM_TO_PX))
+      const all = elementos.value.filter(
+        (el) => el.plantaId === contextoNavegacion.value.id,
+      )
+      const res = validateWallPlacement({
+        el: nuevoElemento,
+        all,
+        bodegaH: bH,
+        CM_TO_PX,
+      })
+      if (!res.ok) {
+        window.__toasts?.show?.(res.reason, { type: 'warn' }) ??
+          console.warn('[WALL_RULES]', res.reason, debugWall(nuevoElemento, bH, CM_TO_PX))
+        return false
+      }
     }
 
     // Si estamos dentro de un elemento o contenedor, el nuevo elemento es hijo
@@ -883,20 +1006,23 @@ export const useCanvasStore = defineStore('canvas', () => {
    * Versiones con historial de las acciones principales
    */
   const actualizarElementoConHistorial = (elementoId, propiedades, description) => {
-    actualizarElemento(elementoId, propiedades)
+    const ok = actualizarElemento(elementoId, propiedades)
+    if (!ok) return false
 
     const descripcionAuto =
       description || `Propiedades actualizadas: ${Object.keys(propiedades).join(', ')}`
     saveToHistory(descripcionAuto)
+    return true
   }
 
   const actualizarPosicionConHistorial = (elementoId, x, y, description) => {
-    actualizarPosicion(elementoId, x, y)
+    const ok = actualizarPosicion(elementoId, x, y)
 
     // Solo guardar en historial al finalizar el arrastre, no en cada movimiento
-    if (description) {
+    if (ok && description) {
       saveToHistory(description)
     }
+    return ok
   }
 
   const seleccionarPlantaConHistorial = (plantaId) => {
@@ -967,83 +1093,111 @@ export const useCanvasStore = defineStore('canvas', () => {
       }),
 
       // Estado de elementos con propiedades estáticas y personalizadas
-      elementos: elementos.value.map((elemento) => ({
-        // Elevación y tolerancias
-        elevacion: elemento.elevacion || {
-          zBase: 0,
-          altura: elemento.dimensiones?.alto || elemento.alto || 0,
-          espesor: elemento.elevacion?.espesor || 0,
-        },
-        tolerancias: elemento.tolerancias || { junta: 0, paralelismo: 0, zEpsilon: 0 },
-        id: elemento.id,
-        nombre: elemento.nombre,
-        tipo: elemento.tipo,
-        categoria: elemento.categoria,
-        plantaId: elemento.plantaId,
+      elementos: elementos.value.map((elemento) => {
+        const planta = plantaPorId.value(elemento.plantaId)
+        const bHcm = Number(
+          planta?.dimensiones?.alto || planta?.altura || 0,
+        )
+        const zBaseCm = toCmSmart(
+          elemento.elevacion?.zBase ??
+            elemento.alturaRespectoAlSuelo ??
+            elemento.alturaRespectoSuelo ??
+            0,
+          { CM_TO_PX, bodegaHcm: bHcm },
+        )
+        const altoCm = toCmSmart(
+          elemento.dimensiones?.alto ?? elemento.alto ?? 0,
+          { CM_TO_PX, bodegaHcm: bHcm },
+        )
+        if (elemento.elevacion) {
+          elemento.elevacion.zBase = zBaseCm
+          elemento.elevacion.altura = altoCm
+        } else {
+          elemento.elevacion = { zBase: zBaseCm, altura: altoCm, espesor: 0 }
+        }
+        if (elemento.dimensiones) {
+          elemento.dimensiones.alto = altoCm
+        } else if (elemento.width || elemento.height) {
+          elemento.dimensiones = {
+            ancho: elemento.width || 100,
+            largo: elemento.height || 60,
+            alto: altoCm,
+          }
+        }
+        return {
+          // Elevación y tolerancias
+          elevacion: {
+            zBase: zBaseCm,
+            altura: altoCm,
+            espesor: elemento.elevacion?.espesor || 0,
+          },
+          tolerancias:
+            elemento.tolerancias || { junta: 0, paralelismo: 0, zEpsilon: 0 },
+          id: elemento.id,
+          nombre: elemento.nombre,
+          tipo: elemento.tipo,
+          categoria: elemento.categoria,
+          plantaId: elemento.plantaId,
 
-        // Propiedades físicas (maneja formato nuevo y legacy)
-        dimensiones: elemento.dimensiones
-          ? {
-              ancho: elemento.dimensiones.ancho,
-              largo: elemento.dimensiones.largo,
-              alto: elemento.dimensiones.alto,
-            }
-          : elemento.width || elemento.height
+          // Propiedades físicas (maneja formato nuevo y legacy)
+          dimensiones: elemento.dimensiones
             ? {
-                // Fallback para formato legacy (width, height directos)
-                ancho: elemento.width || 100,
-                largo: elemento.height || 60,
-                alto: elemento.alto || 20,
+                ancho: elemento.dimensiones.ancho,
+                largo: elemento.dimensiones.largo,
+                alto: altoCm,
               }
             : null,
 
-        // Posición y transformación (maneja formato nuevo y legacy)
-        posicion: elemento.posicion
-          ? {
-              x: elemento.posicion.x,
-              y: elemento.posicion.y,
-              z: elemento.posicion.z || 0,
-              rotation: elemento.posicion.rotation || 0,
-            }
-          : {
-              // Fallback para formato legacy (x, y directos)
-              x: elemento.x || 0,
-              y: elemento.y || 0,
-              z: elemento.z || 0,
-              rotation: elemento.rotation || 0,
-            },
+          // Posición y transformación (maneja formato nuevo y legacy)
+          posicion: elemento.posicion
+            ? {
+                x: elemento.posicion.x,
+                y: elemento.posicion.y,
+                z: elemento.posicion.z || 0,
+                rotation: elemento.posicion.rotation || 0,
+              }
+            : {
+                // Fallback para formato legacy (x, y directos)
+                x: elemento.x || 0,
+                y: elemento.y || 0,
+                z: elemento.z || 0,
+                rotation: elemento.rotation || 0,
+              },
 
-        // Propiedades visuales
-        visual: {
-          colorBase: elemento.colorBase || '#3b82f6',
-          forma: elemento.forma || 'rectangular',
-          visible: elemento.visible !== false, // Por defecto visible
-        },
+          // Propiedades visuales
+          visual: {
+            colorBase: elemento.colorBase || '#3b82f6',
+            forma: elemento.forma || 'rectangular',
+            visible: elemento.visible !== false, // Por defecto visible
+          },
 
-        // Propiedades funcionales
-        propiedades: {
-          pesoMaximo: elemento.pesoMaximo || 0,
-          ubicacion: elemento.ubicacion || 'suelo',
-          descripcion: elemento.descripcion || '',
-        },
+          // Propiedades funcionales
+          propiedades: {
+            pesoMaximo: elemento.pesoMaximo || 0,
+            ubicacion: elemento.ubicacion || 'suelo',
+            descripcion: elemento.descripcion || '',
+          },
 
-        // Jerarquía
-        jerarquia: {
-          padre: elemento.padre || null,
-          hijos: elemento.hijos || [],
-          nivel: elemento.nivel || 0,
-        },
+          // Jerarquía
+          jerarquia: {
+            padre: elemento.padre || null,
+            hijos: elemento.hijos || [],
+            nivel: elemento.nivel || 0,
+          },
 
-        // Propiedades personalizadas del usuario
-        propiedadesPersonalizadas: elemento.propiedadesPersonalizadas || {},
+          // Propiedades personalizadas del usuario
+          propiedadesPersonalizadas: elemento.propiedadesPersonalizadas || {},
 
-        // Metadatos adicionales
-        metadatos: {
-          fechaCreacion: elemento.fechaCreacion || new Date().toISOString(),
-          fechaModificacion: elemento.fechaModificacion || new Date().toISOString(),
-          creador: elemento.creador || 'usuario',
-        },
-      })),
+          // Metadatos adicionales
+          metadatos: {
+            fechaCreacion:
+              elemento.fechaCreacion || new Date().toISOString(),
+            fechaModificacion:
+              elemento.fechaModificacion || new Date().toISOString(),
+            creador: elemento.creador || 'usuario',
+          },
+        }
+      }),
 
       // Estado de navegación y configuración
       configuracion: {
@@ -1120,6 +1274,21 @@ export const useCanvasStore = defineStore('canvas', () => {
         const posY = elementoData.posicion?.y || 0
         const width = elementoData.dimensiones?.ancho || 100
         const height = elementoData.dimensiones?.largo || 60
+        const planta = plantaPorId.value(elementoData.plantaId)
+        const bHcm = Number(
+          planta?.dimensiones?.alto || planta?.altura || 0,
+        )
+        const zBase = toCmSmart(
+          elementoData.elevacion?.zBase ??
+            elementoData.alturaRespectoAlSuelo ??
+            elementoData.alturaRespectoSuelo ??
+            (elementoData.posicion?.z || 0),
+          { CM_TO_PX, bodegaHcm: bHcm },
+        )
+        const alto = toCmSmart(
+          elementoData.dimensiones?.alto ?? elementoData.alto ?? 0,
+          { CM_TO_PX, bodegaHcm: bHcm },
+        )
 
         elementos.value.push({
           id: elementoData.id,
@@ -1128,18 +1297,19 @@ export const useCanvasStore = defineStore('canvas', () => {
           categoria: elementoData.categoria,
           plantaId: elementoData.plantaId,
 
-          elevacion: elementoData.elevacion || {
-            zBase: elementoData.posicion?.z || 0,
-            altura: elementoData.dimensiones?.alto || 0,
-            espesor: 0,
+          elevacion: {
+            zBase,
+            altura: alto,
+            espesor: elementoData.elevacion?.espesor || 0,
           },
-          tolerancias: elementoData.tolerancias || { junta: 0, paralelismo: 0, zEpsilon: 0 },
+          tolerancias:
+            elementoData.tolerancias || { junta: 0, paralelismo: 0, zEpsilon: 0 },
 
           // Propiedades físicas (estructura nueva)
           dimensiones: {
             ancho: width,
             largo: height,
-            alto: elementoData.dimensiones?.alto || 20,
+            alto,
           },
 
           // Posición (estructura nueva)

--- a/src/tests/wall_rules.spec.js
+++ b/src/tests/wall_rules.spec.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isWallFormValid,
+  wallZOk,
+  wallNoZOverlap,
+  wallVsFloorOk,
+  validateWallPlacement,
+} from '@/utils/wallRules'
+import { CM_TO_PX } from '@/utils/constants'
+
+describe('wallRules utils', () => {
+  it('isWallFormValid', () => {
+    const bH = 300
+    expect(
+      isWallFormValid(
+        {
+          ubicacion: 'pared',
+          alturaRespectoAlSuelo: '10',
+          dimensiones: { alto: '5' },
+        },
+        bH,
+        CM_TO_PX,
+      ),
+    ).toBe(true)
+    expect(
+      isWallFormValid(
+        {
+          ubicacion: 'PARED',
+          alturaRespectoAlSuelo: 0,
+          dimensiones: { alto: 5 },
+        },
+        bH,
+        CM_TO_PX,
+      ),
+    ).toBe(false)
+    // acepta valores en px
+    expect(
+      isWallFormValid(
+        {
+          ubicacion: 'pared',
+          alturaRespectoAlSuelo: 1500, // 150px? Wait 1500 = 1500 cm? Correction: it's px 1500
+          dimensiones: { alto: 750 },
+        },
+        bH,
+        CM_TO_PX,
+      ),
+    ).toBe(true)
+  })
+
+  it('wallZOk with warehouse height', () => {
+    expect(
+      wallZOk(
+        { ubicacion: 'pared', alturaRespectoAlSuelo: '100', dimensiones: { alto: '150' } },
+        300,
+        CM_TO_PX,
+      ),
+    ).toBe(true)
+    expect(
+      wallZOk(
+        { ubicacion: 'PARED', alturaRespectoSuelo: 205, dimensiones: { alto: 151 } },
+        300,
+        CM_TO_PX,
+      ),
+    ).toBe(false)
+  })
+
+  it('wallNoZOverlap disjoint vs overlapping', () => {
+    const a = {
+      metadata: { ubicacion: 'Pared' },
+      alturaRespectoAlSuelo: 0,
+      altura: 100,
+    }
+    const b = { ubicacion: 'pared', alturaRespectoSuelo: 110, altura: 50 }
+    const c = { ubicacion: 'PARED', elevacion: { zBase: 50 }, dimensiones: { alto: 80 } }
+    expect(wallNoZOverlap(a, b, 300, CM_TO_PX)).toBe(true)
+    expect(wallNoZOverlap(a, c, 300, CM_TO_PX)).toBe(false)
+  })
+
+  it('wallVsFloorOk with high floor', () => {
+    const wall = { ubicacion: 'pared', elevacion: { zBase: 15 } }
+    const floor = { metadata: { ubicacion: 'Suelo' }, dimensiones: { alto: 11 } }
+    const lowWall = { ubicacion: 'PARED', alturaRespectoSuelo: 9 }
+    expect(wallVsFloorOk(wall, floor, 300, CM_TO_PX)).toBe(true)
+    expect(wallVsFloorOk(lowWall, floor, 300, CM_TO_PX)).toBe(false)
+  })
+
+  it('validateWallPlacement ok and ko', () => {
+    const el = {
+      id: 'w',
+      ubicacion: 'PARED',
+      alturaRespectoAlSuelo: 50,
+      dimensiones: { alto: 100 },
+    }
+    const floor = { id: 'f', metadata: { ubicacion: 'Suelo' }, dimensiones: { alto: 10 } }
+    const other = {
+      id: 'o',
+      ubicacion: 'pared',
+      elevacion: { zBase: 200 },
+      altura: 50,
+    }
+    expect(
+      validateWallPlacement({
+        el,
+        all: [floor, other],
+        bodegaH: 300,
+        CM_TO_PX,
+      }),
+    ).toEqual({ ok: true })
+    const badOther = {
+      id: 'b',
+      metadata: { ubicacion: 'pared' },
+      alturaRespectoSuelo: 80,
+      dimensiones: { alto: 80 },
+    }
+    const res = validateWallPlacement({
+      el,
+      all: [badOther],
+      bodegaH: 300,
+      CM_TO_PX,
+    })
+    expect(res.ok).toBe(false)
+  })
+})

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,0 +1,25 @@
+export function toCmSmart(value, { CM_TO_PX, bodegaHcm }) {
+  const v = Number(value || 0)
+  if (!v) return 0
+  if (
+    (bodegaHcm && v > bodegaHcm * 0.9 && v <= bodegaHcm * CM_TO_PX * 1.2) ||
+    (CM_TO_PX && v % CM_TO_PX === 0 && v / CM_TO_PX <= bodegaHcm * 1.2)
+  )
+    return Math.round(v / CM_TO_PX)
+  return v
+}
+
+export function ensureWallCm(el, { CM_TO_PX, bodegaHcm }) {
+  const ubic = (el?.ubicacion ?? el?.metadata?.ubicacion ?? '')
+    .toString()
+    .toLowerCase()
+  const zRaw =
+    el?.alturaRespectoAlSuelo ??
+    el?.alturaRespectoSuelo ??
+    el?.elevacion?.zBase ??
+    0
+  const hRaw = el?.dimensiones?.alto ?? el?.altura ?? 0
+  const zBase = toCmSmart(zRaw, { CM_TO_PX, bodegaHcm })
+  const alto = toCmSmart(hRaw, { CM_TO_PX, bodegaHcm })
+  return { ubic, zBase, alto }
+}

--- a/src/utils/wallRules.js
+++ b/src/utils/wallRules.js
@@ -1,0 +1,65 @@
+import { ensureWallCm, toCmSmart } from './units'
+
+const normalizeWall = (el, bodegaHcm, CM_TO_PX) =>
+  ensureWallCm(el, { CM_TO_PX, bodegaHcm })
+
+export const isWallFormValid = (el, bodegaHcm, CM_TO_PX) => {
+  const n = normalizeWall(el, bodegaHcm, CM_TO_PX)
+  return n.ubic === 'pared' ? n.zBase > 0 && n.alto > 0 : true
+}
+
+export const wallZOk = (el, bodegaHcm, CM_TO_PX, eps = 0.5) => {
+  const n = normalizeWall(el, bodegaHcm, CM_TO_PX)
+  if (n.ubic !== 'pared') return true
+  return n.zBase + n.alto <= (Number(bodegaHcm) || 0) + eps
+}
+
+export const wallNoZOverlap = (a, b, bodegaHcm, CM_TO_PX, eps = 0.5) => {
+  const A = normalizeWall(a, bodegaHcm, CM_TO_PX)
+  const B = normalizeWall(b, bodegaHcm, CM_TO_PX)
+  if (A.ubic !== 'pared' || B.ubic !== 'pared') return true
+  const a0 = A.zBase
+  const a1 = A.zBase + A.alto
+  const b0 = B.zBase
+  const b1 = B.zBase + B.alto
+  return a1 <= b0 + eps || b1 <= a0 + eps
+}
+
+export const wallVsFloorOk = (el, vecSuelo, bodegaHcm, CM_TO_PX, eps = 0.5) => {
+  const A = normalizeWall(el, bodegaHcm, CM_TO_PX)
+  const ubicSuelo = (vecSuelo?.ubicacion ?? vecSuelo?.metadata?.ubicacion ?? '')
+    .toString()
+    .toLowerCase()
+  if (A.ubic !== 'pared' || ubicSuelo !== 'suelo') return true
+  const sueloH = toCmSmart(vecSuelo?.dimensiones?.alto ?? 0, {
+    CM_TO_PX,
+    bodegaHcm,
+  })
+  return A.zBase >= sueloH + eps
+}
+
+export const validateWallPlacement = ({ el, all, bodegaH, CM_TO_PX }) => {
+  if (!isWallFormValid(el, bodegaH, CM_TO_PX))
+    return { ok: false, reason: 'Falta altura respecto al suelo (>0) y alto' }
+  if (!wallZOk(el, bodegaH, CM_TO_PX))
+    return { ok: false, reason: 'Supera la altura de la bodega' }
+  for (const v of all) {
+    if (v?.id === el?.id) continue
+    if (!wallNoZOverlap(el, v, bodegaH, CM_TO_PX))
+      return { ok: false, reason: 'Solape vertical con otra pared' }
+    if (!wallVsFloorOk(el, v, bodegaH, CM_TO_PX))
+      return { ok: false, reason: 'Altura insuficiente sobre elemento de suelo' }
+  }
+  return { ok: true }
+}
+
+export const debugWall = (el, bodegaH, CM_TO_PX) => {
+  const n = normalizeWall(el, bodegaH, CM_TO_PX)
+  return {
+    ubic: n.ubic,
+    zBase: n.zBase,
+    alto: n.alto,
+    bodegaH: Number(bodegaH) || 0,
+    CM_TO_PX,
+  }
+}


### PR DESCRIPTION
## Summary
- convert potential pixel inputs to centimeters via `toCmSmart` and `ensureWallCm`
- apply warehouse height and pixel factor to all wall validators and store/buffer guards
- persist wall heights in cm during serialize/deserialize and disable save when wall data is incomplete

## Testing
- `npm run test:unit src/tests/wall_rules.spec.js -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c8935f083219512de75558fdacb