### PR TITLE
Add wall and Z-stacking placement validations with guard rollback

### DIFF
--- a/src/__tests__/delete_element.spec.js
+++ b/src/__tests__/delete_element.spec.js
@@ -164,7 +164,8 @@ describe('deleteSelected', () => {
 
     const toasts = { show: vi.fn() }
     // stub toasts
-    global.window.__toasts = toasts
+    globalThis.window = globalThis.window || {}
+    globalThis.window.__toasts = toasts
 
     const ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
@@ -186,7 +187,8 @@ describe('deleteSelected', () => {
     history.initializeHistory('pre')
 
     // Primero intenta y bloquea
-    global.window.__toasts = { show: vi.fn() }
+    globalThis.window = globalThis.window || {}
+    globalThis.window.__toasts = { show: vi.fn() }
     let ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
 
@@ -220,7 +222,8 @@ describe('deleteSelected', () => {
     const hBefore = history.historySize.value
 
     const toasts = { show: vi.fn() }
-    global.window.__toasts = toasts
+    globalThis.window = globalThis.window || {}
+    globalThis.window.__toasts = toasts
 
     const ok = await deleteSelected({ withConfirm: true })
     expect(ok).toBe(false)
@@ -249,7 +252,8 @@ describe('deleteSelected', () => {
 
     // Stub de toasts para capturar opciones
     const showSpy = vi.fn()
-    global.window.__toasts = { show: showSpy }
+    globalThis.window = globalThis.window || {}
+    globalThis.window.__toasts = { show: showSpy }
 
     // Confirmación positiva
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)

--- a/src/__tests__/drop-validation.spec.js
+++ b/src/__tests__/drop-validation.spec.js
@@ -67,7 +67,7 @@ vi.mock('@/composables/useConflicts', () => ({
 }))
 
 // Mock del sistema de toast
-global.window = {
+globalThis.window = {
   __toasts: {
     show: vi.fn()
   }

--- a/src/__tests__/innerNoOverlap.spec.js
+++ b/src/__tests__/innerNoOverlap.spec.js
@@ -12,7 +12,7 @@ describe('makeInnerSession basic behaviours', () => {
       posicion: { x: 0, y: 0 },
       hijos: [],
     }
-    global.window = { __GRID_SIZE_PX: 1 }
+    globalThis.window = { __GRID_SIZE_PX: 1 }
   })
 
   it('isValidLocal prevents overlap but allows touching', () => {

--- a/src/__tests__/placement-validators.spec.js
+++ b/src/__tests__/placement-validators.spec.js
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+} from '@/validation/placementOrchestrator'
+
+describe('validateWallZBaseRequired', () => {
+  it('passes for non-wall', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'suelo' }, {}, {})
+    expect(res.valid).toBe(true)
+  })
+
+  it('fails when wall and zBase missing', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'pared' }, {}, {})
+    expect(res).toEqual({ valid: false, code: 'ZBASE_REQUIRED' })
+  })
+
+  it('fails when wall and zBase <=0', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'pared', alturaRespectoAlSuelo: 0 }, {}, {})
+    expect(res).toEqual({ valid: false, code: 'ZBASE_REQUIRED' })
+  })
+
+  it('passes when wall and zBase >0', () => {
+    const res = validateWallZBaseRequired({ ubicacion: 'pared', alturaRespectoAlSuelo: 5 }, {}, {})
+    expect(res.valid).toBe(true)
+  })
+})
+
+describe('validateHeightWithinWarehouse', () => {
+  it('allows floor element with nested height when below roof', () => {
+    const res = validateHeightWithinWarehouse(
+      {},
+      { ubicacion: 'Suelo', dimensiones: { alto: 180 } },
+      { alturaBodega: 500 },
+    )
+    expect(res.valid).toBe(true)
+  })
+
+  it('allows lowercase ubicacion for floor element', () => {
+    const res = validateHeightWithinWarehouse(
+      {},
+      { ubicacion: 'suelo', dimensiones: { alto: 180 } },
+      { alturaBodega: 500 },
+    )
+    expect(res.valid).toBe(true)
+  })
+
+  it('skips check when warehouse height missing', () => {
+    const res = validateHeightWithinWarehouse(
+      {},
+      { ubicacion: 'Suelo', dimensiones: { alto: 180 } },
+      {},
+    )
+    expect(res.valid).toBe(true)
+  })
+
+  it('allows wall element exactly at warehouse height', () => {
+    const res = validateHeightWithinWarehouse(
+      {},
+      { ubicacion: 'Pared', zBase: 400, alto: 100 },
+      { alturaBodega: 500 },
+    )
+    expect(res.valid).toBe(true)
+  })
+
+  it('rejects wall element exceeding warehouse height', () => {
+    const res = validateHeightWithinWarehouse(
+      {},
+      { ubicacion: 'Pared', zBase: 401, alto: 100 },
+      { alturaBodega: 500 },
+    )
+    expect(res).toEqual({ valid: false, code: 'HEIGHT_EXCEEDS_WAREHOUSE' })
+  })
+})
+
+describe('validateZStacking', () => {
+  const base = {
+    id: 'a',
+    plantaId: 'p1',
+    width: 10,
+    height: 10,
+    x: 0,
+    y: 0,
+    ubicacion: 'suelo',
+    zBase: 0,
+    alto: 100,
+  }
+
+  it('detects overlapping Z with XY overlap', () => {
+    const neighbor = { ...base, id: 'b', zBase: 50 }
+    const res = validateZStacking(base, { x: 0, y: 0 }, [neighbor])
+    expect(res).toEqual({ valid: false, code: 'Z_STACK_CONFLICT', offenderId: 'b' })
+  })
+
+  it('allows exact top touch in Z', () => {
+    const neighbor = { ...base, id: 'b', zBase: 100 }
+    const res = validateZStacking(base, { x: 0, y: 0 }, [neighbor])
+    expect(res.valid).toBe(true)
+  })
+
+  it('allows separated Z intervals', () => {
+    const neighbor = { ...base, id: 'b', zBase: 150 }
+    const res = validateZStacking(base, { x: 0, y: 0 }, [neighbor])
+    expect(res.valid).toBe(true)
+  })
+})

