### PR TITLE
fix: allow clearing edge state when passing null

### DIFF
--- a/src/__tests__/edge_state.spec.js
+++ b/src/__tests__/edge_state.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setEdgeState, getEdgeState, resetEdgeState } from '@/composables/useEdgeState'
+
+describe('useEdgeState', () => {
+  const id = 'e1'
+
+  beforeEach(() => {
+    resetEdgeState(id)
+  })
+
+  it('borra edgeX cuando se establece a null', () => {
+    setEdgeState(id, { edgeX: 'min', edgeY: 'max' })
+    expect(getEdgeState(id)).toEqual({ edgeX: 'min', edgeY: 'max' })
+
+    setEdgeState(id, { edgeX: null })
+    expect(getEdgeState(id)).toEqual({ edgeX: null, edgeY: 'max' })
+
+    setEdgeState(id, { edgeY: null })
+    expect(getEdgeState(id)).toEqual({ edgeX: null, edgeY: null })
+  })
+})

--- a/src/composables/useEdgeState.js
+++ b/src/composables/useEdgeState.js
@@ -17,7 +17,10 @@ export function getEdgeState(id) {
 export function setEdgeState(id, next) {
   if (!id) return
   const cur = edgeMap.get(id) || { edgeX: null, edgeY: null }
-  edgeMap.set(id, { edgeX: next.edgeX ?? cur.edgeX ?? null, edgeY: next.edgeY ?? cur.edgeY ?? null })
+  edgeMap.set(id, {
+    edgeX: next.edgeX !== undefined ? next.edgeX : cur.edgeX,
+    edgeY: next.edgeY !== undefined ? next.edgeY : cur.edgeY,
+  })
 }
 
 export function resetEdgeState(id) {


### PR DESCRIPTION
## Summary
- allow setEdgeState to store null values instead of preserving previous state
- add unit test verifying edgeX clears when set to null

## Testing
- `npm run test:unit -- run src/__tests__/edge_constraint.spec.js src/__tests__/edge_state.spec.js`
- `npm run test:unit` *(fails: e.g., missing Pinia in App.spec.js)*

------
https://chatgpt.com/codex/tasks/task_e_68af282ffc208321a88fbf6846ba3c62