### PR TITLE
feat: validate wall placement

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,9 @@
+/* eslint-env node */
+module.exports = {
+  overrides: [
+    {
+      files: ["src/__tests__/**/*.spec.js"],
+      env: { vitest: true, browser: true },
+    },
+  ],
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ export default defineConfig([
     files: ['**/*.{js,mjs,jsx,vue}'],
   },
 
-  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
+  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**', '.eslintrc.cjs']),
 
   {
     languageOptions: {
@@ -27,6 +27,16 @@ export default defineConfig([
   {
     ...pluginVitest.configs.recommended,
     files: ['src/**/__tests__/*'],
+  },
+
+  {
+    files: ['src/__tests__/**/*.spec.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.vitest,
+      },
+    },
   },
 
   {

--- a/src/App.vue
+++ b/src/App.vue
@@ -35,6 +35,7 @@
     <!-- Modal de confirmación global -->
     <ConfirmModal />
     <WorkspaceEditor/>
+    <DevSettings v-if="import.meta.env.DEV" />
   </div>
 </template>
 
@@ -51,6 +52,7 @@ import { useCanvasBuffer } from './composables/useCanvasBuffer'
 import { useDeleteElement } from './composables/useDeleteElement'
 import ToastContainer from './components/ToastContainer.vue'
 import ConfirmModal from './components/ConfirmModal.vue'
+import DevSettings from './components/dev/DevSettings.vue'
 
 
 // Composable para undo/redo global

--- a/src/__tests__/delete_element.spec.js
+++ b/src/__tests__/delete_element.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useCanvasStore } from '@/composables/useCanvasStore'
@@ -164,7 +165,7 @@ describe('deleteSelected', () => {
 
     const toasts = { show: vi.fn() }
     // stub toasts
-    global.window.__toasts = toasts
+    globalThis.window.__toasts = toasts
 
     const ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
@@ -186,7 +187,7 @@ describe('deleteSelected', () => {
     history.initializeHistory('pre')
 
     // Primero intenta y bloquea
-    global.window.__toasts = { show: vi.fn() }
+    globalThis.window.__toasts = { show: vi.fn() }
     let ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
 
@@ -220,7 +221,7 @@ describe('deleteSelected', () => {
     const hBefore = history.historySize.value
 
     const toasts = { show: vi.fn() }
-    global.window.__toasts = toasts
+    globalThis.window.__toasts = toasts
 
     const ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
@@ -249,7 +250,7 @@ describe('deleteSelected', () => {
 
     // Stub de toasts para capturar opciones
     const showSpy = vi.fn()
-    global.window.__toasts = { show: showSpy }
+    globalThis.window.__toasts = { show: showSpy }
 
     // Confirmación positiva
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)

--- a/src/__tests__/dev-settings.spec.js
+++ b/src/__tests__/dev-settings.spec.js
@@ -1,0 +1,80 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import usePlacementGuards from '@/composables/usePlacementGuards'
+import { CM_TO_PX } from '@/utils/constants'
+
+class DummyTransform {
+  point(p) {
+    return { x: p.x, y: p.y }
+  }
+  copy() {
+    return new DummyTransform()
+  }
+  invert() {
+    return this
+  }
+}
+class DummyParent {
+  getAbsoluteTransform() {
+    return new DummyTransform()
+  }
+}
+class DummyNode {
+  constructor({ x = 0, y = 0, width = 0, height = 0 } = {}) {
+    this._pos = { x, y }
+    this.width = width
+    this.height = height
+    this._dbf = (p) => p
+    this._parent = new DummyParent()
+    this._events = {}
+  }
+  getParent() {
+    return this._parent
+  }
+  dragBoundFunc(f) {
+    if (typeof f === 'function') this._dbf = f
+    return this._dbf
+  }
+  absolutePosition(p) {
+    if (p) this._pos = { x: p.x, y: p.y }
+    return { ...this._pos }
+  }
+  getAbsolutePosition() {
+    return { ...this._pos }
+  }
+  on(evt, handler) {
+    this._events[evt] = handler
+  }
+  off(evt) {
+    delete this._events[evt]
+  }
+}
+
+describe('dev settings', () => {
+  it('loads flag from localStorage and persists changes', () => {
+    localStorage.setItem('useDragBoundsClamp', 'true')
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    expect(store.useDragBoundsClamp).toBe(true)
+    store.useDragBoundsClamp = false
+    expect(localStorage.getItem('useDragBoundsClamp')).toBe('false')
+  })
+
+  it('installDragBounds activates only when flag true', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({ id: 'el', plantaId: 'planta_1', x: 0, y: 0, width: 10, height: 10 })
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const node = new DummyNode({ x: 0, y: 0, width: 10, height: 10 })
+    const orig = node.dragBoundFunc()
+    guards.installDragBounds(node, 'el')
+    expect(node.dragBoundFunc()).toBe(orig)
+    store.useDragBoundsClamp = true
+    const node2 = new DummyNode({ x: 0, y: 0, width: 10, height: 10 })
+    const orig2 = node2.dragBoundFunc()
+    guards.installDragBounds(node2, 'el')
+    expect(node2.dragBoundFunc()).not.toBe(orig2)
+  })
+})

--- a/src/__tests__/drop-validation.spec.js
+++ b/src/__tests__/drop-validation.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
@@ -67,7 +68,7 @@ vi.mock('@/composables/useConflicts', () => ({
 }))
 
 // Mock del sistema de toast
-global.window = {
+globalThis.window = {
   __toasts: {
     show: vi.fn()
   }

--- a/src/__tests__/element-editor-wall.spec.js
+++ b/src/__tests__/element-editor-wall.spec.js
@@ -1,0 +1,65 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import ElementEditor from '@/components/modals/ElementEditor.vue'
+
+vi.mock('@/composables/useCanvasStore', () => ({
+  useCanvasStore: () => ({
+    plantaActivaData: ref({ dimensiones: { alto: 300 } }),
+  }),
+}))
+
+describe('ElementEditor wall validation', () => {
+  const baseProps = {
+    visible: true,
+    categorias: [{ id: 'cat', nombre: 'Cat' }],
+    formas: [{ id: 'rectangular', nombre: 'Rect' }],
+    ubicaciones: [
+      { id: 'Suelo', nombre: 'Suelo' },
+      { id: 'Pared', nombre: 'Pared' },
+    ],
+  }
+
+  const fillRequired = (wrapper) => {
+    wrapper.vm.localElemento.nombre = 'Elem'
+    wrapper.vm.localElemento.categoria = 'cat'
+    wrapper.vm.localElemento.forma = 'rectangular'
+    wrapper.vm.localElemento.pesoMaximo = 10
+    wrapper.vm.localElemento.dimensiones.ancho = 50
+    wrapper.vm.localElemento.dimensiones.largo = 50
+  }
+
+  it('muestra error si zBase es inválido', async () => {
+    const wrapper = mount(ElementEditor, { props: baseProps })
+    fillRequired(wrapper)
+    wrapper.vm.localElemento.ubicacion = 'Pared'
+    wrapper.vm.localElemento.dimensiones.alto = 100
+    wrapper.vm.localElemento.alturaRespectoAlSuelo = 0
+    await wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('save')).toBeUndefined()
+  })
+
+  it('muestra error si zBase + alto excede alturaBodega', async () => {
+    const wrapper = mount(ElementEditor, { props: baseProps })
+    fillRequired(wrapper)
+    wrapper.vm.localElemento.ubicacion = 'Pared'
+    wrapper.vm.localElemento.dimensiones.alto = 200
+    wrapper.vm.localElemento.alturaRespectoAlSuelo = 150
+    await wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('save')).toBeUndefined()
+  })
+
+  it('emite save cuando zBase + alto es igual a alturaBodega', async () => {
+    const wrapper = mount(ElementEditor, { props: baseProps })
+    fillRequired(wrapper)
+    wrapper.vm.localElemento.ubicacion = 'Pared'
+    wrapper.vm.localElemento.dimensiones.alto = 100
+    wrapper.vm.localElemento.alturaRespectoAlSuelo = 200
+    await wrapper.find('form').trigger('submit.prevent')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('save')).toBeTruthy()
+  })
+})

--- a/src/__tests__/innerNoOverlap.spec.js
+++ b/src/__tests__/innerNoOverlap.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 
@@ -12,7 +13,7 @@ describe('makeInnerSession basic behaviours', () => {
       posicion: { x: 0, y: 0 },
       hijos: [],
     }
-    global.window = { __GRID_SIZE_PX: 1 }
+    globalThis.window = { __GRID_SIZE_PX: 1 }
   })
 
   it('isValidLocal prevents overlap but allows touching', () => {

--- a/src/__tests__/placement-guards-integration.spec.js
+++ b/src/__tests__/placement-guards-integration.spec.js
@@ -1,0 +1,661 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+const showError = vi.fn()
+vi.mock('@/composables/useToast', () => ({ useToast: () => ({ showError }) }))
+import usePlacementGuards from '@/composables/usePlacementGuards'
+import { CM_TO_PX } from '@/utils/constants'
+import { errorsPlacement } from '@/utils/errorsPlacement'
+
+class DummyTransform {
+  point(p) {
+    return { x: p.x, y: p.y }
+  }
+  copy() {
+    return new DummyTransform()
+  }
+  invert() {
+    return this
+  }
+}
+class DummyParent {
+  getAbsoluteTransform() {
+    return new DummyTransform()
+  }
+}
+class DummyNode {
+  constructor({ x = 0, y = 0, width = 0, height = 0 } = {}) {
+    this._pos = { x, y }
+    this.width = width
+    this.height = height
+    this._dbf = (p) => p
+    this._events = {}
+    this._parent = new DummyParent()
+  }
+  getParent() {
+    return this._parent
+  }
+  dragBoundFunc(f) {
+    if (typeof f === 'function') this._dbf = f
+    return this._dbf
+  }
+  absolutePosition(p) {
+    if (p) this._pos = { x: p.x, y: p.y }
+    return { ...this._pos }
+  }
+  getAbsolutePosition() {
+    return { ...this._pos }
+  }
+  on(evt, handler) {
+    this._events[evt] = handler
+  }
+  off(evt) {
+    delete this._events[evt]
+  }
+  fire(evt) {
+    if (this._events[evt]) this._events[evt]()
+  }
+}
+
+describe('placement guards integration', () => {
+  it('drag de elemento Suelo no dispara ZBASE_REQUIRED', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Suelo',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('drag de elemento Pared con zBase válido no dispara error', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 10, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('elemento con alturaRespectoAlSuelo no dispara ZBASE_REQUIRED', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alturaRespectoAlSuelo: 10,
+      alto: 100,
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('elemento con z_base pasa sin errores', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      z_base: 15,
+      alto: 100,
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('candidate sin zBase pero con element.zBase válido pasa', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 10, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    showError.mockClear()
+    const res = guards.onDragEndGuard({
+      ...store.elementos[0],
+      elevacion: { altura: 100 },
+      x: 5,
+      y: 5,
+      start: { x: 0, y: 0 },
+    })
+    expect(res.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('falla cuando zBase <= 0', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 0, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    showError.mockClear()
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 5, y: 5, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(false)
+    expect(res.code).toBe('ZBASE_REQUIRED')
+    expect(spyUpdate).toHaveBeenCalledWith('a', { x: 0, y: 0 })
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.ZBASE_REQUIRED)
+  })
+  it('reviertes y no guardas cuando hay colisión vertical', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 50, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    showError.mockClear()
+    store.elementos[1].x = 0
+    const res = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
+    expect(res.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('b', { x: 20, y: 0 })
+    expect(spySave).not.toHaveBeenCalled()
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACKING_COLLISION)
+  })
+
+  it('reviertes y no guardas si altura excede en drag end', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 250, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 10, y: 10, start: { x: 0, y: 0 } })
+    expect(res.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('a', { x: 0, y: 0 })
+    expect(spySave).not.toHaveBeenCalled()
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.HEIGHT_EXCEEDS_WAREHOUSE)
+  })
+
+  it('permite drag end válido dentro de altura', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 100, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    const res = guards.onDragEndGuard({ ...store.elementos[0], x: 10, y: 10, start: { x: 0, y: 0 } })
+    if (res.valid) {
+      store.saveToHistory('drag end')
+    }
+    expect(spySave).toHaveBeenCalled()
+  })
+
+  it('reviertes resize cuando altura excede', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 250, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    const res = guards.onTransformEndGuard({ ...store.elementos[0], width: 20, height: 20, start: { x: 0, y: 0, width: 10, height: 10 } })
+    expect(res.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('a', { x: 0, y: 0, width: 10, height: 10 })
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.HEIGHT_EXCEEDS_WAREHOUSE)
+  })
+
+  it('permite resize válido dentro de altura', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push({
+      id: 'a',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 100, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 300, CM_TO_PX })
+    const res = guards.onTransformEndGuard({ ...store.elementos[0], width: 20, height: 20, start: { x: 0, y: 0, width: 10, height: 10 } })
+    expect(res.valid).toBe(true)
+  })
+
+  it('apilar estantes permite tocar pero no solapar', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 100, altura: 100 },
+      },
+      {
+        id: 'c',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 40,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 150, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    showError.mockClear()
+    store.elementos[1].x = 0
+    const resB = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
+    if (resB.valid) store.saveToHistory('drag b')
+    expect(resB.valid).toBe(true)
+    expect(spySave).toHaveBeenCalledTimes(1)
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    store.elementos[2].x = 0
+    const resC = guards.onDragEndGuard({ ...store.elementos[2], start: { x: 40, y: 0 } })
+    expect(resC.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('c', { x: 40, y: 0 })
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACKING_COLLISION)
+    expect(spySave).toHaveBeenCalledTimes(1)
+  })
+
+  it('tope en drag entre elementos de pared', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 10, altura: 100 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 10, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    showError.mockClear()
+
+    const moveRes = guards.onDragMoveGuard({ ...store.elementos[1], x: 8, y: 0 })
+    expect(moveRes.reason).toBe('Z_STACK_CONFLICT')
+    expect(moveRes.corrected.x).toBe(10)
+
+    store.elementos[1].x = moveRes.corrected.x
+    const endRes = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
+    if (endRes.valid) store.saveToHistory('drag b')
+    expect(endRes.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+    expect(spySave).toHaveBeenCalledTimes(1)
+
+    store.elementos[1].x = 8
+    const spyUpdate = vi.spyOn(store, 'actualizarElemento')
+    const endResBad = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
+    expect(endResBad.valid).toBe(false)
+    expect(spyUpdate).toHaveBeenCalledWith('b', { x: 20, y: 0 })
+    expect(showError).toHaveBeenCalledWith(errorsPlacement.Z_STACKING_COLLISION)
+    expect(spySave).toHaveBeenCalledTimes(1)
+  })
+
+  it('tope entre pared y suelo', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'floor',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Suelo',
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 20,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'wall',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 40,
+        y: 5,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 50, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    showError.mockClear()
+
+    const moveRes = guards.onDragMoveGuard({ ...store.elementos[1], x: 10, y: 5 })
+    expect(moveRes.reason).toBe('Z_STACK_CONFLICT')
+    expect(moveRes.corrected.x).toBe(20)
+
+    store.elementos[1].x = moveRes.corrected.x
+    const endRes = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 40, y: 0 } })
+    if (endRes.valid) store.saveToHistory('drag wall')
+    expect(endRes.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+    expect(spySave).toHaveBeenCalledTimes(1)
+  })
+
+  it('flag off: no clamp during drag', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'floor',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Suelo',
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 20,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'wall',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 40,
+        y: 5,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 50, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const node = new DummyNode({ x: 40, y: 5, width: 10, height: 10 })
+    guards.installDragBounds(node, 'wall')
+
+    const next = node.dragBoundFunc()({ x: 10, y: 5 })
+    node.absolutePosition(next)
+    expect(node.getAbsolutePosition().x).toBe(10)
+  })
+
+  it('flag on: clamp prevents entering neighbor', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.useDragBoundsClamp = true
+    store.elementos.push(
+      {
+        id: 'floor',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Suelo',
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 20,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'wall',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Pared',
+        x: 40,
+        y: 5,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 50, altura: 100 },
+      },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const node = new DummyNode({ x: 40, y: 5, width: 10, height: 10 })
+    guards.installDragBounds(node, 'wall')
+
+    let next = node.dragBoundFunc()({ x: 10, y: 5 })
+    node.absolutePosition(next)
+    expect(node.getAbsolutePosition().x).toBe(20)
+    next = node.dragBoundFunc()({ x: 10, y: 5 })
+    node.absolutePosition(next)
+    expect(node.getAbsolutePosition().x).toBe(20)
+  })
+
+  it('dragend snaps or reverts when snapping invalid', () => {
+    // Snap inside safe area
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.useDragBoundsClamp = true
+    store.gridSize = 50
+    store.elementos.push({
+      id: 'wall',
+      plantaId: 'planta_1',
+      tipo: 'elementos',
+      ubicacion: 'Suelo',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 0, altura: 100 },
+    })
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const node = new DummyNode({ x: 0, y: 0, width: 10, height: 10 })
+    guards.installDragBounds(node, 'wall')
+    let next = node.dragBoundFunc()({ x: 63, y: 0 })
+    node.absolutePosition(next)
+    showError.mockClear()
+    const resSnap = guards.onDragEndGuard({ ...store.elementos[0], x: node.getAbsolutePosition().x, y: 0, start: { x: 0, y: 0 } })
+    node.fire('dragend')
+    expect(resSnap.valid).toBe(true)
+    expect(store.elementos[0].x).toBe(50)
+    expect(showError).not.toHaveBeenCalled()
+
+    // Snap invalid -> revert
+    setActivePinia(createPinia())
+    const store2 = useCanvasStore()
+    store2.useDragBoundsClamp = true
+    store2.gridSize = 50
+    store2.elementos.push(
+      {
+        id: 'wall',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Suelo',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'neighbor',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        ubicacion: 'Suelo',
+        x: 100,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+    )
+    const guards2 = usePlacementGuards({ store: store2, alturaBodega: 500, CM_TO_PX })
+    const node2 = new DummyNode({ x: 0, y: 0, width: 10, height: 10 })
+    guards2.installDragBounds(node2, 'wall')
+    next = node2.dragBoundFunc()({ x: 96, y: 0 })
+    node2.absolutePosition(next)
+    showError.mockClear()
+    const resRevert = guards2.onDragEndGuard({ ...store2.elementos[0], x: node2.getAbsolutePosition().x, y: 0, start: { x: 0, y: 0 } })
+    node2.fire('dragend')
+    expect(resRevert.valid).toBe(true)
+    expect(store2.elementos[0].x).toBe(0)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('neighbors computed once on dragstart', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.useDragBoundsClamp = true
+    store.elementos.push(
+      { id: 'a', plantaId: 'planta_1', tipo: 'elementos', ubicacion: 'Suelo', x: 0, y: 0, width: 10, height: 10, alto: 100 },
+      { id: 'b', plantaId: 'planta_1', tipo: 'elementos', ubicacion: 'Suelo', x: 40, y: 0, width: 10, height: 10, alto: 100 },
+    )
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const node = new DummyNode({ x: 0, y: 0, width: 10, height: 10 })
+    const spy = vi.spyOn(Array.prototype, 'filter')
+    guards.installDragBounds(node, 'a')
+    const afterInstall = spy.mock.calls.length
+    node.dragBoundFunc()({ x: 5, y: 0 })
+    node.dragBoundFunc()({ x: 6, y: 0 })
+    expect(spy.mock.calls.length).toBe(afterInstall)
+    spy.mockRestore()
+  })
+})