--- a/src/__tests__/test-setup.js
+++ b/src/__tests__/test-setup.js
@@ -26,7 +26,7 @@ class ResizeObserver {
   disconnect() {}
 }
 // @ts-ignore
-if (typeof global !== 'undefined') {
+if (typeof globalThis !== 'undefined') {
   // @ts-ignore
-  global.ResizeObserver = ResizeObserver
+  globalThis.ResizeObserver = ResizeObserver
 }

--- a/src/__tests__/wall-placement-integration.spec.js
+++ b/src/__tests__/wall-placement-integration.spec.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import CanvasView from '@/components/CanvasView.vue'
+import ElementEditor from '@/components/modals/ElementEditor.vue'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import { errorsPlacement } from '@/validation/placementOrchestrator'
+
+describe('wall placement integration', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    globalThis.window = globalThis.window || {}
+    window.__toasts = { show: vi.fn() }
+  })
+
+  it('reverts drop that exceeds warehouse height and skips history', () => {
+    const store = useCanvasStore()
+    store.plantas[0].dimensiones.alto = 100
+    store.elementos = [
+      {
+        id: 'el1',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 20,
+        x: 0,
+        y: 0,
+        alturaRespectoAlSuelo: 90,
+      },
+    ]
+    const spy = vi.spyOn(store, 'saveToHistory')
+
+    const wrapper = mount(CanvasView)
+
+    wrapper.vm.innerSessions.set('el1', {
+      session: {
+        toLocal: (p) => p,
+        dragBoundFuncLocal: (p) => p,
+        toWorld: (p) => p,
+        finalizeLocal: (p) => p,
+      },
+      parent: null,
+      initial: { x: 0, y: 0 },
+    })
+
+    const shape = {
+      _pos: { x: 10, y: 10 },
+      position(pos) {
+        if (pos) this._pos = pos
+        return this._pos
+      },
+    }
+
+    wrapper.vm.onShapeDragEnd({ target: shape }, store.elementos[0])
+
+    expect(shape.position()).toEqual({ x: 0, y: 0 })
+    expect(spy).not.toHaveBeenCalled()
+    expect(window.__toasts.show).toHaveBeenCalledWith(
+      errorsPlacement.HEIGHT_EXCEEDS_WAREHOUSE,
+      { type: 'error' },
+    )
+  })
+
+  it('blocks form submit when wall element lacks zBase', async () => {
+    const store = useCanvasStore()
+    store.plantas[0].dimensiones.alto = 300
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    const wrapper = mount(ElementEditor, {
+      props: {
+        visible: true,
+        categorias: [{ id: 'cat', nombre: 'Cat' }],
+        formas: [{ id: 'rectangular', nombre: 'Rect' }],
+        ubicaciones: [
+          { id: 'suelo', nombre: 'Suelo' },
+          { id: 'pared', nombre: 'Pared' },
+        ],
+      },
+    })
+
+    const el = wrapper.vm.localElemento
+    el.nombre = 'A'
+    el.categoria = 'cat'
+    el.forma = 'rectangular'
+    el.ubicacion = 'pared'
+    el.dimensiones.ancho = 10
+    el.dimensiones.largo = 10
+    el.dimensiones.alto = 10
+    el.pesoMaximo = 5
+    el.alturaRespectoAlSuelo = 0
+
+    await wrapper.find('form').trigger('submit.prevent')
+
+    expect(alertSpy).toHaveBeenCalledWith(errorsPlacement.ZBASE_REQUIRED)
+    expect(wrapper.emitted('save')).toBeUndefined()
+  })
+
+  it('prevents drop for wall element missing zBase', () => {
+    const store = useCanvasStore()
+    store.plantas[0].dimensiones.alto = 300
+    store.elementos = [
+      {
+        id: 'el1',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 10,
+        x: 0,
+        y: 0,
+        ubicacion: 'pared',
+      },
+    ]
+    const spy = vi.spyOn(store, 'saveToHistory')
+
+    const wrapper = mount(CanvasView)
+
+    wrapper.vm.innerSessions.set('el1', {
+      session: {
+        toLocal: (p) => p,
+        dragBoundFuncLocal: (p) => p,
+        toWorld: (p) => p,
+        finalizeLocal: (p) => p,
+      },
+      parent: null,
+      initial: { x: 0, y: 0 },
+    })
+
+    const shape = {
+      _pos: { x: 5, y: 5 },
+      position(pos) {
+        if (pos) this._pos = pos
+        return this._pos
+      },
+    }
+
+    wrapper.vm.onShapeDragEnd({ target: shape }, store.elementos[0])
+
+    expect(shape.position()).toEqual({ x: 0, y: 0 })
+    expect(spy).not.toHaveBeenCalled()
+    expect(window.__toasts.show).toHaveBeenCalledWith(
+      errorsPlacement.ZBASE_REQUIRED,
+      { type: 'error' },
+    )
+  })
+})

