### PR TITLE
feat: validate wall placement

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,9 @@
+/* eslint-env node */
+module.exports = {
+  overrides: [
+    {
+      files: ["src/__tests__/**/*.spec.js"],
+      env: { vitest: true, browser: true },
+    },
+  ],
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ export default defineConfig([
     files: ['**/*.{js,mjs,jsx,vue}'],
   },
 
-  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
+  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**', '.eslintrc.cjs']),
 
   {
     languageOptions: {
@@ -27,6 +27,16 @@ export default defineConfig([
   {
     ...pluginVitest.configs.recommended,
     files: ['src/**/__tests__/*'],
+  },
+
+  {
+    files: ['src/__tests__/**/*.spec.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.vitest,
+      },
+    },
   },
 
   {

--- a/src/__tests__/delete_element.spec.js
+++ b/src/__tests__/delete_element.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useCanvasStore } from '@/composables/useCanvasStore'
@@ -164,7 +165,7 @@ describe('deleteSelected', () => {
 
     const toasts = { show: vi.fn() }
     // stub toasts
-    global.window.__toasts = toasts
+    globalThis.window.__toasts = toasts
 
     const ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
@@ -186,7 +187,7 @@ describe('deleteSelected', () => {
     history.initializeHistory('pre')
 
     // Primero intenta y bloquea
-    global.window.__toasts = { show: vi.fn() }
+    globalThis.window.__toasts = { show: vi.fn() }
     let ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
 
@@ -220,7 +221,7 @@ describe('deleteSelected', () => {
     const hBefore = history.historySize.value
 
     const toasts = { show: vi.fn() }
-    global.window.__toasts = toasts
+    globalThis.window.__toasts = toasts
 
     const ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
@@ -249,7 +250,7 @@ describe('deleteSelected', () => {
 
     // Stub de toasts para capturar opciones
     const showSpy = vi.fn()
-    global.window.__toasts = { show: showSpy }
+    globalThis.window.__toasts = { show: showSpy }
 
     // Confirmación positiva
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)

--- a/src/__tests__/drop-validation.spec.js
+++ b/src/__tests__/drop-validation.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
@@ -67,7 +68,7 @@ vi.mock('@/composables/useConflicts', () => ({
 }))
 
 // Mock del sistema de toast
-global.window = {
+globalThis.window = {
   __toasts: {
     show: vi.fn()
   }

--- a/src/__tests__/element-editor-wall.spec.js
+++ b/src/__tests__/element-editor-wall.spec.js
@@ -1,0 +1,65 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import ElementEditor from '@/components/modals/ElementEditor.vue'
+
+vi.mock('@/composables/useCanvasStore', () => ({
+  useCanvasStore: () => ({
+    plantaActivaData: ref({ dimensiones: { alto: 300 } }),
+  }),
+}))
+
+describe('ElementEditor wall validation', () => {
+  const baseProps = {
+    visible: true,
+    categorias: [{ id: 'cat', nombre: 'Cat' }],
+    formas: [{ id: 'rectangular', nombre: 'Rect' }],
+    ubicaciones: [
+      { id: 'suelo', nombre: 'Suelo' },
+      { id: 'pared', nombre: 'Pared' },
+    ],
+  }
+
+  const fillRequired = (wrapper) => {
+    wrapper.vm.localElemento.nombre = 'Elem'
+    wrapper.vm.localElemento.categoria = 'cat'
+    wrapper.vm.localElemento.forma = 'rectangular'
+    wrapper.vm.localElemento.pesoMaximo = 10
+    wrapper.vm.localElemento.dimensiones.ancho = 50
+    wrapper.vm.localElemento.dimensiones.largo = 50
+  }
+
+  it('muestra error si zBase es inválido', async () => {
+    const wrapper = mount(ElementEditor, { props: baseProps })
+    fillRequired(wrapper)
+    wrapper.vm.localElemento.ubicacion = 'pared'
+    wrapper.vm.localElemento.dimensiones.alto = 100
+    wrapper.vm.localElemento.alturaRespectoAlSuelo = 0
+    await wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('save')).toBeUndefined()
+  })
+
+  it('muestra error si zBase + alto excede alturaBodega', async () => {
+    const wrapper = mount(ElementEditor, { props: baseProps })
+    fillRequired(wrapper)
+    wrapper.vm.localElemento.ubicacion = 'pared'
+    wrapper.vm.localElemento.dimensiones.alto = 200
+    wrapper.vm.localElemento.alturaRespectoAlSuelo = 150
+    await wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('save')).toBeUndefined()
+  })
+
+  it('emite save cuando zBase + alto es igual a alturaBodega', async () => {
+    const wrapper = mount(ElementEditor, { props: baseProps })
+    fillRequired(wrapper)
+    wrapper.vm.localElemento.ubicacion = 'pared'
+    wrapper.vm.localElemento.dimensiones.alto = 100
+    wrapper.vm.localElemento.alturaRespectoAlSuelo = 200
+    await wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('save')).toBeTruthy()
+  })
+})

--- a/src/__tests__/element-editor-wall.spec.js
+++ b/src/__tests__/element-editor-wall.spec.js
@@ -16,8 +16,8 @@ describe('ElementEditor wall validation', () => {
     categorias: [{ id: 'cat', nombre: 'Cat' }],
     formas: [{ id: 'rectangular', nombre: 'Rect' }],
     ubicaciones: [
-      { id: 'suelo', nombre: 'Suelo' },
-      { id: 'pared', nombre: 'Pared' },
+      { id: 'Suelo', nombre: 'Suelo' },
+      { id: 'Pared', nombre: 'Pared' },
     ],
   }
 
@@ -33,7 +33,7 @@ describe('ElementEditor wall validation', () => {
   it('muestra error si zBase es inválido', async () => {
     const wrapper = mount(ElementEditor, { props: baseProps })
     fillRequired(wrapper)
-    wrapper.vm.localElemento.ubicacion = 'pared'
+    wrapper.vm.localElemento.ubicacion = 'Pared'
     wrapper.vm.localElemento.dimensiones.alto = 100
     wrapper.vm.localElemento.alturaRespectoAlSuelo = 0
     await wrapper.find('form').trigger('submit.prevent')
@@ -44,7 +44,7 @@ describe('ElementEditor wall validation', () => {
   it('muestra error si zBase + alto excede alturaBodega', async () => {
     const wrapper = mount(ElementEditor, { props: baseProps })
     fillRequired(wrapper)
-    wrapper.vm.localElemento.ubicacion = 'pared'
+    wrapper.vm.localElemento.ubicacion = 'Pared'
     wrapper.vm.localElemento.dimensiones.alto = 200
     wrapper.vm.localElemento.alturaRespectoAlSuelo = 150
     await wrapper.find('form').trigger('submit.prevent')
@@ -55,7 +55,7 @@ describe('ElementEditor wall validation', () => {
   it('emite save cuando zBase + alto es igual a alturaBodega', async () => {
     const wrapper = mount(ElementEditor, { props: baseProps })
     fillRequired(wrapper)
-    wrapper.vm.localElemento.ubicacion = 'pared'
+    wrapper.vm.localElemento.ubicacion = 'Pared'
     wrapper.vm.localElemento.dimensiones.alto = 100
     wrapper.vm.localElemento.alturaRespectoAlSuelo = 200
     await wrapper.find('form').trigger('submit.prevent')

--- a/src/__tests__/innerNoOverlap.spec.js
+++ b/src/__tests__/innerNoOverlap.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 
@@ -12,7 +13,7 @@ describe('makeInnerSession basic behaviours', () => {
       posicion: { x: 0, y: 0 },
       hijos: [],
     }
-    global.window = { __GRID_SIZE_PX: 1 }
+    globalThis.window = { __GRID_SIZE_PX: 1 }
   })
 
   it('isValidLocal prevents overlap but allows touching', () => {

--- a/src/__tests__/placement-guards-integration.spec.js
+++ b/src/__tests__/placement-guards-integration.spec.js
@@ -1,0 +1,193 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+const showError = vi.fn()
+vi.mock('@/composables/useToast', () => ({ useToast: () => ({ showError }) }))
+import usePlacementGuards from '@/composables/usePlacementGuards'
+import { CM_TO_PX } from '@/utils/constants'
+import { errorsPlacement } from '@/utils/errorsPlacement'
+
+describe('placement guards integration', () => {
+  it('reviertes y no guardas cuando hay colisión vertical', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'pared',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        elevacion: { zBase: 50, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    showError.mockClear()
+    store.elementos[1].x = 0
+    const res = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
+    expect(res.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('b', { x: 20, y: 0 })
+    expect(spySave).not.toHaveBeenCalled()
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACKING_COLLISION)
+  })
+
+  it('reviertes y no guardas si altura excede en drag end', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 250, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 10, y: 10, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('a', { x: 0, y: 0 })
+    expect(spySave).not.toHaveBeenCalled()
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.HEIGHT_EXCEEDS_WAREHOUSE)
+  })
+
+  it('permite drag end válido dentro de altura', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 100, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 10, y: 10, start: { x: 0, y: 0 } })
+    if (res.valid) {
+      store.saveToHistory('drag end')
+    }
+    expect(spySave).toHaveBeenCalled()
+  })
+
+  it('reviertes resize cuando altura excede', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 250, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    const res = guards.onTransformEndGuard({ ...store.elementos[0], width: 20, height: 20, start: { x: 0, y: 0, width: 10, height: 10 } })
+    expect(res.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('a', { x: 0, y: 0, width: 10, height: 10 })
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.HEIGHT_EXCEEDS_WAREHOUSE)
+  })
+
+  it('permite resize válido dentro de altura', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 100, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const res = guards.onTransformEndGuard({ ...store.elementos[0], width: 20, height: 20, start: { x: 0, y: 0, width: 10, height: 10 } })
+    expect(res.valid).toBe(true)
+  })
+
+  it('apilar estantes permite tocar pero no solapar', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'pared',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        elevacion: { zBase: 100, altura: 100 },
+      },
+      {
+        id: 'c',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'pared',
+        x: 40,
+        y: 0,
+        width: 10,
+        height: 10,
+        elevacion: { zBase: 150, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    showError.mockClear()
+    store.elementos[1].x = 0
+    const resB = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
+    if (resB.valid) store.saveToHistory('drag b')
+    expect(resB.valid).toBe(true)
+    expect(spySave).toHaveBeenCalledTimes(1)
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    store.elementos[2].x = 0
+    const resC = guards.onDragEndGuard({ ...store.elementos[2], start: { x: 40, y: 0 } })
+    expect(resC.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('c', { x: 40, y: 0 })
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACKING_COLLISION)
+    expect(spySave).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__tests__/placement-guards-integration.spec.js
+++ b/src/__tests__/placement-guards-integration.spec.js
@@ -16,7 +16,7 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'suelo',
+      ubicacion: 'Suelo',
       x: 0,
       y: 0,
       width: 10,
@@ -36,12 +36,57 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 10, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('elemento con alturaRespectoAlSuelo no dispara ZBASE_REQUIRED', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alturaRespectoAlSuelo: 10,
+      alto: 100,
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('elemento con z_base pasa sin errores', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      z_base: 15,
+      alto: 100,
     })
     const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
     showError.mockClear()
@@ -57,11 +102,12 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 10, altura: 100 },
     })
     const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
@@ -84,11 +130,12 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 0, altura: 100 },
     })
     const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
@@ -108,22 +155,24 @@ describe('placement guards integration', () => {
         id: 'a',
         plantaId: 'planta_1',
         tipo: 'elementos',
-        ubicacion: 'pared',
+        ubicacion: 'Pared',
         x: 0,
         y: 0,
         width: 10,
         height: 10,
+        alto: 100,
         elevacion: { zBase: 0, altura: 100 },
       },
       {
         id: 'b',
         plantaId: 'planta_1',
         tipo: 'elementos',
-        ubicacion: 'pared',
+        ubicacion: 'Pared',
         x: 20,
         y: 0,
         width: 10,
         height: 10,
+        alto: 100,
         elevacion: { zBase: 50, altura: 100 },
       },
     )
@@ -146,11 +195,12 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 250, altura: 100 },
     })
     const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
@@ -170,11 +220,12 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 100, altura: 100 },
     })
     const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
@@ -193,11 +244,12 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 250, altura: 100 },
     })
     const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
@@ -215,11 +267,12 @@ describe('placement guards integration', () => {
       id: 'a',
       plantaId: 'planta_1',
       tipo: 'elementos',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 100, altura: 100 },
     })
     const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
@@ -235,33 +288,36 @@ describe('placement guards integration', () => {
         id: 'a',
         plantaId: 'planta_1',
         tipo: 'elementos',
-        ubicacion: 'pared',
+        ubicacion: 'Pared',
         x: 0,
         y: 0,
         width: 10,
         height: 10,
+        alto: 100,
         elevacion: { zBase: 0, altura: 100 },
       },
       {
         id: 'b',
         plantaId: 'planta_1',
         tipo: 'elementos',
-        ubicacion: 'pared',
+        ubicacion: 'Pared',
         x: 20,
         y: 0,
         width: 10,
         height: 10,
+        alto: 100,
         elevacion: { zBase: 100, altura: 100 },
       },
       {
         id: 'c',
         plantaId: 'planta_1',
         tipo: 'elementos',
-        ubicacion: 'pared',
+        ubicacion: 'Pared',
         x: 40,
         y: 0,
         width: 10,
         height: 10,
+        alto: 100,
         elevacion: { zBase: 150, altura: 100 },
       },
     )

--- a/src/__tests__/placement-guards-integration.spec.js
+++ b/src/__tests__/placement-guards-integration.spec.js
@@ -9,6 +9,97 @@ import { CM_TO_PX } from '@/utils/constants'
 import { errorsPlacement } from '@/utils/errorsPlacement'
 
 describe('placement guards integration', () => {
+  it('drag de elemento Suelo no dispara ZBASE_REQUIRED', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'suelo',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('drag de elemento Pared con zBase válido no dispara error', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 10, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('candidate sin zBase pero con element.zBase válido pasa', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 10, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({
+      ...store.elementos[0],
+      elevacion: { altura: 100 },
+      x: 5,
+      y: 5,
+      start: { x: 0, y: 0 },
+    })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('falla cuando zBase <= 0', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 0, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(false)
+    expect(res.code).toBe('ZBASE_REQUIRED')
+    expect(spyUpdate).toHaveBeenCalledWith('a', { x: 0, y: 0 })
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.ZBASE_REQUIRED)
+  })
   it('reviertes y no guardas cuando hay colisión vertical', () => {
     setActivePinia(createPinia())
     const store = useCanvasStore()

--- a/src/__tests__/placement-guards-integration.spec.js
+++ b/src/__tests__/placement-guards-integration.spec.js
@@ -183,9 +183,10 @@ describe('placement guards integration', () => {
     store.elementos[1].x = 0
     const res = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
     expect(res.valid).toBe(false)
+    expect(res.code).toBe('Z_STACK_CONFLICT')
     expect(spyUpdate).toHaveBeenCalledWith('b', { x: 20, y: 0 })
     expect(spySave).not.toHaveBeenCalled()
-    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACKING_COLLISION)
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACK_CONFLICT)
   })
 
   it('reviertes y no guardas si altura excede en drag end', () => {
@@ -334,7 +335,95 @@ describe('placement guards integration', () => {
     const resC = guards.onDragEndGuard({ ...store.elementos[2], start: { x: 40, y: 0 } })
     expect(resC.valid).toBe(false)
     expect(spyUpdate).toHaveBeenCalledWith('c', { x: 40, y: 0 })
-    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACKING_COLLISION)
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACK_CONFLICT)
     expect(spySave).toHaveBeenCalledTimes(1)
+  })
+
+  it('tope pared con pared evita solape y guarda al soltar', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 50, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    showError.mockClear()
+    const el = store.elementos[1]
+    el.x = 5
+    const moveRes = guards.onDragMoveGuard(el)
+    expect(moveRes.reason).toBe('Z_STACK_CONFLICT')
+    expect(el.x).toBe(10)
+    const endRes = guards.onDragEndGuard({ ...el, start: { x: 20, y: 0 } })
+    if (endRes.valid) store.saveToHistory('move')
+    expect(endRes.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+    expect(spySave).toHaveBeenCalled()
+  })
+
+  it('tope pared con suelo evita solape y guarda al soltar', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Suelo',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 10,
+        elevacion: { zBase: 0, altura: 10 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 5, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    showError.mockClear()
+    const el = store.elementos[1]
+    el.x = 5
+    const moveRes = guards.onDragMoveGuard(el)
+    expect(moveRes.reason).toBe('Z_STACK_CONFLICT')
+    expect(el.x).toBe(10)
+    const endRes = guards.onDragEndGuard({ ...el, start: { x: 20, y: 0 } })
+    if (endRes.valid) store.saveToHistory('move')
+    expect(endRes.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+    expect(spySave).toHaveBeenCalled()
   })
 })

--- a/src/__tests__/placement-orchestrator.spec.js
+++ b/src/__tests__/placement-orchestrator.spec.js
@@ -1,16 +1,17 @@
 /* eslint-env vitest, jsdom */
 import { describe, it, expect } from 'vitest'
 import { validateWallZBaseRequired, validateHeightWithinWarehouse, validateZStacking } from '@/validation/placementOrchestrator'
+import { resolveVerticalProps } from '@/validation/fieldResolvers'
 
 describe('validateWallZBaseRequired', () => {
   it('rechaza zBase faltante o <=0', () => {
-    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 0 }, {})
+    const res = validateWallZBaseRequired({ ubicacion: 'Pared', zBase: 0 }, {})
     expect(res.valid).toBe(false)
     expect(res.code).toBe('ZBASE_REQUIRED')
   })
 
   it('acepta zBase mayor a 0', () => {
-    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 10 }, {})
+    const res = validateWallZBaseRequired({ ubicacion: 'Pared', zBase: 10 }, {})
     expect(res.valid).toBe(true)
   })
 })
@@ -18,13 +19,13 @@ describe('validateWallZBaseRequired', () => {
 describe('validateHeightWithinWarehouse', () => {
   const ALTURA = 300
   it('rechaza cuando excede altura de bodega', () => {
-    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 250, alto: 100 }, ALTURA)
+    const res = validateHeightWithinWarehouse({ ubicacion: 'Pared', zBase: 250, alto: 100 }, {}, ALTURA)
     expect(res.valid).toBe(false)
     expect(res.code).toBe('HEIGHT_EXCEEDS_WAREHOUSE')
   })
 
   it('permite cuando zBase + alto es igual a alturaBodega', () => {
-    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 200, alto: 100 }, ALTURA)
+    const res = validateHeightWithinWarehouse({ ubicacion: 'Pared', zBase: 200, alto: 100 }, {}, ALTURA)
     expect(res.valid).toBe(true)
   })
 })
@@ -32,22 +33,24 @@ describe('validateHeightWithinWarehouse', () => {
 describe('validateZStacking', () => {
   const base = {
     id: 'a',
-    ubicacion: 'pared',
+    ubicacion: 'Pared',
     x: 0,
     y: 0,
     width: 10,
     height: 10,
+    alto: 100,
     elevacion: { zBase: 0, altura: 100 },
   }
 
   it('detecta solape en Z', () => {
     const cand = {
       id: 'b',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 50, altura: 100 },
     }
     const res = validateZStacking([base], cand)
@@ -58,11 +61,12 @@ describe('validateZStacking', () => {
   it('permite tocar en Z', () => {
     const cand = {
       id: 'b',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 100,
       elevacion: { zBase: 100, altura: 100 },
     }
     const res = validateZStacking([base], cand)
@@ -72,14 +76,27 @@ describe('validateZStacking', () => {
   it('permite alturas separadas', () => {
     const cand = {
       id: 'b',
-      ubicacion: 'pared',
+      ubicacion: 'Pared',
       x: 0,
       y: 0,
       width: 10,
       height: 10,
+      alto: 50,
       elevacion: { zBase: 200, altura: 50 },
     }
     const res = validateZStacking([base], cand)
     expect(res.valid).toBe(true)
+  })
+})
+
+describe('resolveVerticalProps', () => {
+  it('coalesce y parsea strings numéricos', () => {
+    const res = resolveVerticalProps(
+      { ubicacion: 'Pared', alturaRespectoAlSuelo: '120', altura: '80' },
+      { alto: '80' }
+    )
+    expect(res.ubic).toBe('Pared')
+    expect(res.zBaseCm).toBe(120)
+    expect(res.altoCm).toBe(80)
   })
 })

--- a/src/__tests__/placement-orchestrator.spec.js
+++ b/src/__tests__/placement-orchestrator.spec.js
@@ -1,0 +1,84 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect } from 'vitest'
+import { validateWallZBaseRequired, validateHeightWithinWarehouse, validateZStacking } from '@/validation/placementOrchestrator'
+
+describe('validateWallZBaseRequired', () => {
+  it('rechaza zBase faltante o <=0', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 0 })
+    expect(res.valid).toBe(false)
+  })
+
+  it('acepta zBase mayor a 0', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 10 })
+    expect(res.valid).toBe(true)
+  })
+})
+
+describe('validateHeightWithinWarehouse', () => {
+  const ALTURA = 300
+  it('rechaza cuando excede altura de bodega', () => {
+    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 250, alto: 100, alturaBodega: ALTURA })
+    expect(res.valid).toBe(false)
+    expect(res.reason).toBe('HEIGHT_EXCEEDS_WAREHOUSE')
+  })
+
+  it('permite cuando zBase + alto es igual a alturaBodega', () => {
+    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 200, alto: 100, alturaBodega: ALTURA })
+    expect(res.valid).toBe(true)
+  })
+})
+
+describe('validateZStacking', () => {
+  const base = {
+    id: 'a',
+    ubicacion: 'pared',
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    elevacion: { zBase: 0, altura: 100 },
+  }
+
+  it('detecta solape en Z', () => {
+    const cand = {
+      id: 'b',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 50, altura: 100 },
+    }
+    const res = validateZStacking([base], cand)
+    expect(res.valid).toBe(false)
+    expect(res.reason).toBe('Z_STACKING_COLLISION')
+  })
+
+  it('permite tocar en Z', () => {
+    const cand = {
+      id: 'b',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 100, altura: 100 },
+    }
+    const res = validateZStacking([base], cand)
+    expect(res.valid).toBe(true)
+  })
+
+  it('permite alturas separadas', () => {
+    const cand = {
+      id: 'b',
+      ubicacion: 'pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      elevacion: { zBase: 200, altura: 50 },
+    }
+    const res = validateZStacking([base], cand)
+    expect(res.valid).toBe(true)
+  })
+})