--- a/src/__tests__/placement-guards-integration.spec.js
+++ b/src/__tests__/placement-guards-integration.spec.js
@@ -423,9 +423,8 @@ describe('placement guards integration', () => {
 
     const moveRes = guards.onDragMoveGuard({ ...store.elementos[1], x: 8, y: 0 })
     expect(moveRes.reason).toBe('Z_STACK_CONFLICT')
-    expect(moveRes.corrected.x).toBe(10)
+    expect(store.elementos[1].x).toBe(10)
 
-    store.elementos[1].x = moveRes.corrected.x
     const endRes = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 20, y: 0 } })
     if (endRes.valid) store.saveToHistory('drag b')
     expect(endRes.valid).toBe(true)
@@ -476,9 +475,8 @@ describe('placement guards integration', () => {
 
     const moveRes = guards.onDragMoveGuard({ ...store.elementos[1], x: 10, y: 5 })
     expect(moveRes.reason).toBe('Z_STACK_CONFLICT')
-    expect(moveRes.corrected.x).toBe(20)
+    expect(store.elementos[1].x).toBe(20)
 
-    store.elementos[1].x = moveRes.corrected.x
     const endRes = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 40, y: 0 } })
     if (endRes.valid) store.saveToHistory('drag wall')
     expect(endRes.valid).toBe(true)

