### PR TITLE
feat: enforce wall placement rules

### DIFF
--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -313,6 +313,14 @@
       </div>
       <div class="flex gap-2">
         <button
+          @click="guardarCambios"
+          class="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm"
+          :disabled="!canSave"
+          :class="{ 'opacity-50 cursor-not-allowed': !canSave }"
+        >
+          Guardar
+        </button>
+        <button
           @click="resetearPropiedades"
           class="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm"
         >
@@ -325,6 +333,9 @@
           Deseleccionar
         </button>
       </div>
+      <p v-if="wallHint" class="text-xs text-red-500 mt-2">
+        Falta altura respecto al suelo (>0) y alto
+      </p>
     </div>
   </div>
   <CreateTagModal
@@ -338,10 +349,11 @@
 <script setup>
 import { ref, watch, computed } from 'vue'
 import { useCanvasStore } from '@/composables/useCanvasStore.js'
-import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS } from '@/utils/constants'
+import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS, CM_TO_PX } from '@/utils/constants'
 import { useDeleteElement } from '@/composables/useDeleteElement'
 import TagFilter from './TagFilter.vue'
 import CreateTagModal from './CreateTagModal.vue'
+import { isWallFormValid } from '@/utils/wallRules'
 
 // Store
 const canvasStore = useCanvasStore()
@@ -362,6 +374,22 @@ const isLockedSelected = computed(() => {
   const el = elementoSeleccionado.value
   return !!(el && (el.bloqueado === true || el.locked === true))
 })
+
+const bodegaHcm = computed(() => {
+  const d = canvasStore.plantaActivaData
+  return Number(d?.dimensiones?.alto ?? d?.altura ?? 0)
+})
+
+const wallHint = computed(() => {
+  const el = elementoSeleccionado.value
+  if (!el) return false
+  const ubic = (el.ubicacion ?? el.metadata?.ubicacion ?? '')
+    .toString()
+    .toLowerCase()
+  return ubic === 'pared' && !isWallFormValid(el, bodegaHcm.value, CM_TO_PX)
+})
+
+const canSave = computed(() => !wallHint.value)
 
 // Watchers
 watch(
@@ -419,6 +447,15 @@ const resetearPropiedades = () => {
 
 const deseleccionarElemento = () => {
   canvasStore.seleccionarElemento(null)
+}
+
+const guardarCambios = () => {
+  if (!elementoSeleccionado.value) return
+  canvasStore.saveToHistory(
+    `Propiedades guardadas: ${
+      elementoSeleccionado.value.nombre || elementoSeleccionado.value.id
+    }`,
+  )
 }
 
 const onDeleteClick = () => {

--- a/src/composables/useCanvasBuffer.js
+++ b/src/composables/useCanvasBuffer.js
@@ -13,6 +13,9 @@
 
 import { ref, computed } from 'vue'
 import { useCanvasStore } from './useCanvasStore'
+import { validateWallPlacement, isWallFormValid, debugWall } from '@/utils/wallRules'
+import { CM_TO_PX } from '@/utils/constants'
+import { ensureWallCm } from '@/utils/units'
 
 // Estado global del buffer (singleton)
 const bufferItems = ref([])
@@ -231,8 +234,55 @@ export const useCanvasBuffer = () => {
       }
     }
 
+    const ubic = (newElement.ubicacion ?? newElement.metadata?.ubicacion ?? '')
+      .toString()
+      .toLowerCase()
+    if (ubic === 'pared') {
+      const bH =
+        Number(
+          canvasStore.plantaActivaData?.dimensiones?.alto ??
+            canvasStore.plantaActivaData?.altura ??
+            0,
+        )
+      const { zBase, alto } = ensureWallCm(newElement, {
+        CM_TO_PX,
+        bodegaHcm: bH,
+      })
+      newElement.alturaRespectoAlSuelo = zBase
+      newElement.alturaRespectoSuelo = zBase
+      newElement.elevacion = { ...(newElement.elevacion || {}), zBase }
+      newElement.dimensiones = { ...(newElement.dimensiones || {}), alto }
+      newElement.altura = alto
+      if (!isWallFormValid(newElement, bH, CM_TO_PX)) {
+        window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+          type: 'warn',
+        }) ??
+          console.warn(
+            '[WALL_RULES]',
+            'Falta altura respecto al suelo (>0) y alto',
+            debugWall(newElement, bH, CM_TO_PX),
+          )
+        return false
+      }
+      const all = canvasStore.elementosEnPlanta(canvasStore.plantaActiva)
+      if (import.meta.env.DEV)
+        console.debug('[WALL_RULES:CM]', debugWall(newElement, bH, CM_TO_PX))
+      const res = validateWallPlacement({
+        el: newElement,
+        all,
+        bodegaH: bH,
+        CM_TO_PX,
+      })
+      if (!res.ok) {
+        window.__toasts?.show?.(`${res.reason}`, { type: 'warn' }) ??
+          console.warn('[WALL_RULES]', res.reason, debugWall(newElement, bH, CM_TO_PX))
+        return false
+      }
+    }
+
     // Agregar al canvas