--- a/src/__tests__/placement-orchestrator.spec.js
+++ b/src/__tests__/placement-orchestrator.spec.js
@@ -4,12 +4,13 @@ import { validateWallZBaseRequired, validateHeightWithinWarehouse, validateZStac
 
 describe('validateWallZBaseRequired', () => {
   it('rechaza zBase faltante o <=0', () => {
-    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 0 })
+    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 0 }, {})
     expect(res.valid).toBe(false)
+    expect(res.code).toBe('ZBASE_REQUIRED')
   })
 
   it('acepta zBase mayor a 0', () => {
-    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 10 })
+    const res = validateWallZBaseRequired({ ubicacion: 'pared', zBase: 10 }, {})
     expect(res.valid).toBe(true)
   })
 })
@@ -17,13 +18,13 @@ describe('validateWallZBaseRequired', () => {
 describe('validateHeightWithinWarehouse', () => {
   const ALTURA = 300
   it('rechaza cuando excede altura de bodega', () => {
-    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 250, alto: 100, alturaBodega: ALTURA })
+    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 250, alto: 100 }, ALTURA)
     expect(res.valid).toBe(false)
-    expect(res.reason).toBe('HEIGHT_EXCEEDS_WAREHOUSE')
+    expect(res.code).toBe('HEIGHT_EXCEEDS_WAREHOUSE')
   })
 
   it('permite cuando zBase + alto es igual a alturaBodega', () => {
-    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 200, alto: 100, alturaBodega: ALTURA })
+    const res = validateHeightWithinWarehouse({ ubicacion: 'pared', zBase: 200, alto: 100 }, ALTURA)
     expect(res.valid).toBe(true)
   })
 })