--- a/src/__tests__/z-stacking-integration.spec.js
+++ b/src/__tests__/z-stacking-integration.spec.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import CanvasView from '@/components/CanvasView.vue'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import { errorsPlacement } from '@/validation/placementOrchestrator'
+
+describe('z stacking integration', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    globalThis.window = globalThis.window || {}
+    window.__toasts = { show: vi.fn() }
+  })
+
+  const makeSession = (initial) => ({
+    session: {
+      toLocal: (p) => p,
+      dragBoundFuncLocal: (p) => p,
+      toWorld: (p) => p,
+      finalizeLocal: (p) => p,
+    },
+    parent: null,
+    initial,
+  })
+
+  const makeShape = (pos) => ({
+    _pos: pos,
+    position(p) {
+      if (p) this._pos = p
+      return this._pos
+    },
+  })
+
+  it('reverts when XY and Z overlap', () => {
+    const store = useCanvasStore()
+    store.elementos = [
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 10,
+        x: 0,
+        y: 0,
+        ubicacion: 'suelo',
+        zBase: 0,
+        alto: 100,
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 10,
+        x: 20,
+        y: 0,
+        ubicacion: 'suelo',
+        zBase: 50,
+        alto: 100,
+      },
+    ]
+    const spy = vi.spyOn(store, 'saveToHistory')
+    const wrapper = mount(CanvasView)
+
+    wrapper.vm.innerSessions.set('b', makeSession({ x: 20, y: 0 }))
+    const shape = makeShape({ x: 0, y: 0 })
+
+    wrapper.vm.onShapeDragEnd({ target: shape }, store.elementos[1])
+
+    expect(shape.position()).toEqual({ x: 20, y: 0 })
+    expect(spy).not.toHaveBeenCalled()
+    expect(window.__toasts.show).toHaveBeenCalledWith(
+      errorsPlacement.Z_STACK_CONFLICT,
+      { type: 'error' },
+    )
+  })
+
+  it('allows exact Z touch', () => {
+    const store = useCanvasStore()
+    store.elementos = [
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 10,
+        x: 0,
+        y: 0,
+        ubicacion: 'suelo',
+        zBase: 0,
+        alto: 100,
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 10,
+        x: 20,
+        y: 0,
+        ubicacion: 'suelo',
+        zBase: 100,
+        alto: 100,
+      },
+    ]
+    const wrapper = mount(CanvasView)
+
+    wrapper.vm.innerSessions.set('b', makeSession({ x: 20, y: 0 }))
+    const shape = makeShape({ x: 0, y: 0 })
+
+    wrapper.vm.onShapeDragEnd({ target: shape }, store.elementos[1])
+
+    expect(shape.position()).toEqual({ x: 0, y: 0 })
+    expect(window.__toasts.show).not.toHaveBeenCalled()
+  })
+
+  it('allows when no XY overlap', () => {
+    const store = useCanvasStore()
+    store.elementos = [
+      {
+        id: 'a',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 10,
+        x: 0,
+        y: 0,
+        ubicacion: 'suelo',
+        zBase: 0,
+        alto: 100,
+      },
+      {
+        id: 'b',
+        plantaId: 'planta_1',
+        tipo: 'elementos',
+        width: 10,
+        height: 10,
+        x: 20,
+        y: 0,
+        ubicacion: 'suelo',
+        zBase: 50,
+        alto: 100,
+      },
+    ]
+    const wrapper = mount(CanvasView)
+
+    wrapper.vm.innerSessions.set('b', makeSession({ x: 20, y: 0 }))
+    const shape = makeShape({ x: 40, y: 0 })
+
+    wrapper.vm.onShapeDragEnd({ target: shape }, store.elementos[1])
+
+    expect(shape.position()).toEqual({ x: 40, y: 0 })
+    expect(window.__toasts.show).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -581,6 +581,7 @@ import { finalizePlacement } from '@/utils/finalizeDrag'
 import { isPlacementValid } from '@/utils/isPlacementValid'
 import { makeInnerSession } from '@/composables/useInnerNoOverlap'
 import { useObjectSnapping } from '@/composables/useObjectSnapping'
+import { usePlacementGuards } from '@/composables/usePlacementGuards'
 import FloatingToolbar from './FloatingToolbar.vue'
 import SnapGuides from './SnapGuides.vue'
 
@@ -610,7 +611,8 @@ function scheduleDraw() {
   rafId = requestAnimationFrame(() => {
     rafId = null
     if (needsDraw) {
-      layerRef.value?.getNode()?.batchDraw()
+      const layerNode = layerRef.value?.getNode ? layerRef.value.getNode() : layerRef.value
+      layerNode?.batchDraw?.()
       needsDraw = false
     }
   })
@@ -618,6 +620,7 @@ function scheduleDraw() {
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
+const { onDragMoveGuard, onDragEndGuard, onTransformEndGuard } = usePlacementGuards()
 const buffer = useCanvasBuffer()
 const ctx = useContextMenu()
 const { visible: ctxVisible, x: ctxX, y: ctxY, isLocked: ctxIsLocked, elementId: ctxElementId } = ctx
@@ -1381,13 +1384,17 @@ const endElementDrag = async (elementId) => {
         const positionChanged = Math.abs(finalPosition.x - lastPos.x) > 1e-6 || Math.abs(finalPosition.y - lastPos.y) > 1e-6
 
         if (positionChanged) {
-          canvasStore.actualizarPosicionConHistorial(
-            elementId,
-            finalPosition.x,
-            finalPosition.y,
-            `Elemento movido: ${elementoActual.nombre || elementoActual.tipo || elementId}`,
-          )
-        }        // Actualizar lastValidPositions con la posición final
+          const guardRes = onDragEndGuard(elementoActual, finalPosition)
+          if (guardRes.valid) {
+            canvasStore.actualizarPosicionConHistorial(
+              elementId,
+              finalPosition.x,
+              finalPosition.y,
+              `Elemento movido: ${elementoActual.nombre || elementoActual.tipo || elementId}`,
+            )
+          }
+        }
+        // Actualizar lastValidPositions con la posición final
         lastValidPositions.value.set(elementId, finalPosition)
       }
     }
@@ -1433,16 +1440,19 @@ const endElementDrag = async (elementId) => {
       const isValidNow = isPlacementValid({ pos: { x: finalX, y: finalY }, movingEl: storeEl, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
 
       if (isValidNow) {
-        // Persistir posición final con historial
-        canvasStore.actualizarPosicionConHistorial(
-          elementId,
-          finalX,
-          finalY,
-          `Elemento movido: ${storeEl.nombre || storeEl.tipo || elementId}`,
-        )
-        // Actualizar lastValidPositions para evitar divergencias posteriores
-        lastValidPositions.value.set(elementId, { x: finalX, y: finalY })
-        console.debug('[finalize] persisted final pos for', elementId, { finalX, finalY })
+        const guardRes = onDragEndGuard(storeEl, { x: finalX, y: finalY })
+        if (guardRes.valid) {
+          // Persistir posición final con historial
+          canvasStore.actualizarPosicionConHistorial(
+            elementId,
+            finalX,
+            finalY,
+            `Elemento movido: ${storeEl.nombre || storeEl.tipo || elementId}`,
+          )
+          // Actualizar lastValidPositions para evitar divergencias posteriores
+          lastValidPositions.value.set(elementId, { x: finalX, y: finalY })
+          console.debug('[finalize] persisted final pos for', elementId, { finalX, finalY })
+        }
       } else {
         // Si la posición final NO es válida, revertir visualmente a la última válida y persistir esa última válida
         const revertPos = lastGoodPos || lastValidPositions.value.get(elementId) || { x: storeEl.x || 0, y: storeEl.y || 0 }
@@ -1467,13 +1477,16 @@ const endElementDrag = async (elementId) => {
 
         // Persistir la posición revertida para mantener consistencia
         try {
-          canvasStore.actualizarPosicionConHistorial(
-            elementId,
-            revertPos.x,
-            revertPos.y,
-            `Revertir posición inválida: ${storeEl.nombre || storeEl.tipo || elementId}`,
-          )
-          lastValidPositions.value.set(elementId, { x: revertPos.x, y: revertPos.y })
+          const guardRes = onDragEndGuard(storeEl, revertPos)
+          if (guardRes.valid) {
+            canvasStore.actualizarPosicionConHistorial(
+              elementId,
+              revertPos.x,
+              revertPos.y,
+              `Revertir posición inválida: ${storeEl.nombre || storeEl.tipo || elementId}`,
+            )
+            lastValidPositions.value.set(elementId, { x: revertPos.x, y: revertPos.y })
+          }
         } catch (err) {
           console.warn('Error persisting revert position', err)
         }
@@ -1918,12 +1931,18 @@ const onShapeDragMove = (e, el) => {
         }
       }
     }
-    
+    const guardRes = onDragMoveGuard(el, { x: finalWorld.x, y: finalWorld.y })
+    if (!guardRes.valid) return
+
     shape.position(finalWorld)
     needsDraw = true
     scheduleDraw()
   } else {
-    updateElementPosition(e, el.id, el.forma === 'circular' ? 'circular' : 'rectangular')
+    const candidate = { x: e.target?.x?.() ?? 0, y: e.target?.y?.() ?? 0 }
+    const guardRes = onDragMoveGuard(el, candidate)
+    if (guardRes.valid) {
+      updateElementPosition(e, el.id, el.forma === 'circular' ? 'circular' : 'rectangular')
+    }
   }
 }
 
@@ -1945,6 +1964,20 @@ const onShapeDragEnd = (e, el) => {
     shape.position(finalWorld)
     needsDraw = true
     scheduleDraw()
+
+    const guardRes = onDragEndGuard(
+      el,
+      { x: finalWorld.x, y: finalWorld.y },
+      {
+        revert: () => {
+          shape.position(initial)
+          needsDraw = true
+          scheduleDraw()
+        },
+      },
+    )
+    if (!guardRes.valid) return
+
     const changed =
       Math.round(finalWorld.x) !== Math.round(initial.x) || Math.round(finalWorld.y) !== Math.round(initial.y)
     if (changed) {
@@ -2339,6 +2372,36 @@ const handleTransformEnd = (e, elementId, forma) => {
 
     const elemento = canvasStore.elementosVisibles.find(e => e.id === elementId)
     if (!elemento) return
+
+    const guardRes = onTransformEndGuard(
+      elemento,
+      { x, y, width, height, rotation },
+      {
+        revert: () => {
+          const prev =
+            transformInitialState.get(elementId) ||
+            { x: elemento.x, y: elemento.y, width: elemento.width, height: elemento.height, rotation: elemento.rotation || 0 }
+          try {
+            if (forma === 'circular') {
+              const r = Math.min(prev.width, prev.height) / 2
+              node.x(prev.x + r)
+              node.y(prev.y + r)
+            } else {
+              node.x(prev.x)
+              node.y(prev.y)
+            }
+            node.width && node.width(prev.width)
+            node.height && node.height(prev.height)
+            node.rotation && node.rotation(prev.rotation || 0)
+          } catch {
+            /* ignore */
+          }
+          needsDraw = true
+          scheduleDraw()
+        },
+      },
+    )
+    if (!guardRes.valid) return
 
     // Validar con isPlacementValid contra vecinos y área
     const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)

--- a/src/components/modals/ElementEditor.vue
+++ b/src/components/modals/ElementEditor.vue
@@ -235,6 +235,12 @@
 <script setup>
 import { ref, watch, computed } from 'vue'
 import { useWeightValidation } from '@/composables/useWeightValidation'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  errorsPlacement,
+} from '@/validation/placementOrchestrator'
 
 const props = defineProps({
   visible: Boolean,
@@ -246,6 +252,7 @@ const props = defineProps({
 const emit = defineEmits(['cancel', 'save'])
 
 const weightValidation = useWeightValidation()
+const canvasStore = useCanvasStore()
 
 const esFormaCircular = computed(() => localElemento.value.forma === 'circular')
 
@@ -395,6 +402,16 @@ const validarFormulario = () => {
   if (elemento.pesoMaximo <= 0) {
     alert('La capacidad de carga debe ser mayor a 0')
     return false
+  }
+  const ctx = {
+    alturaBodega: canvasStore.plantaPorId(canvasStore.plantaActiva)?.dimensiones?.alto,
+  }
+  for (const v of [validateWallZBaseRequired, validateHeightWithinWarehouse]) {
+    const res = v(null, elemento, ctx)
+    if (res.valid === false) {
+      alert(errorsPlacement[res.code])
+      return false
+    }
   }
   return true
 }

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -17,6 +17,12 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+  errorsPlacement,
+} from '@/validation/placementOrchestrator'
 
 // Variable para evitar circular import - será inicializada por el composable de historial
 let historyComposable = null
@@ -587,6 +593,8 @@ export const useCanvasStore = defineStore('canvas', () => {
 
   const actualizarElemento = (elementoId, propiedades) => {
     const elemento = elementos.value.find((el) => el.id === elementoId)
+    if (!elemento) return false
+    if (!runPlacementValidators(elemento, propiedades)) return false
     if (elemento) {
       for (const key in propiedades) {
         if (typeof propiedades[key] === 'object' && propiedades[key] !== null && !Array.isArray(propiedades[key])) {
@@ -622,6 +630,7 @@ export const useCanvasStore = defineStore('canvas', () => {
         }
       }
     }
+    return true
   }
 
   const configurarZoom = (nuevoZoom) => {
@@ -704,9 +713,44 @@ export const useCanvasStore = defineStore('canvas', () => {
     }
   }
 
+  const runPlacementValidators = (element, candidate) => {
+    const plantaId = candidate?.plantaId ?? element?.plantaId ?? plantaActiva.value
+    const planta = plantaPorId.value(plantaId)
+    const ctx = { alturaBodega: planta?.dimensiones?.alto }
+    const neighbors = elementos.value.filter(
+      (n) => n.plantaId === plantaId && n.id !== element?.id && n.id !== candidate?.id,
+    )
+    const checks = [
+      validateWallZBaseRequired,
+      validateHeightWithinWarehouse,
+      validateZStacking,
+    ]
+    for (const v of checks) {
+      const res = v === validateZStacking ? v(element, candidate, neighbors) : v(element, candidate, ctx)
+      if (res.valid === false) {
+        const msg = errorsPlacement[res.code] || 'Posición inválida'
+        window?.__toasts?.show?.(msg, { type: 'error' })
+        return false
+      }
+    }
+    return true
+  }
+
   // Actions para elementos
   const agregarElemento = (nuevoElemento) => {
     console.log('Agregando elemento al store:', nuevoElemento)
+
+    const ubic = (nuevoElemento.ubicacion || nuevoElemento.ubic || nuevoElemento.location || '').toLowerCase()
+    const hasZBase =
+      nuevoElemento.zBase != null ||
+      nuevoElemento.alturaRespectoAlSuelo != null ||
+      nuevoElemento.z_base != null ||
+      nuevoElemento.baseZ != null
+    if (ubic === 'suelo' && !hasZBase) {
+      nuevoElemento.zBase = 0
+    }
+
+    if (!runPlacementValidators(null, nuevoElemento)) return null
 
     // Validar tipo de elemento
     if (!nuevoElemento.tipo) {
@@ -884,7 +928,8 @@ export const useCanvasStore = defineStore('canvas', () => {
    * Versiones con historial de las acciones principales
    */
   const actualizarElementoConHistorial = (elementoId, propiedades, description) => {
-    actualizarElemento(elementoId, propiedades)
+    const ok = actualizarElemento(elementoId, propiedades)
+    if (!ok) return
 
     const descripcionAuto =
       description || `Propiedades actualizadas: ${Object.keys(propiedades).join(', ')}`

--- a/src/composables/usePerfMode.js
+++ b/src/composables/usePerfMode.js
@@ -25,7 +25,7 @@ export function enablePerfMode(layer, opts = {}) {
         strokeWidth: 1,
       })
     }
-  } catch (_) {}
+  } catch (_) { /* ignore */ }
 
   return {
     restore: () => disablePerfMode(layer, { shape, prev }),
@@ -52,5 +52,5 @@ export function disablePerfMode(layer, ctx = {}) {
       if (prev.shapeStrokeWidth !== undefined) attrs.strokeWidth = prev.shapeStrokeWidth
       shape.setAttrs(attrs)
     }
-  } catch (_) {}
+  } catch (_) { /* ignore */ }
 }

--- a/src/composables/usePlacementGuards.js
+++ b/src/composables/usePlacementGuards.js
@@ -1,0 +1,68 @@
+import {
+  validateWallZBaseRequired,
+  validateHeightWithinWarehouse,
+  validateZStacking,
+  validateCoplanarSameTypeNoOverlap,
+  errorsPlacement,
+} from '@/validation/placementOrchestrator'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+
+export function usePlacementGuards() {
+  const store = useCanvasStore()
+  const validators = [
+    validateWallZBaseRequired,
+    validateHeightWithinWarehouse,
+    validateZStacking,
+    validateCoplanarSameTypeNoOverlap,
+  ]
+
+  const getCtx = () => {
+    const planta =
+      typeof store.plantaPorId === 'function'
+        ? store.plantaPorId(store.plantaActiva)
+        : null
+    const alturaBodega =
+      planta?.alturaBodega ??
+      planta?.dimensiones?.alto ??
+      planta?.altura ??
+      null
+    return { alturaBodega }
+  }
+
+  const getNeighbors = (el, cand) => {
+    const plantaId = cand?.plantaId ?? el?.plantaId ?? store.plantaActiva
+    return store.elementos.filter(
+      (n) => n.plantaId === plantaId && n.id !== el?.id && n.id !== cand?.id,
+    )
+  }
+
+  const run = (el, cand) => {
+    const ctx = getCtx()
+    const neighbors = getNeighbors(el, cand)
+    for (const v of validators) {
+      const res = v === validateZStacking ? v(el, cand, neighbors) : v(el, cand, ctx)
+      if (res && res.valid === false) return res
+    }
+    return { valid: true }
+  }
+
+  const handle = (el, cand, opts = {}) => {
+    const res = run(el, cand)
+    if (!res.valid) {
+      opts.revert?.()
+      const msg = errorsPlacement[res.code] || 'Posición inválida'
+      window?.__toasts?.show?.(msg, { type: 'error' })
+    }
+    return res
+  }
+
+  const onDragMoveGuard = (el, cand) => run(el, cand)
+  const onDragEndGuard = (el, cand, opts) => handle(el, cand, opts)
+  const onTransformEndGuard = (el, cand, opts) => handle(el, cand, opts)
+
+  return {
+    onDragMoveGuard,
+    onDragEndGuard,
+    onTransformEndGuard,
+  }
+}

--- a/src/validation/fieldResolvers.js
+++ b/src/validation/fieldResolvers.js
@@ -1,0 +1,56 @@
+export function resolveVerticalProps(element = {}, candidate = {}) {
+  const locationKeys = ['ubicacion', 'ubic', 'location']
+  const zBaseKeys = ['zBase', 'alturaRespectoAlSuelo', 'z_base', 'baseZ']
+  const heightKeys = ['alto', 'altura', 'height', 'heightCm']
+
+  const coalesce = (cand, el, keys) => {
+    for (const k of keys) {
+      if (cand && cand[k] != null) return cand[k]
+    }
+    for (const k of keys) {
+      if (el && el[k] != null) return el[k]
+    }
+    return null
+  }
+
+  const parseNumber = (v) => {
+    const n = Number(v)
+    return Number.isFinite(n) ? n : null
+  }
+
+  let ubic = coalesce(candidate, element, locationKeys)
+  if (typeof ubic === 'string') {
+    const lower = ubic.toLowerCase()
+    if (lower === 'suelo' || lower === 'floor') ubic = 'Suelo'
+    else if (lower === 'pared' || lower === 'wall') ubic = 'Pared'
+  }
+
+  let zBaseCm = parseNumber(coalesce(candidate, element, zBaseKeys))
+
+  let altoCm = parseNumber(
+    candidate?.dimensiones?.alto ??
+      element?.dimensiones?.alto ??
+      coalesce(candidate, element, heightKeys),
+  )
+
+  if (ubic === 'Suelo' && zBaseCm == null) zBaseCm = 0
+
+  return { ubic, zBaseCm, altoCm }
+}
+
+export function resolveTypeId(element = {}, candidate = {}) {
+  const typeKeys = ['typeId', 'tipo', 'class', 'kind']
+
+  const coalesce = (cand, el, keys) => {
+    for (const k of keys) {
+      if (cand && cand[k] != null) return cand[k]
+    }
+    for (const k of keys) {
+      if (el && el[k] != null) return el[k]
+    }
+    return null
+  }
+
+  const v = coalesce(candidate, element, typeKeys)
+  return v != null ? String(v) : null
+}

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -1,0 +1,80 @@
+import { resolveVerticalProps } from './fieldResolvers'
+import { aabbIntersect } from '@/utils/collision'
+
+export const errorsPlacement = {
+  ZBASE_REQUIRED: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0.',
+  HEIGHT_EXCEEDS_WAREHOUSE:
+    'Supera la altura de la bodega (zBase + alto > altura de bodega).',
+  Z_STACK_CONFLICT: 'Colisión vertical: las alturas se solapan',
+}
+
+export function validateWallZBaseRequired(element = {}, candidate = {}, ctx = {}) {
+  const { ubic, zBaseCm } = resolveVerticalProps(element, candidate)
+  if (ubic !== 'Pared') return { valid: true }
+  if (zBaseCm == null || zBaseCm <= 0) {
+    return { valid: false, code: 'ZBASE_REQUIRED' }
+  }
+  return { valid: true }
+}
+
+export function validateHeightWithinWarehouse(element = {}, candidate = {}, ctx = {}) {
+  const { zBaseCm, altoCm } = resolveVerticalProps(element, candidate)
+  const limit = Number(ctx.alturaBodega)
+  if (!Number.isFinite(limit) || limit <= 0) return { valid: true }
+  if (!Number.isFinite(zBaseCm) || !Number.isFinite(altoCm)) return { valid: true }
+  if (zBaseCm + altoCm > limit + 1e-6) {
+    return { valid: false, code: 'HEIGHT_EXCEEDS_WAREHOUSE' }
+  }
+  return { valid: true }
+}
+
+export function validateZStacking(
+  element = {},
+  candidate = {},
+  neighbors = [],
+  Z_EPS = 0.001,
+) {
+  const { zBaseCm, altoCm } = resolveVerticalProps(element, candidate)
+  if (!Number.isFinite(zBaseCm) || !Number.isFinite(altoCm)) return { valid: true }
+
+  const zA0 = zBaseCm
+  const zA1 = zBaseCm + altoCm
+
+  const aabbA = {
+    x: Number(candidate.x ?? element.x ?? 0),
+    y: Number(candidate.y ?? element.y ?? 0),
+    w: Number(candidate.width ?? element.width ?? 0),
+    h: Number(candidate.height ?? element.height ?? 0),
+  }
+
+  const plantaId = candidate.plantaId ?? element.plantaId
+
+  for (const n of neighbors) {
+    if (plantaId && n.plantaId && n.plantaId !== plantaId) continue
+
+    const aabbB = {
+      x: Number(n.x ?? 0),
+      y: Number(n.y ?? 0),
+      w: Number(n.width ?? 0),
+      h: Number(n.height ?? 0),
+    }
+
+    if (!aabbIntersect(aabbA, aabbB)) continue
+
+    const { zBaseCm: zBaseB, altoCm: altoB } = resolveVerticalProps(n, {})
+    if (!Number.isFinite(zBaseB) || !Number.isFinite(altoB)) continue
+    const zB0 = zBaseB
+    const zB1 = zBaseB + altoB
+
+    const overlap = Math.min(zA1, zB1) - Math.max(zA0, zB0)
+    if (overlap > Z_EPS) {
+      return { valid: false, code: 'Z_STACK_CONFLICT', offenderId: n.id }
+    }
+  }
+
+  return { valid: true }
+}
+
+export function validateCoplanarSameTypeNoOverlap() {
+  return { valid: true }
+}


### PR DESCRIPTION
## Summary
- detect vertical stack collisions with new `validateZStacking` rule and error messaging
- guard and store pipelines collect neighboring elements to enforce Z stacking
- expand test coverage for Z stacking conflicts and allowed placements

## Testing
- `npm run lint`
- `npx vitest run src/__tests__/placement-validators.spec.js src/__tests__/wall-placement-integration.spec.js src/__tests__/z-stacking-integration.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0771e020c8321ba4b631c987d7856