-    canvasStore.agregarElemento(newElement)
+    const newId = canvasStore.agregarElemento(newElement)
+    if (!newId) return false
     console.log('📋 Elemento pegado desde buffer:', newElement.nombre)
 
     // Si era un elemento movido (no copiado), remover del buffer
@@ -240,7 +290,7 @@ export const useCanvasBuffer = () => {
       removeFromBuffer(bufferItemId)
     }
 
-    return newElement.id
+    return newId
   }
 
   /**

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -17,6 +17,8 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
+import { validateWallPlacement, isWallFormValid, debugWall } from '@/utils/wallRules'
+import { ensureWallCm } from '@/utils/units'
 
 // Variable para evitar circular import - será inicializada por el composable de historial
 let historyComposable = null
@@ -572,6 +574,18 @@ export const useCanvasStore = defineStore('canvas', () => {
   }
 
   // Actions
+  const fixWallUnits = (obj, bH) => {
+    const { ubic, zBase, alto } = ensureWallCm(obj, {
+      CM_TO_PX,
+      bodegaHcm: bH,
+    })
+    if (ubic !== 'pared') return
+    obj.alturaRespectoAlSuelo = zBase
+    obj.alturaRespectoSuelo = zBase
+    obj.elevacion = { ...(obj.elevacion || {}), zBase }
+    obj.dimensiones = { ...(obj.dimensiones || {}), alto }
+    obj.altura = alto
+  }
   const seleccionarElemento = (id) => {
     elementoSeleccionado.value = id
   }
@@ -579,14 +593,91 @@ export const useCanvasStore = defineStore('canvas', () => {
   const actualizarPosicion = (id, x, y) => {
     const elemento = elementos.value.find((el) => el.id === id)
     if (elemento) {
+      const ubic = (elemento.ubicacion ?? elemento.metadata?.ubicacion ?? '')
+        .toString()
+        .toLowerCase()
+      if (ubic === 'pared') {
+        const bH =
+          Number(
+            plantaActivaData.value?.dimensiones?.alto ??
+              plantaActivaData.value?.altura ??
+              0,
+          )
+        fixWallUnits(elemento, bH)
+        const all = elementos.value.filter((el) => el.plantaId === elemento.plantaId)
+        const el = { ...elemento, x, y }
+        if (!isWallFormValid(el, bH, CM_TO_PX)) {
+          window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+            type: 'warn',
+          }) ??
+            console.warn(
+              '[WALL_RULES]',
+              'Falta altura respecto al suelo (>0) y alto',
+              debugWall(el, bH, CM_TO_PX),
+            )
+          return false
+        }
+        if (import.meta.env.DEV)
+          console.debug('[WALL_RULES:CM]', debugWall(el, bH, CM_TO_PX))
+        const res = validateWallPlacement({ el, all, bodegaH: bH, CM_TO_PX })
+        if (!res.ok) {
+          window.__toasts?.show?.(res.reason, { type: 'warn' }) ??
+            console.warn('[WALL_RULES]', res.reason, debugWall(el, bH, CM_TO_PX))
+          return false
+        }
+      }
       elemento.x = x
       elemento.y = y
+      return true
     }
+    return false
   }
 
   const actualizarElemento = (elementoId, propiedades) => {
     const elemento = elementos.value.find((el) => el.id === elementoId)
     if (elemento) {
+      const candidato = {
+        ...elemento,
+        ...propiedades,
+        dimensiones: { ...elemento.dimensiones, ...propiedades.dimensiones },
+      }
+      const ubic = (candidato.ubicacion ?? candidato.metadata?.ubicacion ?? '')
+        .toString()
+        .toLowerCase()
+      if (ubic === 'pared') {
+        const bH =
+          Number(
+            plantaActivaData.value?.dimensiones?.alto ??
+              plantaActivaData.value?.altura ??
+              0,
+          )
+        fixWallUnits(candidato, bH)
+        const all = elementos.value.filter((el) => el.plantaId === candidato.plantaId)
+        if (!isWallFormValid(candidato, bH, CM_TO_PX)) {
+          window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+            type: 'warn',
+          }) ??
+            console.warn(
+              '[WALL_RULES]',
+              'Falta altura respecto al suelo (>0) y alto',
+              debugWall(candidato, bH, CM_TO_PX),
+            )
+          return false
+        }
+        if (import.meta.env.DEV)
+          console.debug('[WALL_RULES:CM]', debugWall(candidato, bH, CM_TO_PX))
+        const res = validateWallPlacement({
+          el: candidato,
+          all,
+          bodegaH: bH,
+          CM_TO_PX,
+        })
+        if (!res.ok) {
+          window.__toasts?.show?.(res.reason, { type: 'warn' }) ??
+            console.warn('[WALL_RULES]', res.reason, debugWall(candidato, bH, CM_TO_PX))
+          return false
+        }
+      }
       for (const key in propiedades) {
         if (typeof propiedades[key] === 'object' && propiedades[key] !== null && !Array.isArray(propiedades[key])) {
           // Si la propiedad es un objeto (como 'dimensiones'), la fusionamos recursivamente.
@@ -620,7 +711,9 @@ export const useCanvasStore = defineStore('canvas', () => {
           // Nota: largo no afecta a width/height en vista XZ
         }
       }
+      return true
     }
+    return false
   }
 
   const configurarZoom = (nuevoZoom) => {
@@ -738,6 +831,46 @@ export const useCanvasStore = defineStore('canvas', () => {
     ) {
       console.error('En contenedores solo se pueden agregar elementos u otros contenedores')
       return null
+    }
+
+    const ubic = (nuevoElemento.ubicacion ?? nuevoElemento.metadata?.ubicacion ?? '')
+      .toString()
+      .toLowerCase()
+    if (ubic === 'pared') {
+      const bH =
+        Number(
+          plantaActivaData.value?.dimensiones?.alto ??
+            plantaActivaData.value?.altura ??
+            0,
+        )
+      fixWallUnits(nuevoElemento, bH)
+      if (!isWallFormValid(nuevoElemento, bH, CM_TO_PX)) {
+        window.__toasts?.show?.('Falta altura respecto al suelo (>0) y alto', {
+          type: 'warn',
+        }) ??
+          console.warn(
+            '[WALL_RULES]',
+            'Falta altura respecto al suelo (>0) y alto',
+            debugWall(nuevoElemento, bH, CM_TO_PX),
+          )
+        return false
+      }
+      const all = elementos.value.filter(
+        (el) => el.plantaId === contextoNavegacion.value.id,
+      )
+      if (import.meta.env.DEV)
+        console.debug('[WALL_RULES:CM]', debugWall(nuevoElemento, bH, CM_TO_PX))
+      const res = validateWallPlacement({
+        el: nuevoElemento,
+        all,
+        bodegaH: bH,
+        CM_TO_PX,
+      })
+      if (!res.ok) {
+        window.__toasts?.show?.(res.reason, { type: 'warn' }) ??
+          console.warn('[WALL_RULES]', res.reason, debugWall(nuevoElemento, bH, CM_TO_PX))
+        return false
+      }
     }
 
     // Si estamos dentro de un elemento o contenedor, el nuevo elemento es hijo
@@ -883,20 +1016,23 @@ export const useCanvasStore = defineStore('canvas', () => {
    * Versiones con historial de las acciones principales
    */
   const actualizarElementoConHistorial = (elementoId, propiedades, description) => {
-    actualizarElemento(elementoId, propiedades)
+    const ok = actualizarElemento(elementoId, propiedades)
+    if (!ok) return false
 
     const descripcionAuto =
       description || `Propiedades actualizadas: ${Object.keys(propiedades).join(', ')}`
     saveToHistory(descripcionAuto)
+    return true
   }
 
   const actualizarPosicionConHistorial = (elementoId, x, y, description) => {
-    actualizarPosicion(elementoId, x, y)
+    const ok = actualizarPosicion(elementoId, x, y)
 
     // Solo guardar en historial al finalizar el arrastre, no en cada movimiento
-    if (description) {
+    if (ok && description) {
       saveToHistory(description)
     }
+    return ok
   }
 
   const seleccionarPlantaConHistorial = (plantaId) => {

--- a/src/tests/wall_rules.spec.js
+++ b/src/tests/wall_rules.spec.js
@@ -47,39 +47,100 @@ describe('wallRules utils', () => {
     ).toBe(false)
   })
 
-  it('wallNoZOverlap disjoint vs overlapping', () => {
+  it('wallNoZOverlap considers XY overlap', () => {
     const a = {
       metadata: { ubicacion: 'Pared' },
       alturaRespectoAlSuelo: 0,
-      altura: 100,
+      dimensiones: { alto: 100, ancho: 50, largo: 50 },
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
     }
-    const b = { ubicacion: 'pared', alturaRespectoSuelo: 110, altura: 50 }
-    const c = { ubicacion: 'PARED', elevacion: { zBase: 50 }, dimensiones: { alto: 80 } }
+    const b = {
+      ubicacion: 'pared',
+      alturaRespectoSuelo: 20,
+      dimensiones: { alto: 50, ancho: 50, largo: 50 },
+      x: 200,
+      y: 0,
+      width: 50,
+      height: 50,
+    }
+    const c = {
+      ubicacion: 'PARED',
+      elevacion: { zBase: 20 },
+      dimensiones: { alto: 80, ancho: 50, largo: 50 },
+      x: 10,
+      y: 0,
+      width: 50,
+      height: 50,
+    }
     expect(wallNoZOverlap(a, b, 300, CM_TO_PX)).toBe(true)
     expect(wallNoZOverlap(a, c, 300, CM_TO_PX)).toBe(false)
+    const d = { ...c, elevacion: { zBase: 200 } }
+    expect(wallNoZOverlap(a, d, 300, CM_TO_PX)).toBe(true)
   })
 
-  it('wallVsFloorOk with high floor', () => {
-    const wall = { ubicacion: 'pared', elevacion: { zBase: 1500 } }
-    const floor = { metadata: { ubicacion: 'Suelo' }, dimensiones: { alto: 100 } }
-    const lowWall = { ubicacion: 'PARED', alturaRespectoSuelo: 90 }
+  it('wallVsFloorOk checks XY overlap', () => {
+    const wall = {
+      ubicacion: 'pared',
+      elevacion: { zBase: 1500 },
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+    }
+    const floor = {
+      metadata: { ubicacion: 'Suelo' },
+      dimensiones: { alto: 100, ancho: 50, largo: 50 },
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+    }
+    const farFloor = { ...floor, x: 200 }
+    const lowWall = {
+      ubicacion: 'PARED',
+      alturaRespectoSuelo: 90,
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+    }
     expect(wallVsFloorOk(wall, floor, 300, CM_TO_PX)).toBe(true)
     expect(wallVsFloorOk(lowWall, floor, 300, CM_TO_PX)).toBe(false)
+    expect(wallVsFloorOk(lowWall, farFloor, 300, CM_TO_PX)).toBe(true)
   })
 
   it('validateWallPlacement ok and ko', () => {
     const el = {
       id: 'w',
       ubicacion: 'PARED',
-      alturaRespectoAlSuelo: 1500,
-      dimensiones: { alto: 1000 },
+      alturaRespectoAlSuelo: 100,
+      dimensiones: { alto: 100, ancho: 50, largo: 50 },
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
     }
-    const floor = { id: 'f', metadata: { ubicacion: 'Suelo' }, dimensiones: { alto: 100 } }
+    const floor = {
+      id: 'f',
+      metadata: { ubicacion: 'Suelo' },
+      dimensiones: { alto: 100, ancho: 50, largo: 50 },
+      x: 200,
+      y: 0,
+      width: 50,
+      height: 50,
+    }
     const other = {
       id: 'o',
       ubicacion: 'pared',
-      elevacion: { zBase: 200 },
+      elevacion: { zBase: 20 },
       altura: 50,
+      x: 200,
+      y: 0,
+      width: 50,
+      height: 50,
     }
     expect(
       validateWallPlacement({ el, all: [floor, other], bodegaH: 300, CM_TO_PX }),
@@ -87,8 +148,12 @@ describe('wallRules utils', () => {
     const badOther = {
       id: 'b',
       metadata: { ubicacion: 'pared' },
-      alturaRespectoSuelo: 800,
-      dimensiones: { alto: 800 },
+      alturaRespectoSuelo: 150,
+      dimensiones: { alto: 80, ancho: 50, largo: 50 },
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
     }
     const res = validateWallPlacement({ el, all: [badOther], bodegaH: 300, CM_TO_PX })
     expect(res.ok).toBe(false)

--- a/src/tests/wall_rules.spec.js
+++ b/src/tests/wall_rules.spec.js
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isWallFormValid,
+  wallZOk,
+  wallNoZOverlap,
+  wallVsFloorOk,
+  validateWallPlacement,
+} from '@/utils/wallRules'
+import { CM_TO_PX } from '@/utils/constants'
+
+describe('wallRules utils', () => {
+  it('isWallFormValid', () => {
+    expect(
+      isWallFormValid(
+        {
+          ubicacion: 'pared',
+          alturaRespectoAlSuelo: 1500,
+          dimensiones: { alto: 750 },
+        },
+        500,
+        CM_TO_PX,
+      ),
+    ).toBe(true)
+    expect(
+      isWallFormValid(
+        { ubicacion: 'PARED', alturaRespectoAlSuelo: 0, dimensiones: { alto: 5 } },
+        300,
+        CM_TO_PX,
+      ),
+    ).toBe(false)
+  })
+
+  it('wallZOk with warehouse height', () => {
+    expect(
+      wallZOk(
+        { ubicacion: 'pared', alturaRespectoAlSuelo: 1000, dimensiones: { alto: 1500 } },
+        300,
+        CM_TO_PX,
+      ),
+    ).toBe(true)
+    expect(
+      wallZOk(
+        { ubicacion: 'PARED', alturaRespectoSuelo: 2000, dimensiones: { alto: 1500 } },
+        300,
+        CM_TO_PX,
+      ),
+    ).toBe(false)
+  })
+
+  it('wallNoZOverlap disjoint vs overlapping', () => {
+    const a = {
+      metadata: { ubicacion: 'Pared' },
+      alturaRespectoAlSuelo: 0,
+      altura: 100,
+    }
+    const b = { ubicacion: 'pared', alturaRespectoSuelo: 110, altura: 50 }
+    const c = { ubicacion: 'PARED', elevacion: { zBase: 50 }, dimensiones: { alto: 80 } }
+    expect(wallNoZOverlap(a, b, 300, CM_TO_PX)).toBe(true)
+    expect(wallNoZOverlap(a, c, 300, CM_TO_PX)).toBe(false)
+  })
+
+  it('wallVsFloorOk with high floor', () => {
+    const wall = { ubicacion: 'pared', elevacion: { zBase: 1500 } }
+    const floor = { metadata: { ubicacion: 'Suelo' }, dimensiones: { alto: 100 } }
+    const lowWall = { ubicacion: 'PARED', alturaRespectoSuelo: 90 }
+    expect(wallVsFloorOk(wall, floor, 300, CM_TO_PX)).toBe(true)
+    expect(wallVsFloorOk(lowWall, floor, 300, CM_TO_PX)).toBe(false)
+  })
+
+  it('validateWallPlacement ok and ko', () => {
+    const el = {
+      id: 'w',
+      ubicacion: 'PARED',
+      alturaRespectoAlSuelo: 1500,
+      dimensiones: { alto: 1000 },
+    }
+    const floor = { id: 'f', metadata: { ubicacion: 'Suelo' }, dimensiones: { alto: 100 } }
+    const other = {
+      id: 'o',
+      ubicacion: 'pared',
+      elevacion: { zBase: 200 },
+      altura: 50,
+    }
+    expect(
+      validateWallPlacement({ el, all: [floor, other], bodegaH: 300, CM_TO_PX }),
+    ).toEqual({ ok: true })
+    const badOther = {
+      id: 'b',
+      metadata: { ubicacion: 'pared' },
+      alturaRespectoSuelo: 800,
+      dimensiones: { alto: 800 },
+    }
+    const res = validateWallPlacement({ el, all: [badOther], bodegaH: 300, CM_TO_PX })
+    expect(res.ok).toBe(false)
+  })
+})

--- a/src/utils/serialization.js
+++ b/src/utils/serialization.js
@@ -2,18 +2,20 @@
  * serialization.js
  *
  * Utilidades para serialización y deserialización del estado del editor.
- *
- * Responsabilidades:
- * - Serializar estado completo del canvas a formato JSON
- * - Deserializar y restaurar estado desde JSON
- * - Manejar versionado de formatos de guardado
- * - Validar integridad de datos al cargar
- * - Comprimir/descomprimir datos para optimizar almacenamiento
- * - Exportar/importar en diferentes formatos
- * - Manejar referencias y jerarquías complejas
- * - Migración entre versiones de formato
- * - Backup automático y recuperación de errores
  */
+
+import { CM_TO_PX } from './constants'
+import { ensureWallCm } from './units'
+
+const fixWallUnits = (el, bodegaHcm) => {
+  const { ubic, zBase, alto } = ensureWallCm(el, { CM_TO_PX, bodegaHcm })
+  if (ubic !== 'pared') return
+  el.alturaRespectoAlSuelo = zBase
+  el.alturaRespectoSuelo = zBase
+  el.elevacion = { ...(el.elevacion || {}), zBase }
+  el.dimensiones = { ...(el.dimensiones || {}), alto }
+  el.altura = alto
+}
 
 /**
  * Serializa el estado completo del canvas a JSON
@@ -21,12 +23,14 @@
  * @returns {string} JSON serializado del estado
  */
 export function serializeCanvas(canvasState) {
-  // TODO: Implementar serialización del canvas
-  // - Convertir estado a formato JSON
-  // - Manejar referencias circulares
-  // - Incluir metadatos (versión, timestamp)
-  // - Validar integridad antes de serializar
-
+  const plantasHeights = {}
+  canvasState?.plantas?.forEach((p) => {
+    plantasHeights[p.id] = Number(p?.dimensiones?.alto ?? p?.altura ?? 0)
+  })
+  canvasState?.elementos?.forEach((el) => {
+    const bH = plantasHeights[el.plantaId]
+    fixWallUnits(el, bH)
+  })
   return JSON.stringify({
     version: '1.0.0',
     timestamp: new Date().toISOString(),
@@ -40,14 +44,16 @@ export function serializeCanvas(canvasState) {
  * @returns {Object} Estado deserializado del canvas
  */
 export function deserializeCanvas(jsonData) {
-  // TODO: Implementar deserialización del canvas
-  // - Parsear JSON y validar formato
-  // - Verificar versión y migrar si es necesario
-  // - Restaurar referencias y jerarquías
-  // - Validar integridad de elementos
-
   try {
     const parsed = JSON.parse(jsonData)
+    const plantasHeights = {}
+    parsed.data?.plantas?.forEach((p) => {
+      plantasHeights[p.id] = Number(p?.dimensiones?.alto ?? p?.altura ?? 0)
+    })
+    parsed.data?.elementos?.forEach((el) => {
+      const bH = plantasHeights[el.plantaId]
+      fixWallUnits(el, bH)
+    })
     return parsed.data
   } catch (error) {
     console.error('Error deserializando canvas:', error)

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,0 +1,26 @@
+export function toCmSmart(value, { CM_TO_PX, bodegaHcm }) {
+  const v = Number(value || 0)
+  if (!v) return 0
+  if (
+    (bodegaHcm &&
+      v > bodegaHcm * 0.9 &&
+      v <= bodegaHcm * CM_TO_PX * 1.2) ||
+    (CM_TO_PX && v % CM_TO_PX === 0 && v / CM_TO_PX <= bodegaHcm * 1.2)
+  )
+    return Math.round(v / CM_TO_PX)
+  return v
+}
+export function ensureWallCm(el, { CM_TO_PX, bodegaHcm }) {
+  const ubic = (el?.ubicacion ?? el?.metadata?.ubicacion ?? '')
+    .toString()
+    .toLowerCase()
+  const zRaw =
+    el?.alturaRespectoAlSuelo ??
+    el?.alturaRespectoSuelo ??
+    el?.elevacion?.zBase ??
+    0
+  const hRaw = el?.dimensiones?.alto ?? el?.altura ?? 0
+  const zBase = toCmSmart(zRaw, { CM_TO_PX, bodegaHcm })
+  const alto = toCmSmart(hRaw, { CM_TO_PX, bodegaHcm })
+  return { ubic, zBase, alto }
+}

--- a/src/utils/wallRules.js
+++ b/src/utils/wallRules.js
@@ -1,0 +1,59 @@
+import { ensureWallCm, toCmSmart } from './units'
+
+const normalizeWall = (el, bodegaHcm, CM_TO_PX) =>
+  ensureWallCm(el, { CM_TO_PX, bodegaHcm })
+
+export const isWallFormValid = (el, bodegaHcm, CM_TO_PX) => {
+  const n = normalizeWall(el, bodegaHcm, CM_TO_PX)
+  return n.ubic === 'pared' ? n.zBase > 0 && n.alto > 0 : true
+}
+
+export const wallZOk = (el, bodegaHcm, CM_TO_PX, eps = 0.5) => {
+  const n = normalizeWall(el, bodegaHcm, CM_TO_PX)
+  if (n.ubic !== 'pared') return true
+  return n.zBase + n.alto <= (Number(bodegaHcm) || 0) + eps
+}
+
+export const wallNoZOverlap = (a, b, bodegaHcm, CM_TO_PX, eps = 0.5) => {
+  const A = normalizeWall(a, bodegaHcm, CM_TO_PX)
+  const B = normalizeWall(b, bodegaHcm, CM_TO_PX)
+  if (A.ubic !== 'pared' || B.ubic !== 'pared') return true
+  const a0 = A.zBase
+  const a1 = A.zBase + A.alto
+  const b0 = B.zBase
+  const b1 = B.zBase + B.alto
+  return a1 <= b0 + eps || b1 <= a0 + eps
+}
+
+export const wallVsFloorOk = (el, vecSuelo, bodegaHcm, CM_TO_PX, eps = 0.5) => {
+  const A = normalizeWall(el, bodegaHcm, CM_TO_PX)
+  const ubicSuelo = (vecSuelo?.ubicacion ?? vecSuelo?.metadata?.ubicacion ?? '')
+    .toString()
+    .toLowerCase()
+  if (A.ubic !== 'pared' || ubicSuelo !== 'suelo') return true
+  const sueloH = toCmSmart(vecSuelo?.dimensiones?.alto ?? 0, {
+    CM_TO_PX,
+    bodegaHcm,
+  })
+  return A.zBase >= sueloH + eps
+}
+
+export const validateWallPlacement = ({ el, all, bodegaH, CM_TO_PX }) => {
+  if (!isWallFormValid(el, bodegaH, CM_TO_PX))
+    return { ok: false, reason: 'Falta altura respecto al suelo (>0) y alto' }
+  if (!wallZOk(el, bodegaH, CM_TO_PX))
+    return { ok: false, reason: 'Supera la altura de la bodega' }
+  for (const v of all) {
+    if (v?.id === el?.id) continue
+    if (!wallNoZOverlap(el, v, bodegaH, CM_TO_PX))
+      return { ok: false, reason: 'Solape vertical con otra pared' }
+    if (!wallVsFloorOk(el, v, bodegaH, CM_TO_PX))
+      return { ok: false, reason: 'Altura insuficiente sobre elemento de suelo' }
+  }
+  return { ok: true }
+}
+
+export const debugWall = (el, bodegaHcm, CM_TO_PX) => {
+  const n = normalizeWall(el, bodegaHcm, CM_TO_PX)
+  return { ubic: n.ubic, zBase: n.zBase, alto: n.alto, bodegaH: Number(bodegaHcm) || 0 }
+}

--- a/src/utils/wallRules.js
+++ b/src/utils/wallRules.js
@@ -1,7 +1,31 @@
 import { ensureWallCm, toCmSmart } from './units'
 
-const normalizeWall = (el, bodegaHcm, CM_TO_PX) =>
-  ensureWallCm(el, { CM_TO_PX, bodegaHcm })
+// Extract XY rectangle in pixels for overlap checks
+const getXYRect = (el, CM_TO_PX) => {
+  const x = Number(el?.x ?? el?.posicion?.x ?? 0)
+  const y = Number(el?.y ?? el?.posicion?.y ?? 0)
+  const w = Number(
+    el?.width ?? (el?.dimensiones?.ancho ?? 0) * (CM_TO_PX || 0),
+  )
+  const h = Number(
+    el?.height ?? (el?.dimensiones?.largo ?? 0) * (CM_TO_PX || 0),
+  )
+  return { x, y, w, h }
+}
+
+const overlapXY = (a, b, eps = 0.5) => {
+  return !(
+    a.x + a.w <= b.x + eps ||
+    b.x + b.w <= a.x + eps ||
+    a.y + a.h <= b.y + eps ||
+    b.y + b.h <= a.y + eps
+  )
+}
+
+const normalizeWall = (el, bodegaHcm, CM_TO_PX) => ({
+  ...ensureWallCm(el, { CM_TO_PX, bodegaHcm }),
+  ...getXYRect(el, CM_TO_PX),
+})
 
 export const isWallFormValid = (el, bodegaHcm, CM_TO_PX) => {
   const n = normalizeWall(el, bodegaHcm, CM_TO_PX)
@@ -18,6 +42,7 @@ export const wallNoZOverlap = (a, b, bodegaHcm, CM_TO_PX, eps = 0.5) => {
   const A = normalizeWall(a, bodegaHcm, CM_TO_PX)
   const B = normalizeWall(b, bodegaHcm, CM_TO_PX)
   if (A.ubic !== 'pared' || B.ubic !== 'pared') return true
+  if (!overlapXY(A, B, eps)) return true
   const a0 = A.zBase
   const a1 = A.zBase + A.alto
   const b0 = B.zBase
@@ -25,12 +50,20 @@ export const wallNoZOverlap = (a, b, bodegaHcm, CM_TO_PX, eps = 0.5) => {
   return a1 <= b0 + eps || b1 <= a0 + eps
 }
 
-export const wallVsFloorOk = (el, vecSuelo, bodegaHcm, CM_TO_PX, eps = 0.5) => {
+export const wallVsFloorOk = (
+  el,
+  vecSuelo,
+  bodegaHcm,
+  CM_TO_PX,
+  eps = 0.5,
+) => {
   const A = normalizeWall(el, bodegaHcm, CM_TO_PX)
   const ubicSuelo = (vecSuelo?.ubicacion ?? vecSuelo?.metadata?.ubicacion ?? '')
     .toString()
     .toLowerCase()
   if (A.ubic !== 'pared' || ubicSuelo !== 'suelo') return true
+  const rectFloor = getXYRect(vecSuelo, CM_TO_PX)
+  if (!overlapXY(A, rectFloor, eps)) return true
   const sueloH = toCmSmart(vecSuelo?.dimensiones?.alto ?? 0, {
     CM_TO_PX,
     bodegaHcm,
@@ -55,5 +88,14 @@ export const validateWallPlacement = ({ el, all, bodegaH, CM_TO_PX }) => {
 
 export const debugWall = (el, bodegaHcm, CM_TO_PX) => {
   const n = normalizeWall(el, bodegaHcm, CM_TO_PX)
-  return { ubic: n.ubic, zBase: n.zBase, alto: n.alto, bodegaH: Number(bodegaHcm) || 0 }
+  return {
+    ubic: n.ubic,
+    zBase: n.zBase,
+    alto: n.alto,
+    x: n.x,
+    y: n.y,
+    w: n.w,
+    h: n.h,
+    bodegaH: Number(bodegaHcm) || 0,
+  }
 }


### PR DESCRIPTION
## Summary
- normalize wall validation utilities and expose debug info
- guard store and buffer mutations against invalid walls
- disable save when wall fields incomplete and test normalization cases
- auto-convert wall dimensions from px to cm and persist corrected values

## Testing
- `npm run test:unit src/tests/wall_rules.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c8935f083219512de75558fdacb