@@ -51,7 +52,7 @@ describe('validateZStacking', () => {
     }
     const res = validateZStacking([base], cand)
     expect(res.valid).toBe(false)
-    expect(res.reason).toBe('Z_STACKING_COLLISION')
+    expect(res.code).toBe('Z_STACKING_COLLISION')
   })
 
   it('permite tocar en Z', () => {

--- a/src/__tests__/placement-orchestrator.spec.js
+++ b/src/__tests__/placement-orchestrator.spec.js
@@ -1,6 +1,11 @@
 /* eslint-env vitest, jsdom */
 import { describe, it, expect } from 'vitest'
-import { validateWallZBaseRequired, validateHeightWithinWarehouse, validateZStacking } from '@/validation/placementOrchestrator'
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+  resolveZStackClamp,
+} from '@/validation/placementOrchestrator'
 import { resolveVerticalProps } from '@/validation/fieldResolvers'
 
 describe('validateWallZBaseRequired', () => {
@@ -55,7 +60,7 @@ describe('validateZStacking', () => {
     }
     const res = validateZStacking([base], cand)
     expect(res.valid).toBe(false)
-    expect(res.code).toBe('Z_STACKING_COLLISION')
+    expect(res.code).toBe('Z_STACK_CONFLICT')
   })
 
   it('permite tocar en Z', () => {
@@ -86,6 +91,34 @@ describe('validateZStacking', () => {
     }
     const res = validateZStacking([base], cand)
     expect(res.valid).toBe(true)
+  })
+})
+
+describe('resolveZStackClamp', () => {
+  it('corrige posición al borde no conflictivo', () => {
+    const base = {
+      id: 'a',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 0, altura: 100 },
+    }
+    const cand = {
+      id: 'b',
+      ubicacion: 'Pared',
+      x: 5,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 50, altura: 100 },
+    }
+    const { corrected } = resolveZStackClamp(cand, [base])
+    expect(corrected.x).toBe(10)
+    expect(corrected.y).toBe(0)
   })
 })
 