--- a/src/__tests__/placement-guards-integration.spec.js
+++ b/src/__tests__/placement-guards-integration.spec.js
@@ -204,6 +204,7 @@ describe('placement guards integration', () => {
       {
         id: 'a',
         plantaId: 'planta_1',
+        typeId: 'rackA',
         tipo: 'elementos',
         ubicacion: 'Pared',
         x: 0,
@@ -216,6 +217,7 @@ describe('placement guards integration', () => {
       {
         id: 'b',
         plantaId: 'planta_1',
+        typeId: 'rackB',
         tipo: 'elementos',
         ubicacion: 'Pared',
         x: 20,
@@ -395,6 +397,7 @@ describe('placement guards integration', () => {
       {
         id: 'a',
         plantaId: 'planta_1',
+        typeId: 'rackA',
         tipo: 'elementos',
         ubicacion: 'Pared',
         x: 0,
@@ -407,6 +410,7 @@ describe('placement guards integration', () => {
       {
         id: 'b',
         plantaId: 'planta_1',
+        typeId: 'rackB',
         tipo: 'elementos',
         ubicacion: 'Pared',
         x: 20,
@@ -479,6 +483,53 @@ describe('placement guards integration', () => {
 
     const endRes = guards.onDragEndGuard({ ...store.elementos[1], start: { x: 40, y: 0 } })
     if (endRes.valid) store.saveToHistory('drag wall')
+    expect(endRes.valid).toBe(true)
+    expect(showError).not.toHaveBeenCalled()
+    expect(spySave).toHaveBeenCalledTimes(1)
+  })
+
+  it('tope entre elementos coplanares del mismo tipo', () => {
+    setActivePinia(createPinia())
+    const store = useCanvasStore()
+    store.elementos.push(
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        typeId: 'rack',
+        ubicacion: 'Pared',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        typeId: 'rack',
+        ubicacion: 'Pared',
+        x: 20,
+        y: 0,
+        width: 10,
+        height: 10,
+        alto: 100,
+        elevacion: { zBase: 0, altura: 100 },
+      },
+    )
+    Object.defineProperty(store, 'elementosVisibles', { value: store.elementos })
+    store.useDragBoundsClamp = true
+    const guards = usePlacementGuards({ store, alturaBodega: 500, CM_TO_PX })
+    const node = new DummyNode({ x: 20, y: 0, width: 10, height: 10 })
+    guards.installDragBounds(node, 'b')
+    const next = node.dragBoundFunc()({ x: 8, y: 0 })
+    expect(next.x).toBe(10)
+    node.absolutePosition(next)
+    const spySave = vi.spyOn(store, 'saveToHistory')
+    showError.mockClear()
+    const endRes = guards.onDragEndGuard({ ...store.elementos[1], x: node.getAbsolutePosition().x, y: 0, start: { x: 20, y: 0 } })
+    node.fire('dragend')
+    if (endRes.valid) store.saveToHistory('drag b')
     expect(endRes.valid).toBe(true)
     expect(showError).not.toHaveBeenCalled()
     expect(spySave).toHaveBeenCalledTimes(1)
@@ -615,6 +666,7 @@ describe('placement guards integration', () => {
       {
         id: 'neighbor',
         plantaId: 'planta_1',
+        typeId: 'neighbor',
         tipo: 'elementos',
         ubicacion: 'Suelo',
         x: 100,
@@ -625,6 +677,7 @@ describe('placement guards integration', () => {
         elevacion: { zBase: 0, altura: 100 },
       },
     )
+    Object.defineProperty(store2, 'elementosVisibles', { value: store2.elementos })
     const guards2 = usePlacementGuards({ store: store2, alturaBodega: 500, CM_TO_PX })
     const node2 = new DummyNode({ x: 0, y: 0, width: 10, height: 10 })
     guards2.installDragBounds(node2, 'wall')

--- a/src/__tests__/placement-orchestrator.spec.js
+++ b/src/__tests__/placement-orchestrator.spec.js
@@ -1,0 +1,124 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect } from 'vitest'
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+} from '@/validation/placementOrchestrator'
+import { resolveVerticalProps } from '@/validation/fieldResolvers'
+
+describe('validateWallZBaseRequired', () => {
+  it('rechaza zBase faltante o <=0', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'Pared', zBase: 0 }, {})
+    expect(res.valid).toBe(false)
+    expect(res.code).toBe('ZBASE_REQUIRED')
+  })
+
+  it('acepta zBase mayor a 0', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'Pared', zBase: 10 }, {})
+    expect(res.valid).toBe(true)
+  })
+})
+
+describe('validateHeightWithinWarehouse', () => {
+  const ALTURA = 300
+  it('rechaza cuando excede altura de bodega', () => {
+    const res = validateHeightWithinWarehouse({ ubicacion: 'Pared', zBase: 250, alto: 100 }, {}, ALTURA)
+    expect(res.valid).toBe(false)
+    expect(res.code).toBe('HEIGHT_EXCEEDS_WAREHOUSE')
+  })
+
+  it('permite cuando zBase + alto es igual a alturaBodega', () => {
+    const res = validateHeightWithinWarehouse({ ubicacion: 'Pared', zBase: 200, alto: 100 }, {}, ALTURA)
+    expect(res.valid).toBe(true)
+  })
+})
+
+describe('validateZStacking', () => {
+  const base = {
+    id: 'a',
+    ubicacion: 'Pared',
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    alto: 100,
+    elevacion: { zBase: 0, altura: 100 },
+  }
+
+  it('detecta solape en Z', () => {
+    const cand = {
+      id: 'b',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 50, altura: 100 },
+    }
+    const res = validateZStacking([base], cand, { minX: 0, minY: 0, maxX: 100, maxY: 100 })
+    expect(res.valid).toBe(false)
+    expect(res.code).toBe('Z_STACKING_COLLISION')
+  })
+
+  it('permite tocar en Z', () => {
+    const cand = {
+      id: 'b',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 100, altura: 100 },
+    }
+    const res = validateZStacking([base], cand, { minX: 0, minY: 0, maxX: 100, maxY: 100 })
+    expect(res.valid).toBe(true)
+  })
+
+  it('permite alturas separadas', () => {
+    const cand = {
+      id: 'b',
+      ubicacion: 'Pared',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 50,
+      elevacion: { zBase: 200, altura: 50 },
+    }
+    const res = validateZStacking([base], cand, { minX: 0, minY: 0, maxX: 100, maxY: 100 })
+    expect(res.valid).toBe(true)
+  })
+
+  it('clamp corrige posición al borde no conflictivo', () => {
+    const cand = {
+      id: 'b',
+      ubicacion: 'Pared',
+      x: 8,
+      y: 0,
+      width: 10,
+      height: 10,
+      alto: 100,
+      elevacion: { zBase: 0, altura: 100 },
+    }
+    const res = validateZStacking([base], cand, { minX: 0, minY: 0, maxX: 100, maxY: 100 })
+    expect(res.valid).toBe(false)
+    expect(res.reason).toBe('Z_STACK_CONFLICT')
+    expect(res.corrected.x).toBe(10)
+    expect(res.corrected.y).toBe(0)
+  })
+})
+
+describe('resolveVerticalProps', () => {
+  it('coalesce y parsea strings numéricos', () => {
+    const res = resolveVerticalProps(
+      { ubicacion: 'Pared', alturaRespectoAlSuelo: '120', altura: '80' },
+      { alto: '80' }
+    )
+    expect(res.ubic).toBe('Pared')
+    expect(res.zBaseCm).toBe(120)
+    expect(res.altoCm).toBe(80)
+  })
+})

--- a/src/__tests__/placement-orchestrator.spec.js
+++ b/src/__tests__/placement-orchestrator.spec.js
@@ -4,6 +4,7 @@ import {
   validateWallZBaseRequired,
   validateHeightWithinWarehouse,
   validateZStacking,
+  validateCoplanarSameTypeNoOverlap,
 } from '@/validation/placementOrchestrator'
 import { resolveVerticalProps } from '@/validation/fieldResolvers'
 
@@ -16,6 +17,46 @@ describe('validateWallZBaseRequired', () => {
 
   it('acepta zBase mayor a 0', () => {
     const res = validateWallZBaseRequired({ ubicacion: 'Pared', zBase: 10 }, {})
+    expect(res.valid).toBe(true)
+  })
+})
+
+describe('validateCoplanarSameTypeNoOverlap', () => {
+  const base = {
+    id: 'a',
+    typeId: 'rack',
+    ubicacion: 'Pared',
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    elevacion: { zBase: 0, altura: 100 },
+  }
+  const neighbor = {
+    id: 'b',
+    typeId: 'rack',
+    ubicacion: 'Pared',
+    x: 20,
+    y: 0,
+    width: 10,
+    height: 10,
+    elevacion: { zBase: 0, altura: 100 },
+  }
+  it('detecta solape entre coplanares del mismo tipo', () => {
+    const cand = { ...base, id: 'c', x: 5 }
+    const res = validateCoplanarSameTypeNoOverlap([base], base, cand)
+    expect(res.valid).toBe(false)
+    expect(res.code).toBe('COPLANAR_SAME_TYPE_OVERLAP')
+  })
+  it('permite tocar sin solape', () => {
+    const cand = { ...base, id: 'c', x: 10 }
+    const res = validateCoplanarSameTypeNoOverlap([base], base, cand)
+    expect(res.valid).toBe(true)
+  })
+  it('ignora tipos distintos', () => {
+    const other = { ...base, id: 'd', typeId: 'other' }
+    const cand = { ...base, id: 'c', x: 5 }
+    const res = validateCoplanarSameTypeNoOverlap([other], base, cand)
     expect(res.valid).toBe(true)
   })
 })

--- a/src/__tests__/test-setup.js
+++ b/src/__tests__/test-setup.js
@@ -1,3 +1,4 @@
+/* eslint-env vitest, jsdom */
 import { vi } from 'vitest'
 
 // Stub vue-konva components globally
@@ -26,7 +27,7 @@ class ResizeObserver {
   disconnect() {}
 }
 // @ts-ignore
-if (typeof global !== 'undefined') {
+if (typeof globalThis !== 'undefined') {
   // @ts-ignore
-  global.ResizeObserver = ResizeObserver
+  globalThis.ResizeObserver = ResizeObserver
 }

--- a/src/__tests__/test-setup.js
+++ b/src/__tests__/test-setup.js
@@ -20,6 +20,11 @@ config.global.stubs = {
   'rulers-overlay': true
 }
 
+import { beforeEach } from 'vitest'
+beforeEach(() => {
+  localStorage.clear()
+})
+
 // Polyfill ResizeObserver for jsdom
 class ResizeObserver {
   observe() {}

--- a/src/__tests__/wall-placement-helper.spec.js
+++ b/src/__tests__/wall-placement-helper.spec.js
@@ -1,0 +1,22 @@
+/* eslint-env vitest, jsdom */
+import { describe, it, expect } from 'vitest'
+import { validateWallPlacement } from '@/utils/placementValidity'
+
+const ALTURA_BODEGA = 300
+
+describe('validateWallPlacement', () => {
+  it('requiere zBase mayor a 0', () => {
+    const res = validateWallPlacement({ zBase: 0, alto: 50, alturaBodega: ALTURA_BODEGA })
+    expect(res.valido).toBe(false)
+  })
+
+  it('detecta exceder altura de bodega', () => {
+    const res = validateWallPlacement({ zBase: 250, alto: 100, alturaBodega: ALTURA_BODEGA })
+    expect(res.valido).toBe(false)
+  })
+
+  it('permite cuando zBase + alto es igual a alturaBodega', () => {
+    const res = validateWallPlacement({ zBase: 200, alto: 100, alturaBodega: ALTURA_BODEGA })
+    expect(res.valido).toBe(true)
+  })
+})

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -1788,7 +1788,6 @@ const onShapeDragStart = (e, el) => {
 }
 
 const onShapeDragMove = (e, el) => {
-  onDragMoveGuard(el)
   const data = innerSessions.get(el.id)
   if (data) {
     const { session, parent } = data
@@ -1805,8 +1804,10 @@ const onShapeDragMove = (e, el) => {
     shape.position(session.toWorld(nextLocal, parent))
     needsDraw = true
     scheduleDraw()
+    onDragMoveGuard(el)
   } else {
     updateElementPosition(e, el.id, el.forma === 'circular' ? 'circular' : 'rectangular')
+    onDragMoveGuard(canvasStore.elementoPorId(el.id))
   }
 }
 

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -191,7 +191,6 @@
               shadowColor: getElementShadow(elemento).color,
               shadowBlur: getElementShadow(elemento).blur / canvasStore.zoom,
               shadowOpacity: getElementShadow(elemento).opacity,
-              dragBoundFunc: (pos) => dragBoundForElement(pos, elemento, 'rect'),
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
@@ -261,7 +260,6 @@
               shadowColor: getElementShadow(elemento).color,
               shadowBlur: getElementShadow(elemento).blur / canvasStore.zoom,
               shadowOpacity: getElementShadow(elemento).opacity,
-              dragBoundFunc: (pos) => dragBoundForElement(pos, elemento, 'circle'),
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
@@ -294,7 +292,6 @@
               shadowColor: 'black',
               shadowBlur: 4,
               shadowOpacity: 0.3,
-              dragBoundFunc: (pos) => dragBoundForElement(pos, elemento, 'rect'),
             }"
             @click="() => selectElement(elemento.id)"
             @dblclick="() => handleElementDoubleClick(elemento)"
@@ -568,6 +565,7 @@ import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
 import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 import FloatingToolbar from './FloatingToolbar.vue'
+import usePlacementGuards from '@/composables/usePlacementGuards'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -609,6 +607,12 @@ const { visible: ctxVisible, x: ctxX, y: ctxY, isLocked: ctxIsLocked, elementId:
 const { deleteSelected } = useDeleteElement()
 const confirmDialog = useConfirmDialog()
 const weightValidation = useWeightValidation()
+
+const { onDragMoveGuard, onDragEndGuard, onTransformEndGuard, installDragBounds } = usePlacementGuards({
+  store: canvasStore,
+  alturaBodega: canvasStore.plantaActivaData.value?.dimensiones?.alto || Infinity,
+  CM_TO_PX,
+})
 
 // === HELPERS DE CONVERSIÓN ===
 /**
@@ -949,53 +953,6 @@ const lastVelocityMap = ref(new Map())
 const getStrokeColor = (elementId) => {
   if (atEdgeMap.value.get(elementId)) return '#f59e0b' // advertencia en borde
   return canvasStore.elementoSeleccionado === elementId ? '#000' : '#666'
-}
-
-// Convierte posición stage->layer considerando zoom/pan
-
-const toLayerCoords = (pos) => {
-  const stage = stageRef.value.getNode()
-  const scale = stage.scaleX() || 1
-  const x = (pos.x - stage.x()) / scale
-  const y = (pos.y - stage.y()) / scale
-  return { x, y }
-}
-
-// Convierte posición layer->stage considerando zoom/pan
-
-const toStageCoords = (pos) => {
-  const stage = stageRef.value.getNode()
-  const scale = stage.scaleX() || 1
-  return { x: pos.x * scale + stage.x(), y: pos.y * scale + stage.y() }
-}
-
-// Drag bound para cada elemento y forma (clamp mínimo al contorno)
-const dragBoundForElement = (pos, elemento, forma = 'rect') => {
-  try {
-    const layerW = layerConfig.value.width
-    const layerH = layerConfig.value.height
-    const lp = toLayerCoords(pos)
-    const boundary = computeBoundary()
-    if (forma === 'circular' || forma === 'circle') {
-      const r = Math.min(elemento.width, elemento.height) / 2
-      const cx = Math.max(r, Math.min(lp.x, layerW - r))
-      const cy = Math.max(r, Math.min(lp.y, layerH - r))
-      return toStageCoords({ x: cx, y: cy })
-    } else {
-      if (boundary.type === 'polygon') {
-        const c = clampRectToPolygon(
-          { x: lp.x, y: lp.y, width: elemento.width, height: elemento.height },
-          boundary.inset,
-        )
-        return toStageCoords(c)
-      } else {
-        const c = clampRectToRect(lp.x, lp.y, elemento.width, elemento.height, layerW, layerH)
-        return toStageCoords(c)
-      }
-    }
-  } catch {
-    return pos
-  }
 }
 
 // RAF + Perf mode state per element
@@ -1825,11 +1782,13 @@ const onShapeDragStart = (e, el) => {
     isElementDragging.value = true
     stageDragEnabled.value = false
   } else {
+    installDragBounds(e.target, el.id)
     startElementDrag(el.id)
   }
 }
 
 const onShapeDragMove = (e, el) => {
+  onDragMoveGuard(el)
   const data = innerSessions.get(el.id)
   if (data) {
     const { session, parent } = data
@@ -1861,23 +1820,34 @@ const onShapeDragEnd = (e, el) => {
     const shape = e.target
     let candLocal = session.toLocal(shape.position(), parent)
     let finalLocal = session.finalizeLocal(candLocal)
-    const finalWorld = session.toWorld(finalLocal, parent)
-    shape.position(finalWorld)
-    needsDraw = true
-    scheduleDraw()
-    const changed =
-      Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
-    if (changed) {
-      canvasStore.actualizarElementoConHistorial(
-        el.id,
-        { posicion: { x: finalWorld.x, y: finalWorld.y }, x: finalWorld.x, y: finalWorld.y },
-        `Elemento movido: ${el.id}`,
-      )
+      const finalWorld = session.toWorld(finalLocal, parent)
+      shape.position(finalWorld)
+      needsDraw = true
+      scheduleDraw()
+      const guardRes = onDragEndGuard({ ...el, x: finalWorld.x, y: finalWorld.y, start: initial })
+      if (!guardRes.valid && guardRes.corrected) {
+        shape.position(guardRes.corrected)
+        needsDraw = true
+        scheduleDraw()
+      }
+      if (guardRes.valid) {
+        const changed =
+          Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
+        if (changed) {
+          canvasStore.actualizarElementoConHistorial(
+            el.id,
+            { posicion: { x: finalWorld.x, y: finalWorld.y }, x: finalWorld.x, y: finalWorld.y },
+            `Elemento movido: ${el.id}`,
+          )
+        }
+      }
+    } else {
+      const guardRes = onDragEndGuard(el)
+      if (guardRes.valid) {
+        endElementDrag(el.id)
+      }
     }
-  } else {
-    endElementDrag(el.id)
   }
-}
 
 const getElementShadow = (elemento) => {
   if (canvasStore.elementoDestacadoId === elemento.id) {
@@ -2253,14 +2223,16 @@ const handleTransformEnd = (e, elementId, forma) => {
     if (!elemento) return
 
     // Validar con isPlacementValid contra vecinos y área
-    const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)
-    const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
-    const isValidNow = isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+      const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)
+      const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
+      const isValidNow = isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+      const prev = transformInitialState.get(elementId) || { x: elemento.x, y: elemento.y, width: elemento.width, height: elemento.height, rotation: elemento.rotation }
+      const guardRes = onTransformEndGuard({ ...elemento, x, y, width, height, start: prev })
 
   console.debug('[transform-debug] end', elementId, { prev: transformInitialState.get(elementId), new: { x, y, width, height, rotation }, isValidNow })
-  if (!isValidNow) {
+    if (!isValidNow || !guardRes.valid) {
       // Revertir al estado inicial guardado
-      const prev = transformInitialState.get(elementId) || { x: elemento.x, y: elemento.y, width: elemento.width, height: elemento.height }
+      const prev = transformInitialState.get(elementId) || { x: elemento.x, y: elemento.y, width: elemento.width, height: elemento.height, rotation: elemento.rotation }
       try {
         if (forma === 'circular') {
           const r = Math.min(prev.width, prev.height) / 2

--- a/src/components/dev/DevSettings.vue
+++ b/src/components/dev/DevSettings.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="dev-settings fixed top-2 right-2 z-50 text-xs">
+    <button class="dev-btn" @click="open = !open">⚙️ dev</button>
+    <div
+      v-if="open"
+      class="panel mt-1 bg-white border border-gray-300 rounded p-2 shadow"
+    >
+      <label class="flex items-center gap-2">
+        <input type="checkbox" v-model="useDragBoundsClamp" />
+        Tope duro en drag (clamp)
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import { storeToRefs } from 'pinia'
+
+const open = ref(false)
+const store = useCanvasStore()
+const { useDragBoundsClamp } = storeToRefs(store)
+</script>
+
+<style scoped>
+.dev-btn {
+  background: #e5e7eb;
+  border: 1px solid #d1d5db;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+</style>

--- a/src/components/modals/ElementEditor.vue
+++ b/src/components/modals/ElementEditor.vue
@@ -83,7 +83,7 @@
             </div>
 
             <!-- Altura respecto al suelo (solo para elementos de pared) -->
-            <div v-if="localElemento.ubicacion === 'pared'" class="mb-6">
+            <div v-if="localElemento.ubicacion === 'Pared'" class="mb-6">
               <h3 class="text-lg font-medium text-gray-800 mb-3">Posicionamiento en Pared</h3>
               <div class="mb-2">
                 <label class="block text-sm font-medium text-gray-700"
@@ -98,6 +98,9 @@
                 />
                 <p class="text-xs text-gray-500 mt-1">
                   Distancia desde el suelo hasta la base del elemento
+                </p>
+                <p v-if="errorAlturaPared" class="text-sm text-red-600 mt-1">
+                  {{ errorAlturaPared }}
                 </p>
               </div>
             </div>
@@ -193,7 +196,7 @@
                     localElemento.forma === 'circular' ? 'w-10 h-10' : 'w-12 h-8',
                     'rounded flex items-center justify-center relative shadow-sm border border-white/20',
                     `shape-${localElemento.forma}`,
-                    localElemento.ubicacion === 'pared' ? 'wall-mounted' : '',
+                    localElemento.ubicacion === 'Pared' ? 'wall-mounted' : '',
                   ]"
                   :style="{ backgroundColor: localElemento.colorBase || '#6b7280' }"
                 >
@@ -235,6 +238,8 @@
 <script setup>
 import { ref, watch, computed } from 'vue'
 import { useWeightValidation } from '@/composables/useWeightValidation'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import { validateWallPlacement } from '@/utils/placementValidity'
 
 const props = defineProps({
   visible: Boolean,
@@ -246,6 +251,7 @@ const props = defineProps({
 const emit = defineEmits(['cancel', 'save'])
 
 const weightValidation = useWeightValidation()
+const canvasStore = useCanvasStore()
 
 const esFormaCircular = computed(() => localElemento.value.forma === 'circular')
 
@@ -295,12 +301,14 @@ const localElemento = ref({
   colorBase: '#3b82f6',
   dimensiones: { ancho: 100, largo: 100, alto: 75 },
   pesoMaximo: 50,
-  ubicacion: 'suelo',
+  ubicacion: 'Suelo',
   alturaRespectoAlSuelo: 0,
   descripcion: '',
   icono: 'box',
   contenedores: [],
 })
+
+const errorAlturaPared = ref('')
 
 watch(
   () => props.value,
@@ -333,6 +341,17 @@ watch(
   },
 )
 
+watch(
+  () => [
+    localElemento.value.alturaRespectoAlSuelo,
+    localElemento.value.dimensiones.alto,
+    localElemento.value.ubicacion,
+  ],
+  () => {
+    errorAlturaPared.value = ''
+  },
+)
+
 // Restablecer el formulario cuando el modal se abre
 watch(
   () => props.visible,
@@ -353,12 +372,13 @@ const restablecerFormulario = () => {
     colorBase: '#3b82f6',
     dimensiones: { ancho: 100, largo: 100, alto: 75 },
     pesoMaximo: 50,
-    ubicacion: 'suelo',
+    ubicacion: 'Suelo',
     alturaRespectoAlSuelo: 0,
     descripcion: '',
     icono: 'box',
-    contenedores: [],
+  contenedores: [],
   }
+  errorAlturaPared.value = ''
 }
 
 const onCancel = () => {
@@ -368,6 +388,7 @@ const onCancel = () => {
 
 const validarFormulario = () => {
   const elemento = localElemento.value
+  errorAlturaPared.value = ''
   if (!elemento.nombre.trim()) {
     alert('El nombre es requerido')
     return false
@@ -395,6 +416,18 @@ const validarFormulario = () => {
   if (elemento.pesoMaximo <= 0) {
     alert('La capacidad de carga debe ser mayor a 0')
     return false
+  }
+  if (elemento.ubicacion === 'Pared') {
+    const alturaBodega = canvasStore.plantaActivaData.value?.dimensiones?.alto || Infinity
+    const { valido, mensaje } = validateWallPlacement({
+      zBase: elemento.alturaRespectoAlSuelo,
+      alto: elemento.dimensiones.alto,
+      alturaBodega
+    })
+    if (!valido) {
+      errorAlturaPared.value = mensaje
+      return false
+    }
   }
   return true
 }

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -17,6 +17,9 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
+import { validateWallPlacement } from '@/utils/placementValidity'
+import { validateZStacking } from '@/validation/placementOrchestrator'
+import { errorsPlacement } from '@/utils/errorsPlacement'
 
 // Variable para evitar circular import - será inicializada por el composable de historial
 let historyComposable = null
@@ -94,6 +97,7 @@ export const useCanvasStore = defineStore('canvas', () => {
   // Configuración de grilla y snap
   const gridSize = ref(50) // px entre líneas de grilla
   const snapGridEps = ref(6) // px de proximidad para aplicar snap al soltar
+  const useDragBoundsClamp = ref(false) // experimental drag clamping
 
   const setGridSize = (sizePx) => {
     const s = Number(sizePx)
@@ -588,14 +592,63 @@ export const useCanvasStore = defineStore('canvas', () => {
   const actualizarElemento = (elementoId, propiedades) => {
     const elemento = elementos.value.find((el) => el.id === elementoId)
     if (elemento) {
+      const ubicacionFinal = propiedades.ubicacion || elemento.ubicacion
+      const zBaseFinal =
+        propiedades.alturaRespectoAlSuelo ??
+        propiedades.elevacion?.zBase ??
+        elemento.alturaRespectoAlSuelo ??
+        elemento.elevacion?.zBase
+      const altoFinal =
+        propiedades.dimensiones?.alto ??
+        elemento.dimensiones?.alto ??
+        elemento.alto ?? 0
+
+      if (ubicacionFinal === 'pared') {
+        const alturaBodega = plantaActivaData.value?.dimensiones?.alto || Infinity
+        const { valido, mensaje } = validateWallPlacement({
+          zBase: zBaseFinal,
+          alto: altoFinal,
+          alturaBodega
+        })
+        if (!valido) {
+          console.error(mensaje)
+          return false
+        }
+      }
+
+      const candidate = {
+        ...elemento,
+        ...propiedades,
+        ubicacion: ubicacionFinal,
+        x: propiedades.x ?? elemento.x,
+        y: propiedades.y ?? elemento.y,
+        width: propiedades.width ?? elemento.width,
+        height: propiedades.height ?? elemento.height,
+        elevacion: {
+          ...(elemento.elevacion || {}),
+          ...(propiedades.elevacion || {}),
+          zBase: zBaseFinal,
+          altura: altoFinal,
+        },
+      }
+      const stackRes = validateZStacking(elementos.value, candidate)
+      if (!stackRes.valid) {
+        console.error(errorsPlacement[stackRes.code || stackRes.reason] || stackRes.code || stackRes.reason)
+        return false
+      }
+
       for (const key in propiedades) {
-        if (typeof propiedades[key] === 'object' && propiedades[key] !== null && !Array.isArray(propiedades[key])) {
+        if (
+          typeof propiedades[key] === 'object' &&
+          propiedades[key] !== null &&
+          !Array.isArray(propiedades[key])
+        ) {
           // Si la propiedad es un objeto (como 'dimensiones'), la fusionamos recursivamente.
           if (!elemento[key]) elemento[key] = {}
-          Object.assign(elemento[key], propiedades[key]);
+          Object.assign(elemento[key], propiedades[key])
         } else {
           // Si es un valor simple, lo asignamos directamente.
-          elemento[key] = propiedades[key];
+          elemento[key] = propiedades[key]
         }
       }
 
@@ -621,7 +674,9 @@ export const useCanvasStore = defineStore('canvas', () => {
           // Nota: largo no afecta a width/height en vista XZ
         }
       }
+      return true
     }
+    return false
   }
 
   const configurarZoom = (nuevoZoom) => {
@@ -711,6 +766,25 @@ export const useCanvasStore = defineStore('canvas', () => {
     // Validar tipo de elemento
     if (!nuevoElemento.tipo) {
       console.error('El elemento debe tener un tipo definido')
+      return null
+    }
+
+    // Validación específica para elementos ubicados en pared
+    if (nuevoElemento.ubicacion === 'pared') {
+      const alturaBodega = plantaActivaData.value?.dimensiones?.alto || Infinity
+      const { valido, mensaje } = validateWallPlacement({
+        zBase: nuevoElemento.alturaRespectoAlSuelo ?? nuevoElemento.elevacion?.zBase,
+        alto: nuevoElemento.dimensiones?.alto ?? nuevoElemento.alto ?? 0,
+        alturaBodega
+      })
+      if (!valido) {
+        console.error(mensaje)
+        return null
+      }
+    }
+    const stackRes = validateZStacking(elementos.value, nuevoElemento)
+    if (!stackRes.valid) {
+      console.error(errorsPlacement[stackRes.code || stackRes.reason] || stackRes.code || stackRes.reason)
       return null
     }
 
@@ -1460,6 +1534,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     panY,
     gridSize,
     snapGridEps,
+    useDragBoundsClamp,
     crearPlanta,
     plantaEnEdicion,
     etiquetas,

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -18,7 +18,10 @@ import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
 import { validateWallPlacement } from '@/utils/placementValidity'
-import { validateZStacking } from '@/validation/placementOrchestrator'
+import {
+  validateZStacking,
+  validateCoplanarSameTypeNoOverlap,
+} from '@/validation/placementOrchestrator'
 import { errorsPlacement } from '@/utils/errorsPlacement'
 
 // Variable para evitar circular import - será inicializada por el composable de historial
@@ -643,6 +646,11 @@ export const useCanvasStore = defineStore('canvas', () => {
           altura: altoFinal,
         },
       }
+      const copRes = validateCoplanarSameTypeNoOverlap(elementos.value, elemento, candidate)
+      if (!copRes.valid) {
+        console.error(errorsPlacement[copRes.code] || copRes.code)
+        return false
+      }
       const stackRes = validateZStacking(elementos.value, candidate)
       if (!stackRes.valid) {
         console.error(errorsPlacement[stackRes.code || stackRes.reason] || stackRes.code || stackRes.reason)
@@ -793,6 +801,11 @@ export const useCanvasStore = defineStore('canvas', () => {
         console.error(mensaje)
         return null
       }
+    }
+    const copRes = validateCoplanarSameTypeNoOverlap(elementos.value, nuevoElemento, nuevoElemento)
+    if (!copRes.valid) {
+      console.error(errorsPlacement[copRes.code] || copRes.code)
+      return null
     }
     const stackRes = validateZStacking(elementos.value, nuevoElemento)
     if (!stackRes.valid) {

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -99,6 +99,18 @@ export const useCanvasStore = defineStore('canvas', () => {
   const snapGridEps = ref(6) // px de proximidad para aplicar snap al soltar
   const useDragBoundsClamp = ref(false) // experimental drag clamping
 
+  if (typeof window !== 'undefined') {
+    const persisted = window.localStorage.getItem('useDragBoundsClamp')
+    if (persisted !== null) {
+      useDragBoundsClamp.value = persisted === 'true'
+    }
+    watch(
+      useDragBoundsClamp,
+      (v) => window.localStorage.setItem('useDragBoundsClamp', v ? 'true' : 'false'),
+      { flush: 'sync' },
+    )
+  }
+
   const setGridSize = (sizePx) => {
     const s = Number(sizePx)
     if (!Number.isFinite(s)) return

--- a/src/composables/useDimensionValidation.js
+++ b/src/composables/useDimensionValidation.js
@@ -1,9 +1,7 @@
 import { useCanvasStore } from '@/composables/useCanvasStore'
 import { useToast } from '@/composables/useToast'
 import { detectConflictsFor } from '@/utils/collision'
-
-// Constante de conversión: 1cm = 10px
-const CM_TO_PX = 10
+import { CM_TO_PX } from '@/utils/constants'
 
 /**
  * Composable para validar dimensiones físicas de elementos

--- a/src/composables/usePerfMode.js
+++ b/src/composables/usePerfMode.js
@@ -25,7 +25,9 @@ export function enablePerfMode(layer, opts = {}) {
         strokeWidth: 1,
       })
     }
-  } catch (_) {}
+  } catch (_) {
+    // ignore errors from perf mode optimizations
+  }
 
   return {
     restore: () => disablePerfMode(layer, { shape, prev }),
@@ -52,5 +54,7 @@ export function disablePerfMode(layer, ctx = {}) {
       if (prev.shapeStrokeWidth !== undefined) attrs.strokeWidth = prev.shapeStrokeWidth
       shape.setAttrs(attrs)
     }
-  } catch (_) {}
+  } catch (_) {
+    // ignore errors when restoring perf mode
+  }
 }

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -99,6 +99,11 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
   const onDragMoveGuard = (el) => {
     const neighbors = store.useDragBoundsClamp ? neighborsCache.get(el.id) : undefined
     const res = runPipeline(el, undefined, neighbors)
+    if (!res.valid && res.reason === 'Z_STACK_CONFLICT' && res.corrected) {
+      store.actualizarElemento(el.id, res.corrected)
+      el.x = res.corrected.x
+      el.y = res.corrected.y
+    }
     el.invalidPlacement = !res.valid
     return res
   }

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -1,8 +1,10 @@
 import {
   validateWallZBaseRequired,
   validateHeightWithinWarehouse,
+  validateCoplanarSameTypeNoOverlap,
   validateZStacking,
   resolveZStackClamp,
+  resolveCoplanarClamp,
 } from '@/validation/placementOrchestrator'
 import { useToast } from '@/composables/useToast'
 import { errorsPlacement } from '@/utils/errorsPlacement'
@@ -79,6 +81,20 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
     const { boundsPx } = getActiveBounds(store)
     const areaBounds = { minX: 0, minY: 0, maxX: boundsPx.width, maxY: boundsPx.height }
     const neighbors = neighborsOverride || store.elementosVisibles
+    const resCop = validateCoplanarSameTypeNoOverlap(neighbors, base, cand)
+    if (!resCop.valid) {
+      if (start) {
+        const { x, y, width, height } = start
+        const payload = {}
+        if (x !== undefined) payload.x = x
+        if (y !== undefined) payload.y = y
+        if (width !== undefined) payload.width = width
+        if (height !== undefined) payload.height = height
+        store.actualizarElemento(candidate.id, payload)
+      }
+      const clamp = resolveCoplanarClamp(cand, neighbors)
+      return { ...resCop, reason: 'COPLANAR_SAME_TYPE_OVERLAP', corrected: clamp.corrected, candidate: cand }
+    }
     const resStack = validateZStacking(neighbors, cand, areaBounds)
     if (!resStack.valid) {
       if (start) {
@@ -99,10 +115,12 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
   const onDragMoveGuard = (el) => {
     const neighbors = store.useDragBoundsClamp ? neighborsCache.get(el.id) : undefined
     const res = runPipeline(el, undefined, neighbors)
-    if (!res.valid && res.reason === 'Z_STACK_CONFLICT' && res.corrected) {
-      store.actualizarElemento(el.id, res.corrected)
-      el.x = res.corrected.x
-      el.y = res.corrected.y
+    if (!res.valid && res.corrected) {
+      if (res.reason === 'COPLANAR_SAME_TYPE_OVERLAP' || res.reason === 'Z_STACK_CONFLICT') {
+        store.actualizarElemento(el.id, res.corrected)
+        el.x = res.corrected.x
+        el.y = res.corrected.y
+      }
     }
     el.invalidPlacement = !res.valid
     return res
@@ -125,12 +143,19 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
         areaBounds,
         grid,
       )
-      const snapRes = resolveZStackClamp({ ...base, x: snapped.x, y: snapped.y }, neighbors, areaBounds)
+      let x = snapped.x
+      let y = snapped.y
+      const copRes = resolveCoplanarClamp({ ...base, x, y }, neighbors)
+      if (copRes.collided) {
+        x = copRes.corrected.x
+        y = copRes.corrected.y
+      }
+      const snapRes = resolveZStackClamp({ ...base, x, y }, neighbors, areaBounds)
       if (!snapRes.collided) {
-        if (snapped.x !== candidate.x || snapped.y !== candidate.y) {
-          store.actualizarElemento(id, { x: snapped.x, y: snapped.y })
-          candidate.x = snapped.x
-          candidate.y = snapped.y
+        if (x !== candidate.x || y !== candidate.y) {
+          store.actualizarElemento(id, { x, y })
+          candidate.x = x
+          candidate.y = y
         }
       } else {
         const last = lastGoodPos.get(id)
@@ -175,6 +200,11 @@ export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
       const cArea = clampToAreaFast(abs.x, abs.y, base.width, base.height, areaFast)
       let x = cArea.x
       let y = cArea.y
+      const copRes = resolveCoplanarClamp({ ...base, x, y }, neighbors)
+      if (copRes.collided && copRes.corrected) {
+        x = copRes.corrected.x
+        y = copRes.corrected.y
+      }
       const res = resolveZStackClamp({ ...base, x, y }, neighbors, areaBounds)
       if (res.collided && res.corrected) {
         x = res.corrected.x

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -1,0 +1,194 @@
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+  resolveZStackClamp,
+} from '@/validation/placementOrchestrator'
+import { useToast } from '@/composables/useToast'
+import { errorsPlacement } from '@/utils/errorsPlacement'
+import { getActiveBounds } from '@/utils/activeBounds'
+import { finalizeRectClampSnapReclamp } from '@/utils/edgeConstraint'
+import { clampToAreaFast } from '@/utils/dragMath'
+
+function hydrateCandidate(element, partial) {
+  const ubicacion = partial.ubicacion ?? element.ubicacion
+  const zBase =
+    partial.zBase ?? partial.elevacion?.zBase ?? element.zBase ?? element.elevacion?.zBase
+  const alto =
+    partial.alto ?? partial.elevacion?.altura ?? element.alto ?? element.elevacion?.altura
+  return {
+    ...element,
+    ...partial,
+    ubicacion,
+    zBase,
+    alto,
+    elevacion: {
+      ...(element.elevacion || {}),
+      ...(partial.elevacion || {}),
+      zBase,
+      altura: alto,
+    },
+  }
+}
+
+/**
+ * Provee guards de validación para movimientos y transformaciones
+ * @param {Object} ctx
+ * @param {Object} ctx.store - store de canvas
+ * @param {number} ctx.alturaBodega - altura máxima permitida
+ * @param {number} ctx.CM_TO_PX - factor de conversión
+ */
+export function usePlacementGuards({ store, alturaBodega, CM_TO_PX }) {
+  void CM_TO_PX
+  const toast = useToast()
+  const neighborsCache = new Map()
+  const lastGoodPos = new Map()
+
+  const runPipeline = (candidate, start, neighborsOverride) => {
+    const base = store.elementos.find((e) => e.id === candidate.id) || candidate
+    const cand = hydrateCandidate(base, candidate)
+
+    const resBase = validateWallZBaseRequired(base, cand)
+    if (!resBase.valid) {
+      if (start) {
+        const { x, y, width, height } = start
+        const payload = {}
+        if (x !== undefined) payload.x = x
+        if (y !== undefined) payload.y = y
+        if (width !== undefined) payload.width = width
+        if (height !== undefined) payload.height = height
+        store.actualizarElemento(candidate.id, payload)
+      }
+      return { ...resBase, candidate: cand }
+    }
+
+    const resHeight = validateHeightWithinWarehouse(base, cand, alturaBodega)
+    if (!resHeight.valid) {
+      if (start) {
+        const { x, y, width, height } = start
+        const payload = {}
+        if (x !== undefined) payload.x = x
+        if (y !== undefined) payload.y = y
+        if (width !== undefined) payload.width = width
+        if (height !== undefined) payload.height = height
+        store.actualizarElemento(candidate.id, payload)
+      }
+      return { ...resHeight, candidate: cand }
+    }
+
+    const { boundsPx } = getActiveBounds(store)
+    const areaBounds = { minX: 0, minY: 0, maxX: boundsPx.width, maxY: boundsPx.height }
+    const neighbors = neighborsOverride || store.elementosVisibles
+    const resStack = validateZStacking(neighbors, cand, areaBounds)
+    if (!resStack.valid) {
+      if (start) {
+        const { x, y, width, height } = start
+        const payload = {}
+        if (x !== undefined) payload.x = x
+        if (y !== undefined) payload.y = y
+        if (width !== undefined) payload.width = width
+        if (height !== undefined) payload.height = height
+        store.actualizarElemento(candidate.id, payload)
+      }
+      return { ...resStack, candidate: cand }
+    }
+
+    return { valid: true, candidate: cand }
+  }
+
+  const onDragMoveGuard = (el) => {
+    const neighbors = store.useDragBoundsClamp ? neighborsCache.get(el.id) : undefined
+    const res = runPipeline(el, undefined, neighbors)
+    el.invalidPlacement = !res.valid
+    return res
+  }
+
+  const handleEnd = (el) => {
+    const id = el.id
+    let candidate = { ...el }
+    const neighbors = store.useDragBoundsClamp ? neighborsCache.get(id) : undefined
+    if (store.useDragBoundsClamp && neighbors) {
+      const base = store.elementos.find((e) => e.id === id) || candidate
+      const { boundsPx } = getActiveBounds(store)
+      const areaBounds = { minX: 0, minY: 0, maxX: boundsPx.width, maxY: boundsPx.height }
+      const grid = store.gridSize || 50
+      const snapped = finalizeRectClampSnapReclamp(
+        candidate.x,
+        candidate.y,
+        base.width,
+        base.height,
+        areaBounds,
+        grid,
+      )
+      const snapRes = resolveZStackClamp({ ...base, x: snapped.x, y: snapped.y }, neighbors, areaBounds)
+      if (!snapRes.collided) {
+        if (snapped.x !== candidate.x || snapped.y !== candidate.y) {
+          store.actualizarElemento(id, { x: snapped.x, y: snapped.y })
+          candidate.x = snapped.x
+          candidate.y = snapped.y
+        }
+      } else {
+        const last = lastGoodPos.get(id)
+        if (last) {
+          store.actualizarElemento(id, { x: last.x, y: last.y })
+          candidate.x = last.x
+          candidate.y = last.y
+        }
+      }
+    }
+    const res = runPipeline(candidate, candidate.start, neighbors)
+    candidate.invalidPlacement = !res.valid
+    if (!res.valid) {
+      toast.showError(errorsPlacement[res.code] || errorsPlacement[res.reason] || res.code || res.reason)
+      if (candidate.start) return { ...res, corrected: candidate.start }
+    }
+    return res
+  }
+
+  const onDragEndGuard = (el) => handleEnd(el)
+  const onTransformEndGuard = (el) => handleEnd(el)
+
+  const installDragBounds = (node, elementId) => {
+    if (!store.useDragBoundsClamp) return
+    const base = store.elementos.find((e) => e.id === elementId)
+    if (!base) return
+    const parent = node.getParent()
+    const parentAbsToLocal = parent.getAbsoluteTransform().copy().invert()
+    const parentLocalToAbs = parent.getAbsoluteTransform().copy()
+    const { boundsPx } = getActiveBounds(store)
+    const areaBounds = { minX: 0, minY: 0, maxX: boundsPx.width, maxY: boundsPx.height }
+    const areaFast = { type: 'rect', W: areaBounds.maxX - areaBounds.minX, H: areaBounds.maxY - areaBounds.minY }
+    const neighbors = store.elementosVisibles.filter((n) => {
+      if (n.id === base.id) return false
+      if (n.plantaId && base.plantaId && n.plantaId !== base.plantaId) return false
+      return true
+    })
+    neighborsCache.set(elementId, neighbors)
+    lastGoodPos.set(elementId, node.getAbsolutePosition())
+    const bound = (posLocal) => {
+      const abs = parentLocalToAbs.point(posLocal)
+      const cArea = clampToAreaFast(abs.x, abs.y, base.width, base.height, areaFast)
+      let x = cArea.x
+      let y = cArea.y
+      const res = resolveZStackClamp({ ...base, x, y }, neighbors, areaBounds)
+      if (res.collided && res.corrected) {
+        x = res.corrected.x
+        y = res.corrected.y
+      }
+      const local = parentAbsToLocal.point({ x, y })
+      return local
+    }
+    node.dragBoundFunc(bound)
+    const cleanup = () => {
+      node.dragBoundFunc(null)
+      node.off('dragend', cleanup)
+      neighborsCache.delete(elementId)
+      lastGoodPos.delete(elementId)
+    }
+    node.on('dragend', cleanup)
+  }
+
+  return { onDragMoveGuard, onDragEndGuard, onTransformEndGuard, installDragBounds }
+}
+
+export default usePlacementGuards

--- a/src/utils/errorsPlacement.js
+++ b/src/utils/errorsPlacement.js
@@ -1,0 +1,7 @@
+export const errorsPlacement = {
+  ZBASE_REQUIRED: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0',
+  HEIGHT_EXCEEDS_WAREHOUSE: 'La suma de la base y altura del elemento excede la altura de la bodega.',
+  Z_STACKING_COLLISION: 'Colisión vertical: las alturas se solapan',
+}
+
+export default errorsPlacement

--- a/src/utils/errorsPlacement.js
+++ b/src/utils/errorsPlacement.js
@@ -2,6 +2,7 @@ export const errorsPlacement = {
   ZBASE_REQUIRED: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0',
   HEIGHT_EXCEEDS_WAREHOUSE: 'La suma de la base y altura del elemento excede la altura de la bodega.',
   Z_STACKING_COLLISION: 'Colisión vertical: las alturas se solapan',
+  COPLANAR_SAME_TYPE_OVERLAP: 'Colisión coplanar: elementos del mismo tipo no pueden traslaparse',
 }
 
 export default errorsPlacement

--- a/src/utils/placementValidity.js
+++ b/src/utils/placementValidity.js
@@ -74,7 +74,38 @@ export function isValidPlacement({ pos, movingEl, neighbors = [], areaBounds, CM
   return blockingConflicts.length === 0
 }
 
+/**
+ * Valida la elevación de un elemento cuando su ubicación es "pared".
+ * Verifica que la base respecto al suelo sea > 0 y que la suma
+ * de dicha base con el alto del elemento no exceda la altura total
+ * de la bodega.
+ *
+ * @param {Object} params - Parámetros de validación
+ * @param {number} params.zBase - Altura de la base respecto al suelo
+ * @param {number} params.alto - Altura del elemento
+ * @param {number} params.alturaBodega - Altura total disponible
+ * @returns {{valido: boolean, mensaje: string}}
+ */
+export function validateWallPlacement({ zBase, alto, alturaBodega }) {
+  if (zBase === undefined || zBase === null || zBase <= 0) {
+    return {
+      valido: false,
+      mensaje: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0'
+    }
+  }
+
+  if (zBase + alto > alturaBodega) {
+    return {
+      valido: false,
+      mensaje: 'La base del elemento más su alto excede la altura de la bodega'
+    }
+  }
+
+  return { valido: true, mensaje: '' }
+}
+
 export default {
   isValidPlacement,
-  insideAreaStrokeSafe
+  insideAreaStrokeSafe,
+  validateWallPlacement
 }

--- a/src/validation/fieldResolvers.js
+++ b/src/validation/fieldResolvers.js
@@ -1,0 +1,45 @@
+export function resolveVerticalProps(element = {}, candidate = {}) {
+  const pick = (...vals) => {
+    for (const v of vals) {
+      if (v !== undefined && v !== null) return v
+    }
+    return null
+  }
+  const ubic = pick(
+    candidate.ubicacion,
+    element.ubicacion,
+    candidate.ubic,
+    element.ubic,
+    candidate.location,
+    element.location,
+  )
+  const rawZ = pick(
+    candidate.zBase,
+    element.zBase,
+    candidate.alturaRespectoAlSuelo,
+    element.alturaRespectoAlSuelo,
+    candidate.z_base,
+    element.z_base,
+    candidate.baseZ,
+    element.baseZ,
+  )
+  const rawAlto = pick(
+    candidate.alto,
+    element.alto,
+    candidate.altura,
+    element.altura,
+    candidate.heightCm,
+    element.heightCm,
+    candidate.height,
+    element.height,
+  )
+  const zBaseCm = rawZ != null ? parseFloat(rawZ) : null
+  const altoCm = rawAlto != null ? parseFloat(rawAlto) : null
+  return {
+    ubic,
+    zBaseCm: Number.isNaN(zBaseCm) ? null : zBaseCm,
+    altoCm: Number.isNaN(altoCm) ? null : altoCm,
+  }
+}
+
+export default { resolveVerticalProps }

--- a/src/validation/fieldResolvers.js
+++ b/src/validation/fieldResolvers.js
@@ -14,6 +14,8 @@ export function resolveVerticalProps(element = {}, candidate = {}) {
     element.location,
   )
   const rawZ = pick(
+    candidate.elevacion?.zBase,
+    element.elevacion?.zBase,
     candidate.zBase,
     element.zBase,
     candidate.alturaRespectoAlSuelo,
@@ -24,6 +26,8 @@ export function resolveVerticalProps(element = {}, candidate = {}) {
     element.baseZ,
   )
   const rawAlto = pick(
+    candidate.elevacion?.altura,
+    element.elevacion?.altura,
     candidate.alto,
     element.alto,
     candidate.altura,
@@ -42,4 +46,23 @@ export function resolveVerticalProps(element = {}, candidate = {}) {
   }
 }
 
-export default { resolveVerticalProps }
+export function resolveTypeId(element = {}, candidate = {}) {
+  const pick = (...vals) => {
+    for (const v of vals) {
+      if (v !== undefined && v !== null) return String(v)
+    }
+    return null
+  }
+  return pick(
+    candidate.typeId,
+    element.typeId,
+    candidate.tipo,
+    element.tipo,
+    candidate.class,
+    element.class,
+    candidate.kind,
+    element.kind,
+  )
+}
+
+export default { resolveVerticalProps, resolveTypeId }

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -1,0 +1,136 @@
+import { validateWallPlacement } from '@/utils/placementValidity'
+import { narrowPhase2D, zOverlapCheck, computeMTD, projectMTDAgainstBoundary } from '@/utils/collision'
+import { finalizeRectClampSnapReclamp } from '@/utils/edgeConstraint'
+import { resolveVerticalProps } from './fieldResolvers'
+
+const Z_EPS = 0.001
+
+/**
+ * Valida que elementos con ubicacion "pared" tengan zBase definido y > 0
+ */
+export function validateWallZBaseRequired(element, candidate) {
+  const { ubic, zBaseCm, altoCm } = resolveVerticalProps(element, candidate)
+  void altoCm
+  if (ubic !== 'Pared') return { valid: true }
+  if (zBaseCm == null || zBaseCm <= 0) {
+    if (globalThis.__DEV__) console.debug('resolveVerticalProps', { ubic, zBaseCm, altoCm })
+    return { valid: false, code: 'ZBASE_REQUIRED' }
+  }
+  return { valid: true }
+}
+
+/**
+ * Valida que la suma zBase + alto no exceda la altura de la bodega
+ */
+export function validateHeightWithinWarehouse(element, candidate, alturaBodega) {
+  const { ubic, zBaseCm, altoCm } = resolveVerticalProps(element, candidate)
+  if (ubic !== 'Pared') return { valid: true }
+  if (zBaseCm == null || altoCm == null) return { valid: true }
+  const { valido, mensaje } = validateWallPlacement({
+    zBase: zBaseCm,
+    alto: altoCm,
+    alturaBodega,
+  })
+  if (!valido && mensaje.includes('excede')) {
+    if (globalThis.__DEV__) console.debug('resolveVerticalProps', { ubic, zBaseCm, altoCm })
+    return { valid: false, code: 'HEIGHT_EXCEEDS_WAREHOUSE' }
+  }
+  return { valid: true }
+}
+
+/**
+ * Valida que los intervalos Z de elementos que se traslapan en XY no se solapen
+ *
+ * @param {Array<Object>} elements - elementos existentes
+ * @param {Object} candidate - elemento candidato
+ * @param {number} [Z_EPS=0.001] - tolerancia para permitir contacto
+ */
+export function resolveZStackClamp(candidate, neighbors, areaBounds, Z_EPS = 0.001) {
+  const candProps = resolveVerticalProps(candidate, {})
+  const m = {
+    ...candidate,
+    elevacion: {
+      ...(candidate.elevacion || {}),
+      zBase: candProps.zBaseCm ?? candidate.elevacion?.zBase,
+      altura: candProps.altoCm ?? candidate.elevacion?.altura,
+    },
+    tolerancias: { ...(candidate.tolerancias || {}), zEpsilon: Z_EPS },
+  }
+
+  let best = null
+  for (const other of neighbors) {
+    if (other.id === candidate.id) continue
+    if (other.plantaId && candidate.plantaId && other.plantaId !== candidate.plantaId) continue
+    if (other.padre && candidate.padre && other.padre !== candidate.padre) continue
+    // Broad-phase AABB check
+    if (
+      candidate.x + candidate.width <= other.x ||
+      other.x + other.width <= candidate.x ||
+      candidate.y + candidate.height <= other.y ||
+      other.y + other.height <= candidate.y
+    )
+      continue
+
+    const { intersectXY, ra, rb } = narrowPhase2D(candidate, other)
+    if (!intersectXY) continue
+    const otherProps = resolveVerticalProps(other, {})
+    const o = {
+      ...other,
+      elevacion: {
+        ...(other.elevacion || {}),
+        zBase: otherProps.zBaseCm ?? other.elevacion?.zBase,
+        altura: otherProps.altoCm ?? other.elevacion?.altura,
+      },
+      tolerancias: { ...(other.tolerancias || {}), zEpsilon: Z_EPS },
+    }
+    const { overlap } = zOverlapCheck(m, o)
+    if (!overlap) continue
+    const { dx, dy } = computeMTD(ra.x, ra.y, ra.w, ra.h, rb.x, rb.y, rb.w, rb.h)
+    const mag = Math.abs(dx) + Math.abs(dy)
+    if (!best || mag < best.mag) best = { dx, dy, mag }
+  }
+
+  if (best) {
+    let { dx, dy } = best
+    if (areaBounds) {
+      const proj = projectMTDAgainstBoundary(
+        candidate.x,
+        candidate.y,
+        dx,
+        dy,
+        candidate.width,
+        candidate.height,
+        areaBounds.maxX - areaBounds.minX,
+        areaBounds.maxY - areaBounds.minY,
+      )
+      dx = proj.dx
+      dy = proj.dy
+      const clamped = finalizeRectClampSnapReclamp(
+        candidate.x + dx,
+        candidate.y + dy,
+        candidate.width,
+        candidate.height,
+        areaBounds,
+        1,
+      )
+      return { collided: true, corrected: { x: clamped.x, y: clamped.y } }
+    }
+    return { collided: true, corrected: { x: candidate.x + dx, y: candidate.y + dy } }
+  }
+  return { collided: false }
+}
+
+export function validateZStacking(elements, candidate, areaBounds, Z_EPS = 0.001) {
+  const res = resolveZStackClamp(candidate, elements, areaBounds, Z_EPS)
+  if (res.collided) {
+    return { valid: false, code: 'Z_STACKING_COLLISION', reason: 'Z_STACK_CONFLICT', corrected: res.corrected }
+  }
+  return { valid: true }
+}
+
+export default {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+  resolveZStackClamp,
+}

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -1,7 +1,12 @@
 import { validateWallPlacement } from '@/utils/placementValidity'
-import { narrowPhase2D, zOverlapCheck, computeMTD, projectMTDAgainstBoundary } from '@/utils/collision'
+import {
+  narrowPhase2D,
+  zOverlapCheck,
+  computeMTD,
+  projectMTDAgainstBoundary,
+} from '@/utils/collision'
 import { finalizeRectClampSnapReclamp } from '@/utils/edgeConstraint'
-import { resolveVerticalProps } from './fieldResolvers'
+import { resolveVerticalProps, resolveTypeId } from './fieldResolvers'
 
 const Z_EPS = 0.001
 
@@ -36,6 +41,58 @@ export function validateHeightWithinWarehouse(element, candidate, alturaBodega) 
     return { valid: false, code: 'HEIGHT_EXCEEDS_WAREHOUSE' }
   }
   return { valid: true }
+}
+
+export function validateCoplanarSameTypeNoOverlap(
+  neighbors,
+  element,
+  candidate,
+  Z_LAYER_EPS = 0.5,
+  Z_EPS = 0.001,
+) {
+  const typeId = resolveTypeId(element, candidate)
+  if (!typeId) return { valid: true }
+  const { zBaseCm: candZ } = resolveVerticalProps(element, candidate)
+  for (const other of neighbors) {
+    if (other.id === candidate.id) continue
+    if (other.plantaId && candidate.plantaId && other.plantaId !== candidate.plantaId) continue
+    if (other.padre && candidate.padre && other.padre !== candidate.padre) continue
+    const otherType = resolveTypeId(other, {})
+    if (otherType !== typeId) continue
+    const { zBaseCm: otherZ } = resolveVerticalProps(other, {})
+    if (candZ == null || otherZ == null || Math.abs(candZ - otherZ) > Z_LAYER_EPS) continue
+    // Broad-phase AABB check
+    if (
+      candidate.x + candidate.width <= other.x ||
+      other.x + other.width <= candidate.x ||
+      candidate.y + candidate.height <= other.y ||
+      other.y + other.height <= candidate.y
+    )
+      continue
+    const { intersectXY } = narrowPhase2D(candidate, other)
+    if (intersectXY) {
+      return { valid: false, code: 'COPLANAR_SAME_TYPE_OVERLAP', offenderId: other.id }
+    }
+  }
+  return { valid: true }
+}
+
+export function resolveCoplanarClamp(candidate, neighbors) {
+  let best = null
+  for (const other of neighbors) {
+    if (other.id === candidate.id) continue
+    if (other.plantaId && candidate.plantaId && other.plantaId !== candidate.plantaId) continue
+    if (other.padre && candidate.padre && other.padre !== candidate.padre) continue
+    const { intersectXY, ra, rb } = narrowPhase2D(candidate, other)
+    if (!intersectXY) continue
+    const { dx, dy } = computeMTD(ra.x, ra.y, ra.w, ra.h, rb.x, rb.y, rb.w, rb.h)
+    const mag = Math.abs(dx) + Math.abs(dy)
+    if (!best || mag < best.mag) best = { dx, dy, mag }
+  }
+  if (best) {
+    return { collided: true, corrected: { x: candidate.x + best.dx, y: candidate.y + best.dy } }
+  }
+  return { collided: false }
 }
 
 /**
@@ -131,6 +188,8 @@ export function validateZStacking(elements, candidate, areaBounds, Z_EPS = 0.001
 export default {
   validateWallZBaseRequired,
   validateHeightWithinWarehouse,
+  validateCoplanarSameTypeNoOverlap,
   validateZStacking,
   resolveZStackClamp,
+  resolveCoplanarClamp,
 }


### PR DESCRIPTION
## Summary
- add optional `useDragBoundsClamp` flag to enable pure Konva drag bounds
- cache transforms and neighbors to clamp drags without store writes and snap only on dragend
- cover flag behavior with integration tests for clamping, snapping, and neighbor caching

## Testing
- `npm run lint -- --fix`
- `node node_modules/vitest/dist/cli.js run src/__tests__/wall-placement-helper.spec.js src/__tests__/element-editor-wall.spec.js src/__tests__/placement-orchestrator.spec.js src/__tests__/placement-guards-integration.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_68af5268050883218889c5eb4c4d208b