--- a/src/__tests__/test-setup.js
+++ b/src/__tests__/test-setup.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { vi } from 'vitest'
 
 // Stub vue-konva components globally
@@ -26,7 +27,7 @@ class ResizeObserver {
   disconnect() {}
 }
 // @ts-ignore
-if (typeof global !== 'undefined') {
+if (typeof globalThis !== 'undefined') {
   // @ts-ignore
-  global.ResizeObserver = ResizeObserver
+  globalThis.ResizeObserver = ResizeObserver
 }

--- a/src/__tests__/wall-placement-helper.spec.js
+++ b/src/__tests__/wall-placement-helper.spec.js
@@ -1,0 +1,22 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect } from 'vitest'
+import { validateWallPlacement } from '@/utils/placementValidity'
+
+const ALTURA_BODEGA = 300
+
+describe('validateWallPlacement', () => {
+  it('requiere zBase mayor a 0', () => {
+    const res = validateWallPlacement({ zBase: 0, alto: 50, alturaBodega: ALTURA_BODEGA })
+    expect(res.valido).toBe(false)
+  })
+
+  it('detecta exceder altura de bodega', () => {
+    const res = validateWallPlacement({ zBase: 250, alto: 100, alturaBodega: ALTURA_BODEGA })
+    expect(res.valido).toBe(false)
+  })
+
+  it('permite cuando zBase + alto es igual a alturaBodega', () => {
+    const res = validateWallPlacement({ zBase: 200, alto: 100, alturaBodega: ALTURA_BODEGA })
+    expect(res.valido).toBe(true)
+  })
+})

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -568,6 +568,7 @@ import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
 import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 import FloatingToolbar from './FloatingToolbar.vue'
+import usePlacementGuards from '@/composables/usePlacementGuards'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -609,6 +610,12 @@ const { visible: ctxVisible, x: ctxX, y: ctxY, isLocked: ctxIsLocked, elementId:
 const { deleteSelected } = useDeleteElement()
 const confirmDialog = useConfirmDialog()
 const weightValidation = useWeightValidation()
+
+const { onDragMoveGuard, onDragEndGuard, onTransformEndGuard } = usePlacementGuards({
+  store: canvasStore,
+  alturaBodega: canvasStore.plantaActivaData.value?.dimensiones?.alto || Infinity,
+  CM_TO_PX,
+})
 
 // === HELPERS DE CONVERSIÓN ===
 /**
@@ -1830,6 +1837,10 @@ const onShapeDragStart = (e, el) => {
 }
 
 const onShapeDragMove = (e, el) => {
+  const guardRes = onDragMoveGuard(el)
+  if (!guardRes.valid && guardRes.corrected) {
+    e.target.position(guardRes.corrected)
+  }
   const data = innerSessions.get(el.id)
   if (data) {
     const { session, parent } = data
@@ -1861,23 +1872,34 @@ const onShapeDragEnd = (e, el) => {
     const shape = e.target
     let candLocal = session.toLocal(shape.position(), parent)
     let finalLocal = session.finalizeLocal(candLocal)
-    const finalWorld = session.toWorld(finalLocal, parent)
-    shape.position(finalWorld)
-    needsDraw = true
-    scheduleDraw()
-    const changed =
-      Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
-    if (changed) {
-      canvasStore.actualizarElementoConHistorial(
-        el.id,
-        { posicion: { x: finalWorld.x, y: finalWorld.y }, x: finalWorld.x, y: finalWorld.y },
-        `Elemento movido: ${el.id}`,
-      )
+      const finalWorld = session.toWorld(finalLocal, parent)
+      shape.position(finalWorld)
+      needsDraw = true
+      scheduleDraw()
+      const guardRes = onDragEndGuard({ ...el, x: finalWorld.x, y: finalWorld.y, start: initial })
+      if (!guardRes.valid && guardRes.corrected) {
+        shape.position(guardRes.corrected)
+        needsDraw = true
+        scheduleDraw()
+      }
+      if (guardRes.valid) {
+        const changed =
+          Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
+        if (changed) {
+          canvasStore.actualizarElementoConHistorial(
+            el.id,
+            { posicion: { x: finalWorld.x, y: finalWorld.y }, x: finalWorld.x, y: finalWorld.y },
+            `Elemento movido: ${el.id}`,
+          )
+        }
+      }
+    } else {
+      const guardRes = onDragEndGuard(el)
+      if (guardRes.valid) {
+        endElementDrag(el.id)
+      }
     }
-  } else {
-    endElementDrag(el.id)
   }
-}
 
 const getElementShadow = (elemento) => {
   if (canvasStore.elementoDestacadoId === elemento.id) {
@@ -2253,14 +2275,16 @@ const handleTransformEnd = (e, elementId, forma) => {
     if (!elemento) return
 
     // Validar con isPlacementValid contra vecinos y área
-    const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)
-    const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
-    const isValidNow = isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+      const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)
+      const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
+      const isValidNow = isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+      const prev = transformInitialState.get(elementId) || { x: elemento.x, y: elemento.y, width: elemento.width, height: elemento.height, rotation: elemento.rotation }
+      const guardRes = onTransformEndGuard({ ...elemento, x, y, width, height, start: prev })
 
   console.debug('[transform-debug] end', elementId, { prev: transformInitialState.get(elementId), new: { x, y, width, height, rotation }, isValidNow })
-  if (!isValidNow) {
+    if (!isValidNow || !guardRes.valid) {
       // Revertir al estado inicial guardado
-      const prev = transformInitialState.get(elementId) || { x: elemento.x, y: elemento.y, width: elemento.width, height: elemento.height }
+      const prev = transformInitialState.get(elementId) || { x: elemento.x, y: elemento.y, width: elemento.width, height: elemento.height, rotation: elemento.rotation }
       try {
         if (forma === 'circular') {
           const r = Math.min(prev.width, prev.height) / 2

--- a/src/components/modals/ElementEditor.vue
+++ b/src/components/modals/ElementEditor.vue
@@ -99,6 +99,9 @@
                 <p class="text-xs text-gray-500 mt-1">
                   Distancia desde el suelo hasta la base del elemento
                 </p>
+                <p v-if="errorAlturaPared" class="text-sm text-red-600 mt-1">
+                  {{ errorAlturaPared }}
+                </p>
               </div>
             </div>
 
@@ -235,6 +238,8 @@
 <script setup>
 import { ref, watch, computed } from 'vue'
 import { useWeightValidation } from '@/composables/useWeightValidation'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import { validateWallPlacement } from '@/utils/placementValidity'
 
 const props = defineProps({
   visible: Boolean,
@@ -246,6 +251,7 @@ const props = defineProps({
 const emit = defineEmits(['cancel', 'save'])
 
 const weightValidation = useWeightValidation()
+const canvasStore = useCanvasStore()
 
 const esFormaCircular = computed(() => localElemento.value.forma === 'circular')
 
@@ -302,6 +308,8 @@ const localElemento = ref({
   contenedores: [],
 })
 
+const errorAlturaPared = ref('')
+
 watch(
   () => props.value,
   (val) => {
@@ -333,6 +341,17 @@ watch(
   },
 )
 
+watch(
+  () => [
+    localElemento.value.alturaRespectoAlSuelo,
+    localElemento.value.dimensiones.alto,
+    localElemento.value.ubicacion,
+  ],
+  () => {
+    errorAlturaPared.value = ''
+  },
+)
+
 // Restablecer el formulario cuando el modal se abre
 watch(
   () => props.visible,
@@ -357,8 +376,9 @@ const restablecerFormulario = () => {
     alturaRespectoAlSuelo: 0,
     descripcion: '',
     icono: 'box',
-    contenedores: [],
+  contenedores: [],
   }
+  errorAlturaPared.value = ''
 }
 
 const onCancel = () => {
@@ -368,6 +388,7 @@ const onCancel = () => {
 
 const validarFormulario = () => {
   const elemento = localElemento.value
+  errorAlturaPared.value = ''
   if (!elemento.nombre.trim()) {
     alert('El nombre es requerido')
     return false
@@ -395,6 +416,18 @@ const validarFormulario = () => {
   if (elemento.pesoMaximo <= 0) {
     alert('La capacidad de carga debe ser mayor a 0')
     return false
+  }
+  if (elemento.ubicacion === 'pared') {
+    const alturaBodega = canvasStore.plantaActivaData.value?.dimensiones?.alto || Infinity
+    const { valido, mensaje } = validateWallPlacement({
+      zBase: elemento.alturaRespectoAlSuelo,
+      alto: elemento.dimensiones.alto,
+      alturaBodega
+    })
+    if (!valido) {
+      errorAlturaPared.value = mensaje
+      return false
+    }
   }
   return true
 }

--- a/src/components/modals/ElementEditor.vue
+++ b/src/components/modals/ElementEditor.vue
@@ -83,7 +83,7 @@
             </div>
 
             <!-- Altura respecto al suelo (solo para elementos de pared) -->
-            <div v-if="localElemento.ubicacion === 'pared'" class="mb-6">
+            <div v-if="localElemento.ubicacion === 'Pared'" class="mb-6">
               <h3 class="text-lg font-medium text-gray-800 mb-3">Posicionamiento en Pared</h3>
               <div class="mb-2">
                 <label class="block text-sm font-medium text-gray-700"
@@ -196,7 +196,7 @@
                     localElemento.forma === 'circular' ? 'w-10 h-10' : 'w-12 h-8',
                     'rounded flex items-center justify-center relative shadow-sm border border-white/20',
                     `shape-${localElemento.forma}`,
-                    localElemento.ubicacion === 'pared' ? 'wall-mounted' : '',
+                    localElemento.ubicacion === 'Pared' ? 'wall-mounted' : '',
                   ]"
                   :style="{ backgroundColor: localElemento.colorBase || '#6b7280' }"
                 >
@@ -301,7 +301,7 @@ const localElemento = ref({
   colorBase: '#3b82f6',
   dimensiones: { ancho: 100, largo: 100, alto: 75 },
   pesoMaximo: 50,
-  ubicacion: 'suelo',
+  ubicacion: 'Suelo',
   alturaRespectoAlSuelo: 0,
   descripcion: '',
   icono: 'box',
@@ -372,7 +372,7 @@ const restablecerFormulario = () => {
     colorBase: '#3b82f6',
     dimensiones: { ancho: 100, largo: 100, alto: 75 },
     pesoMaximo: 50,
-    ubicacion: 'suelo',
+    ubicacion: 'Suelo',
     alturaRespectoAlSuelo: 0,
     descripcion: '',
     icono: 'box',
@@ -417,7 +417,7 @@ const validarFormulario = () => {
     alert('La capacidad de carga debe ser mayor a 0')
     return false
   }
-  if (elemento.ubicacion === 'pared') {
+  if (elemento.ubicacion === 'Pared') {
     const alturaBodega = canvasStore.plantaActivaData.value?.dimensiones?.alto || Infinity
     const { valido, mensaje } = validateWallPlacement({
       zBase: elemento.alturaRespectoAlSuelo,

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -632,7 +632,7 @@ export const useCanvasStore = defineStore('canvas', () => {
       }
       const stackRes = validateZStacking(elementos.value, candidate)
       if (!stackRes.valid) {
-        console.error(errorsPlacement[stackRes.reason] || stackRes.reason)
+        console.error(errorsPlacement[stackRes.code || stackRes.reason] || stackRes.code || stackRes.reason)
         return false
       }
 
@@ -783,7 +783,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     }
     const stackRes = validateZStacking(elementos.value, nuevoElemento)
     if (!stackRes.valid) {
-      console.error(errorsPlacement[stackRes.reason] || stackRes.reason)
+      console.error(errorsPlacement[stackRes.code || stackRes.reason] || stackRes.code || stackRes.reason)
       return null
     }
 

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -17,6 +17,9 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
+import { validateWallPlacement } from '@/utils/placementValidity'
+import { validateZStacking } from '@/validation/placementOrchestrator'
+import { errorsPlacement } from '@/utils/errorsPlacement'
 
 // Variable para evitar circular import - será inicializada por el composable de historial
 let historyComposable = null
@@ -588,14 +591,63 @@ export const useCanvasStore = defineStore('canvas', () => {
   const actualizarElemento = (elementoId, propiedades) => {
     const elemento = elementos.value.find((el) => el.id === elementoId)
     if (elemento) {
+      const ubicacionFinal = propiedades.ubicacion || elemento.ubicacion
+      const zBaseFinal =
+        propiedades.alturaRespectoAlSuelo ??
+        propiedades.elevacion?.zBase ??
+        elemento.alturaRespectoAlSuelo ??
+        elemento.elevacion?.zBase
+      const altoFinal =
+        propiedades.dimensiones?.alto ??
+        elemento.dimensiones?.alto ??
+        elemento.alto ?? 0
+
+      if (ubicacionFinal === 'pared') {
+        const alturaBodega = plantaActivaData.value?.dimensiones?.alto || Infinity
+        const { valido, mensaje } = validateWallPlacement({
+          zBase: zBaseFinal,
+          alto: altoFinal,
+          alturaBodega
+        })
+        if (!valido) {
+          console.error(mensaje)
+          return false
+        }
+      }
+
+      const candidate = {
+        ...elemento,
+        ...propiedades,
+        ubicacion: ubicacionFinal,
+        x: propiedades.x ?? elemento.x,
+        y: propiedades.y ?? elemento.y,
+        width: propiedades.width ?? elemento.width,
+        height: propiedades.height ?? elemento.height,
+        elevacion: {
+          ...(elemento.elevacion || {}),
+          ...(propiedades.elevacion || {}),
+          zBase: zBaseFinal,
+          altura: altoFinal,
+        },
+      }
+      const stackRes = validateZStacking(elementos.value, candidate)
+      if (!stackRes.valid) {
+        console.error(errorsPlacement[stackRes.reason] || stackRes.reason)
+        return false
+      }
+
       for (const key in propiedades) {
-        if (typeof propiedades[key] === 'object' && propiedades[key] !== null && !Array.isArray(propiedades[key])) {
+        if (
+          typeof propiedades[key] === 'object' &&
+          propiedades[key] !== null &&
+          !Array.isArray(propiedades[key])
+        ) {
           // Si la propiedad es un objeto (como 'dimensiones'), la fusionamos recursivamente.
           if (!elemento[key]) elemento[key] = {}
-          Object.assign(elemento[key], propiedades[key]);
+          Object.assign(elemento[key], propiedades[key])
         } else {
           // Si es un valor simple, lo asignamos directamente.
-          elemento[key] = propiedades[key];
+          elemento[key] = propiedades[key]
         }
       }
 
@@ -621,7 +673,9 @@ export const useCanvasStore = defineStore('canvas', () => {
           // Nota: largo no afecta a width/height en vista XZ
         }
       }
+      return true
     }
+    return false
   }
 
   const configurarZoom = (nuevoZoom) => {
@@ -711,6 +765,25 @@ export const useCanvasStore = defineStore('canvas', () => {
     // Validar tipo de elemento
     if (!nuevoElemento.tipo) {
       console.error('El elemento debe tener un tipo definido')
+      return null
+    }
+
+    // Validación específica para elementos ubicados en pared
+    if (nuevoElemento.ubicacion === 'pared') {
+      const alturaBodega = plantaActivaData.value?.dimensiones?.alto || Infinity
+      const { valido, mensaje } = validateWallPlacement({
+        zBase: nuevoElemento.alturaRespectoAlSuelo ?? nuevoElemento.elevacion?.zBase,
+        alto: nuevoElemento.dimensiones?.alto ?? nuevoElemento.alto ?? 0,
+        alturaBodega
+      })
+      if (!valido) {
+        console.error(mensaje)
+        return null
+      }
+    }
+    const stackRes = validateZStacking(elementos.value, nuevoElemento)
+    if (!stackRes.valid) {
+      console.error(errorsPlacement[stackRes.reason] || stackRes.reason)
       return null
     }
 

--- a/src/composables/useDimensionValidation.js
+++ b/src/composables/useDimensionValidation.js
@@ -1,9 +1,7 @@
 import { useCanvasStore } from '@/composables/useCanvasStore'
 import { useToast } from '@/composables/useToast'
 import { detectConflictsFor } from '@/utils/collision'
-
-// Constante de conversión: 1cm = 10px
-const CM_TO_PX = 10
+import { CM_TO_PX } from '@/utils/constants'
 
 /**
  * Composable para validar dimensiones físicas de elementos

--- a/src/composables/usePerfMode.js
+++ b/src/composables/usePerfMode.js
@@ -25,7 +25,9 @@ export function enablePerfMode(layer, opts = {}) {
         strokeWidth: 1,
       })
     }
-  } catch (_) {}
+  } catch (_) {
+    // ignore errors from perf mode optimizations
+  }
 
   return {
     restore: () => disablePerfMode(layer, { shape, prev }),
@@ -52,5 +54,7 @@ export function disablePerfMode(layer, ctx = {}) {
       if (prev.shapeStrokeWidth !== undefined) attrs.strokeWidth = prev.shapeStrokeWidth
       shape.setAttrs(attrs)
     }
-  } catch (_) {}
+  } catch (_) {
+    // ignore errors when restoring perf mode
+  }
 }

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -52,7 +52,7 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
       return { ...resBase, candidate: cand }
     }
 
-    const resHeight = validateHeightWithinWarehouse(cand, alturaBodega)
+    const resHeight = validateHeightWithinWarehouse(base, cand, alturaBodega)
     if (!resHeight.valid) {
       if (start) {
         const { x, y, width, height } = start

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -1,0 +1,70 @@
+import { validateWallZBaseRequired, validateHeightWithinWarehouse, validateZStacking } from '@/validation/placementOrchestrator'
+import { useToast } from '@/composables/useToast'
+import { errorsPlacement } from '@/utils/errorsPlacement'
+
+/**
+ * Provee guards de validación para movimientos y transformaciones
+ * @param {Object} ctx
+ * @param {Object} ctx.store - store de canvas
+ * @param {number} ctx.alturaBodega - altura máxima permitida
+ * @param {number} ctx.CM_TO_PX - factor de conversión
+ */
+export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
+  void CM_TO_PX
+  const toast = useToast()
+
+  const validateAll = (el) => {
+    const base = validateWallZBaseRequired({ ubicacion: el.ubicacion, zBase: el.elevacion?.zBase })
+    if (!base.valid) return base
+    const height = validateHeightWithinWarehouse({
+      ubicacion: el.ubicacion,
+      zBase: el.elevacion?.zBase,
+      alto: el.elevacion?.altura,
+      alturaBodega,
+    })
+    if (!height.valid) return height
+    return validateZStacking(store.elementosVisibles, el)
+  }
+
+  const onDragMoveGuard = (el) => {
+    const height = validateHeightWithinWarehouse({
+      ubicacion: el.ubicacion,
+      zBase: el.elevacion?.zBase,
+      alto: el.elevacion?.altura,
+      alturaBodega,
+    })
+    if (!height.valid) {
+      el.invalidPlacement = true
+      return height
+    }
+    const zRes = validateZStacking(store.elementosVisibles, el)
+    el.invalidPlacement = !zRes.valid
+    return zRes
+  }
+
+  const handleEnd = (el) => {
+    const res = validateAll(el)
+    el.invalidPlacement = !res.valid
+    if (!res.valid) {
+      toast.showError(errorsPlacement[res.reason] || res.reason)
+      if (el.start) {
+        const { x, y, width, height } = el.start
+        const payload = {}
+        if (x !== undefined) payload.x = x
+        if (y !== undefined) payload.y = y
+        if (width !== undefined) payload.width = width
+        if (height !== undefined) payload.height = height
+        store.actualizarElemento(el.id, payload)
+        return { ...res, corrected: el.start }
+      }
+    }
+    return res
+  }
+
+  const onDragEndGuard = (el) => handleEnd(el)
+  const onTransformEndGuard = (el) => handleEnd(el)
+
+  return { onDragMoveGuard, onDragEndGuard, onTransformEndGuard }
+}
+
+export default usePlacementGuards

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -2,6 +2,27 @@ import { validateWallZBaseRequired, validateHeightWithinWarehouse, validateZStac
 import { useToast } from '@/composables/useToast'
 import { errorsPlacement } from '@/utils/errorsPlacement'
 
+function hydrateCandidate(element, partial) {
+  const ubicacion = partial.ubicacion ?? element.ubicacion
+  const zBase =
+    partial.zBase ?? partial.elevacion?.zBase ?? element.zBase ?? element.elevacion?.zBase
+  const alto =
+    partial.alto ?? partial.elevacion?.altura ?? element.alto ?? element.elevacion?.altura
+  return {
+    ...element,
+    ...partial,
+    ubicacion,
+    zBase,
+    alto,
+    elevacion: {
+      ...(element.elevacion || {}),
+      ...(partial.elevacion || {}),
+      zBase,
+      altura: alto,
+    },
+  }
+}
+
 /**
  * Provee guards de validación para movimientos y transformaciones
  * @param {Object} ctx
@@ -13,50 +34,67 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
   void CM_TO_PX
   const toast = useToast()
 
-  const validateAll = (el) => {
-    const base = validateWallZBaseRequired({ ubicacion: el.ubicacion, zBase: el.elevacion?.zBase })
-    if (!base.valid) return base
-    const height = validateHeightWithinWarehouse({
-      ubicacion: el.ubicacion,
-      zBase: el.elevacion?.zBase,
-      alto: el.elevacion?.altura,
-      alturaBodega,
-    })
-    if (!height.valid) return height
-    return validateZStacking(store.elementosVisibles, el)
-  }
+  const runPipeline = (candidate, start) => {
+    const base = store.elementos.find((e) => e.id === candidate.id) || candidate
+    const cand = hydrateCandidate(base, candidate)
 
-  const onDragMoveGuard = (el) => {
-    const height = validateHeightWithinWarehouse({
-      ubicacion: el.ubicacion,
-      zBase: el.elevacion?.zBase,
-      alto: el.elevacion?.altura,
-      alturaBodega,
-    })
-    if (!height.valid) {
-      el.invalidPlacement = true
-      return height
-    }
-    const zRes = validateZStacking(store.elementosVisibles, el)
-    el.invalidPlacement = !zRes.valid
-    return zRes
-  }
-
-  const handleEnd = (el) => {
-    const res = validateAll(el)
-    el.invalidPlacement = !res.valid
-    if (!res.valid) {
-      toast.showError(errorsPlacement[res.reason] || res.reason)
-      if (el.start) {
-        const { x, y, width, height } = el.start
+    const resBase = validateWallZBaseRequired(base, cand)
+    if (!resBase.valid) {
+      if (start) {
+        const { x, y, width, height } = start
         const payload = {}
         if (x !== undefined) payload.x = x
         if (y !== undefined) payload.y = y
         if (width !== undefined) payload.width = width
         if (height !== undefined) payload.height = height
-        store.actualizarElemento(el.id, payload)
-        return { ...res, corrected: el.start }
+        store.actualizarElemento(candidate.id, payload)
       }
+      return { ...resBase, candidate: cand }
+    }
+
+    const resHeight = validateHeightWithinWarehouse(cand, alturaBodega)
+    if (!resHeight.valid) {
+      if (start) {
+        const { x, y, width, height } = start
+        const payload = {}
+        if (x !== undefined) payload.x = x
+        if (y !== undefined) payload.y = y
+        if (width !== undefined) payload.width = width
+        if (height !== undefined) payload.height = height
+        store.actualizarElemento(candidate.id, payload)
+      }
+      return { ...resHeight, candidate: cand }
+    }
+
+    const resStack = validateZStacking(store.elementosVisibles, cand)
+    if (!resStack.valid) {
+      if (start) {
+        const { x, y, width, height } = start
+        const payload = {}
+        if (x !== undefined) payload.x = x
+        if (y !== undefined) payload.y = y
+        if (width !== undefined) payload.width = width
+        if (height !== undefined) payload.height = height
+        store.actualizarElemento(candidate.id, payload)
+      }
+      return { ...resStack, candidate: cand }
+    }
+
+    return { valid: true, candidate: cand }
+  }
+
+  const onDragMoveGuard = (el) => {
+    const res = runPipeline(el)
+    el.invalidPlacement = !res.valid
+    return res
+  }
+
+  const handleEnd = (el) => {
+    const res = runPipeline(el, el.start)
+    el.invalidPlacement = !res.valid
+    if (!res.valid) {
+      toast.showError(errorsPlacement[res.code] || errorsPlacement[res.reason] || res.code || res.reason)
+      if (el.start) return { ...res, corrected: el.start }
     }
     return res
   }

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -1,6 +1,12 @@
-import { validateWallZBaseRequired, validateHeightWithinWarehouse, validateZStacking } from '@/validation/placementOrchestrator'
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+  resolveZStackClamp,
+} from '@/validation/placementOrchestrator'
 import { useToast } from '@/composables/useToast'
 import { errorsPlacement } from '@/utils/errorsPlacement'
+import { getAABB, aabbIntersect } from '@/utils/collision'
 
 function hydrateCandidate(element, partial) {
   const ubicacion = partial.ubicacion ?? element.ubicacion
@@ -66,8 +72,13 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
       return { ...resHeight, candidate: cand }
     }
 
-    const resStack = validateZStacking(store.elementosVisibles, cand)
+    const aabb = getAABB(cand)
+    const neighbors = store.elementosVisibles.filter(
+      (e) => e.id !== cand.id && e.plantaId === cand.plantaId && aabbIntersect(aabb, getAABB(e)),
+    )
+    const resStack = validateZStacking(neighbors, cand)
     if (!resStack.valid) {
+      const { corrected } = resolveZStackClamp(cand, neighbors)
       if (start) {
         const { x, y, width, height } = start
         const payload = {}
@@ -77,7 +88,7 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
         if (height !== undefined) payload.height = height
         store.actualizarElemento(candidate.id, payload)
       }
-      return { ...resStack, candidate: cand }
+      return { ...resStack, reason: resStack.code, candidate: cand, corrected }
     }
 
     return { valid: true, candidate: cand }
@@ -86,6 +97,10 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
   const onDragMoveGuard = (el) => {
     const res = runPipeline(el)
     el.invalidPlacement = !res.valid
+    if (res.reason === 'Z_STACK_CONFLICT' && res.corrected) {
+      el.x = res.corrected.x
+      el.y = res.corrected.y
+    }
     return res
   }
 

--- a/src/utils/errorsPlacement.js
+++ b/src/utils/errorsPlacement.js
@@ -1,7 +1,7 @@
 export const errorsPlacement = {
   ZBASE_REQUIRED: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0',
   HEIGHT_EXCEEDS_WAREHOUSE: 'La suma de la base y altura del elemento excede la altura de la bodega.',
-  Z_STACKING_COLLISION: 'Colisión vertical: las alturas se solapan',
+  Z_STACK_CONFLICT: 'Colisión vertical: las alturas se solapan',
 }
 
 export default errorsPlacement

--- a/src/utils/errorsPlacement.js
+++ b/src/utils/errorsPlacement.js
@@ -1,4 +1,5 @@
 export const errorsPlacement = {
+  ZBASE_REQUIRED: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0',
   HEIGHT_EXCEEDS_WAREHOUSE: 'La suma de la base y altura del elemento excede la altura de la bodega.',
   Z_STACKING_COLLISION: 'Colisión vertical: las alturas se solapan',
 }

--- a/src/utils/errorsPlacement.js
+++ b/src/utils/errorsPlacement.js
@@ -1,0 +1,6 @@
+export const errorsPlacement = {
+  HEIGHT_EXCEEDS_WAREHOUSE: 'La suma de la base y altura del elemento excede la altura de la bodega.',
+  Z_STACKING_COLLISION: 'Colisión vertical: las alturas se solapan',
+}
+
+export default errorsPlacement

--- a/src/utils/placementValidity.js
+++ b/src/utils/placementValidity.js
@@ -74,7 +74,38 @@ export function isValidPlacement({ pos, movingEl, neighbors = [], areaBounds, CM
   return blockingConflicts.length === 0
 }
 
+/**
+ * Valida la elevación de un elemento cuando su ubicación es "pared".
+ * Verifica que la base respecto al suelo sea > 0 y que la suma
+ * de dicha base con el alto del elemento no exceda la altura total
+ * de la bodega.
+ *
+ * @param {Object} params - Parámetros de validación
+ * @param {number} params.zBase - Altura de la base respecto al suelo
+ * @param {number} params.alto - Altura del elemento
+ * @param {number} params.alturaBodega - Altura total disponible
+ * @returns {{valido: boolean, mensaje: string}}
+ */
+export function validateWallPlacement({ zBase, alto, alturaBodega }) {
+  if (zBase === undefined || zBase === null || zBase <= 0) {
+    return {
+      valido: false,
+      mensaje: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0'
+    }
+  }
+
+  if (zBase + alto > alturaBodega) {
+    return {
+      valido: false,
+      mensaje: 'La base del elemento más su alto excede la altura de la bodega'
+    }
+  }
+
+  return { valido: true, mensaje: '' }
+}
+
 export default {
   isValidPlacement,
-  insideAreaStrokeSafe
+  insideAreaStrokeSafe,
+  validateWallPlacement
 }

--- a/src/validation/fieldResolvers.js
+++ b/src/validation/fieldResolvers.js
@@ -1,0 +1,45 @@
+export function resolveVerticalProps(element = {}, candidate = {}) {
+  const pick = (...vals) => {
+    for (const v of vals) {
+      if (v !== undefined && v !== null) return v
+    }
+    return null
+  }
+  const ubic = pick(
+    candidate.ubicacion,
+    element.ubicacion,
+    candidate.ubic,
+    element.ubic,
+    candidate.location,
+    element.location,
+  )
+  const rawZ = pick(
+    candidate.zBase,
+    element.zBase,
+    candidate.alturaRespectoAlSuelo,
+    element.alturaRespectoAlSuelo,
+    candidate.z_base,
+    element.z_base,
+    candidate.baseZ,
+    element.baseZ,
+  )
+  const rawAlto = pick(
+    candidate.alto,
+    element.alto,
+    candidate.altura,
+    element.altura,
+    candidate.heightCm,
+    element.heightCm,
+    candidate.height,
+    element.height,
+  )
+  const zBaseCm = rawZ != null ? parseFloat(rawZ) : null
+  const altoCm = rawAlto != null ? parseFloat(rawAlto) : null
+  return {
+    ubic,
+    zBaseCm: Number.isNaN(zBaseCm) ? null : zBaseCm,
+    altoCm: Number.isNaN(altoCm) ? null : altoCm,
+  }
+}
+
+export default { resolveVerticalProps }

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -1,5 +1,6 @@
 import { validateWallPlacement } from '@/utils/placementValidity'
 import { narrowPhase2D, zOverlapCheck } from '@/utils/collision'
+import { resolveVerticalProps } from './fieldResolvers'
 
 const Z_EPS = 0.001
 
@@ -7,12 +8,11 @@ const Z_EPS = 0.001
  * Valida que elementos con ubicacion "pared" tengan zBase definido y > 0
  */
 export function validateWallZBaseRequired(element, candidate) {
-  const ubic = candidate.ubicacion ?? element.ubicacion
-  if (ubic !== 'pared') return { valid: true }
-  const zEff = candidate.zBase ?? candidate.elevacion?.zBase ?? element.zBase ?? element.elevacion?.zBase
-  const altoEff = candidate.alto ?? candidate.elevacion?.altura ?? element.alto ?? element.elevacion?.altura
-  void altoEff
-  if (zEff == null || zEff <= 0) {
+  const { ubic, zBaseCm, altoCm } = resolveVerticalProps(element, candidate)
+  void altoCm
+  if (ubic !== 'Pared') return { valid: true }
+  if (zBaseCm == null || zBaseCm <= 0) {
+    if (globalThis.__DEV__) console.debug('resolveVerticalProps', { ubic, zBaseCm, altoCm })
     return { valid: false, code: 'ZBASE_REQUIRED' }
   }
   return { valid: true }
@@ -21,14 +21,17 @@ export function validateWallZBaseRequired(element, candidate) {
 /**
  * Valida que la suma zBase + alto no exceda la altura de la bodega
  */
-export function validateHeightWithinWarehouse(candidate, alturaBodega) {
-  if (candidate.ubicacion !== 'pared') return { valid: true }
+export function validateHeightWithinWarehouse(element, candidate, alturaBodega) {
+  const { ubic, zBaseCm, altoCm } = resolveVerticalProps(element, candidate)
+  if (ubic !== 'Pared') return { valid: true }
+  if (zBaseCm == null || altoCm == null) return { valid: true }
   const { valido, mensaje } = validateWallPlacement({
-    zBase: candidate.zBase ?? candidate.elevacion?.zBase ?? 1,
-    alto: candidate.alto ?? candidate.elevacion?.altura,
+    zBase: zBaseCm,
+    alto: altoCm,
     alturaBodega,
   })
   if (!valido && mensaje.includes('excede')) {
+    if (globalThis.__DEV__) console.debug('resolveVerticalProps', { ubic, zBaseCm, altoCm })
     return { valid: false, code: 'HEIGHT_EXCEEDS_WAREHOUSE' }
   }
   return { valid: true }
@@ -42,20 +45,33 @@ export function validateHeightWithinWarehouse(candidate, alturaBodega) {
  * @param {number} [Z_EPS=0.001] - tolerancia para permitir contacto
  */
 export function validateZStacking(elements, candidate, Z_EPS = 0.001) {
+  const candProps = resolveVerticalProps(candidate, {})
   const m = {
     ...candidate,
+    elevacion: {
+      ...(candidate.elevacion || {}),
+      zBase: candProps.zBaseCm ?? candidate.elevacion?.zBase,
+      altura: candProps.altoCm ?? candidate.elevacion?.altura,
+    },
     tolerancias: { ...(candidate.tolerancias || {}), zEpsilon: Z_EPS },
   }
   for (const other of elements) {
     if (other.id === candidate.id) continue
     const { intersectXY } = narrowPhase2D(m, other)
     if (!intersectXY) continue
+    const otherProps = resolveVerticalProps(other, {})
     const o = {
       ...other,
+      elevacion: {
+        ...(other.elevacion || {}),
+        zBase: otherProps.zBaseCm ?? other.elevacion?.zBase,
+        altura: otherProps.altoCm ?? other.elevacion?.altura,
+      },
       tolerancias: { ...(other.tolerancias || {}), zEpsilon: Z_EPS },
     }
     const { overlap } = zOverlapCheck(m, o)
     if (overlap) {
+      if (globalThis.__DEV__) console.debug('resolveVerticalProps', { cand: candProps, other: otherProps })
       return { valid: false, code: 'Z_STACKING_COLLISION' }
     }
   }

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -1,5 +1,6 @@
 import { validateWallPlacement } from '@/utils/placementValidity'
-import { narrowPhase2D, zOverlapCheck } from '@/utils/collision'
+import { narrowPhase2D, zOverlapCheck, computeMTD } from '@/utils/collision'
+import { applyEdgeConstraint } from '@/utils/edgeConstraint'
 import { resolveVerticalProps } from './fieldResolvers'
 
 const Z_EPS = 0.001
@@ -72,14 +73,70 @@ export function validateZStacking(elements, candidate, Z_EPS = 0.001) {
     const { overlap } = zOverlapCheck(m, o)
     if (overlap) {
       if (globalThis.__DEV__) console.debug('resolveVerticalProps', { cand: candProps, other: otherProps })
-      return { valid: false, code: 'Z_STACKING_COLLISION' }
+      return { valid: false, code: 'Z_STACK_CONFLICT' }
     }
   }
   return { valid: true }
+}
+
+/**
+ * Calcula una corrección mínima en XY para liberar colisión vertical
+ */
+export function resolveZStackClamp(candidate, neighbors, Z_EPS = 0.001) {
+  const candProps = resolveVerticalProps(candidate, {})
+  const moving = {
+    ...candidate,
+    elevacion: {
+      ...(candidate.elevacion || {}),
+      zBase: candProps.zBaseCm ?? candidate.elevacion?.zBase,
+      altura: candProps.altoCm ?? candidate.elevacion?.altura,
+    },
+    tolerancias: { ...(candidate.tolerancias || {}), zEpsilon: Z_EPS },
+  }
+  let accDx = 0
+  let accDy = 0
+  for (const other of neighbors) {
+    if (other.id === candidate.id) continue
+    const otherProps = resolveVerticalProps(other, {})
+    const o = {
+      ...other,
+      elevacion: {
+        ...(other.elevacion || {}),
+        zBase: otherProps.zBaseCm ?? other.elevacion?.zBase,
+        altura: otherProps.altoCm ?? other.elevacion?.altura,
+      },
+      tolerancias: { ...(other.tolerancias || {}), zEpsilon: Z_EPS },
+    }
+    const { intersectXY } = narrowPhase2D({ ...moving, x: candidate.x + accDx, y: candidate.y + accDy }, o)
+    if (!intersectXY) continue
+    const { overlap } = zOverlapCheck(moving, o)
+    if (!overlap) continue
+    const { dx, dy } = computeMTD(
+      candidate.x + accDx,
+      candidate.y + accDy,
+      candidate.width,
+      candidate.height,
+      o.x,
+      o.y,
+      o.width,
+      o.height,
+    )
+    accDx += dx
+    accDy += dy
+  }
+  let finalX = candidate.x + accDx
+  let finalY = candidate.y + accDy
+  if (candidate.areaBounds) {
+    const { pos } = applyEdgeConstraint({ x: finalX, y: finalY }, candidate, candidate.areaBounds)
+    finalX = pos.x
+    finalY = pos.y
+  }
+  return { corrected: { x: finalX, y: finalY } }
 }
 
 export default {
   validateWallZBaseRequired,
   validateHeightWithinWarehouse,
   validateZStacking,
+  resolveZStackClamp,
 }

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -6,20 +6,30 @@ const Z_EPS = 0.001
 /**
  * Valida que elementos con ubicacion "pared" tengan zBase definido y > 0
  */
-export function validateWallZBaseRequired({ ubicacion, zBase }) {
-  if (ubicacion !== 'pared') return { valid: true }
-  const { valido, mensaje } = validateWallPlacement({ zBase, alto: 0, alturaBodega: Infinity })
-  return { valid: valido, reason: valido ? '' : mensaje }
+export function validateWallZBaseRequired(element, candidate) {
+  const ubic = candidate.ubicacion ?? element.ubicacion
+  if (ubic !== 'pared') return { valid: true }
+  const zEff = candidate.zBase ?? candidate.elevacion?.zBase ?? element.zBase ?? element.elevacion?.zBase
+  const altoEff = candidate.alto ?? candidate.elevacion?.altura ?? element.alto ?? element.elevacion?.altura
+  void altoEff
+  if (zEff == null || zEff <= 0) {
+    return { valid: false, code: 'ZBASE_REQUIRED' }
+  }
+  return { valid: true }
 }
 
 /**
  * Valida que la suma zBase + alto no exceda la altura de la bodega
  */
-export function validateHeightWithinWarehouse({ ubicacion, zBase, alto, alturaBodega }) {
-  if (ubicacion !== 'pared') return { valid: true }
-  const { valido, mensaje } = validateWallPlacement({ zBase: zBase ?? 1, alto, alturaBodega })
+export function validateHeightWithinWarehouse(candidate, alturaBodega) {
+  if (candidate.ubicacion !== 'pared') return { valid: true }
+  const { valido, mensaje } = validateWallPlacement({
+    zBase: candidate.zBase ?? candidate.elevacion?.zBase ?? 1,
+    alto: candidate.alto ?? candidate.elevacion?.altura,
+    alturaBodega,
+  })
   if (!valido && mensaje.includes('excede')) {
-    return { valid: false, reason: 'HEIGHT_EXCEEDS_WAREHOUSE' }
+    return { valid: false, code: 'HEIGHT_EXCEEDS_WAREHOUSE' }
   }
   return { valid: true }
 }
@@ -46,7 +56,7 @@ export function validateZStacking(elements, candidate, Z_EPS = 0.001) {
     }
     const { overlap } = zOverlapCheck(m, o)
     if (overlap) {
-      return { valid: false, reason: 'Z_STACKING_COLLISION' }
+      return { valid: false, code: 'Z_STACKING_COLLISION' }
     }
   }
   return { valid: true }

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -1,0 +1,59 @@
+import { validateWallPlacement } from '@/utils/placementValidity'
+import { narrowPhase2D, zOverlapCheck } from '@/utils/collision'
+
+const Z_EPS = 0.001
+
+/**
+ * Valida que elementos con ubicacion "pared" tengan zBase definido y > 0
+ */
+export function validateWallZBaseRequired({ ubicacion, zBase }) {
+  if (ubicacion !== 'pared') return { valid: true }
+  const { valido, mensaje } = validateWallPlacement({ zBase, alto: 0, alturaBodega: Infinity })
+  return { valid: valido, reason: valido ? '' : mensaje }
+}
+
+/**
+ * Valida que la suma zBase + alto no exceda la altura de la bodega
+ */
+export function validateHeightWithinWarehouse({ ubicacion, zBase, alto, alturaBodega }) {
+  if (ubicacion !== 'pared') return { valid: true }
+  const { valido, mensaje } = validateWallPlacement({ zBase: zBase ?? 1, alto, alturaBodega })
+  if (!valido && mensaje.includes('excede')) {
+    return { valid: false, reason: 'HEIGHT_EXCEEDS_WAREHOUSE' }
+  }
+  return { valid: true }
+}
+
+/**
+ * Valida que los intervalos Z de elementos que se traslapan en XY no se solapen
+ *
+ * @param {Array<Object>} elements - elementos existentes
+ * @param {Object} candidate - elemento candidato
+ * @param {number} [Z_EPS=0.001] - tolerancia para permitir contacto
+ */
+export function validateZStacking(elements, candidate, Z_EPS = 0.001) {
+  const m = {
+    ...candidate,
+    tolerancias: { ...(candidate.tolerancias || {}), zEpsilon: Z_EPS },
+  }
+  for (const other of elements) {
+    if (other.id === candidate.id) continue
+    const { intersectXY } = narrowPhase2D(m, other)
+    if (!intersectXY) continue
+    const o = {
+      ...other,
+      tolerancias: { ...(other.tolerancias || {}), zEpsilon: Z_EPS },
+    }
+    const { overlap } = zOverlapCheck(m, o)
+    if (overlap) {
+      return { valid: false, reason: 'Z_STACKING_COLLISION' }
+    }
+  }
+  return { valid: true }
+}
+
+export default {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+}


### PR DESCRIPTION
## Summary
- add helper for wall placement height validation
- block store mutations when wall placement invalid
- validate and display wall placement errors in element form
- configure eslint for vitest/browser tests and remove implicit globals
- centralize placement checks with orchestrator and z-stacking validator
- guard drag and transform events against invalid wall placement
- add unit and integration tests for new placement guards
- ensure drag/resize revert and notify when exceeding warehouse height
- detect vertical collisions via z-stack validation and show user-friendly errors
- expand tests to cover stacking scenarios and z-overlap edge cases

## Testing
- `node node_modules/vitest/dist/cli.js run src/__tests__/wall-placement-helper.spec.js src/__tests__/element-editor-wall.spec.js src/__tests__/placement-orchestrator.spec.js src/__tests__/placement-guards-integration.spec.js`
- `npm run lint -- --fix`


------
https://chatgpt.com/codex/tasks/task_e_68af5268050883218889c5eb4c4d208b