### PR TITLE
feat: centralize catalog context and filtering

### DIFF
--- a/src/components/ElementosCatalogo.vue
+++ b/src/components/ElementosCatalogo.vue
@@ -63,7 +63,7 @@
         </div>
 
         <!-- Filtro por categoría (select) -->
-        <div>
+        <div v-if="catalogContext.mode !== 'root'">
           <label for="filtroCategoria" class="sr-only">Categoría</label>
           <select
             id="filtroCategoria"
@@ -87,7 +87,7 @@
     <div class="elementos-lista flex-1 overflow-y-auto p-4">
       <div class="grid grid-cols-1 gap-3">
         <div
-          v-for="elemento in elementosFiltrados"
+          v-for="elemento in filteredCatalogItems"
           :key="elemento.id"
           :draggable="true"
           @dragstart="iniciarArrastre(elemento, $event)"
@@ -180,7 +180,7 @@
       </div>
 
       <!-- Mensaje cuando no hay elementos -->
-      <div v-if="elementosFiltrados.length === 0" class="text-center py-12">
+      <div v-if="filteredCatalogItems.length === 0" class="text-center py-12">
         <svg
           class="w-12 h-12 text-gray-300 mx-auto mb-4"
           fill="none"
@@ -215,9 +215,10 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useCanvasStore } from '@/composables/useCanvasStore'
+import { useCatalogStore } from '@/stores/catalog'
 import {
-  ELEMENTOS_PREDEFINIDOS,
   TODAS_LAS_CATEGORIAS,
   TIPOS_ENTIDAD,
   getColorPorTipo,
@@ -227,14 +228,16 @@ import {
 
 import ElementEditor from './modals/ElementEditor.vue'
 
-// Store
+// Stores
 const canvasStore = useCanvasStore()
+const catalogStore = useCatalogStore()
+const { filteredCatalogItems, catalogContext, searchText, selectedCategory, items } =
+  storeToRefs(catalogStore)
 
 // Estado local
-const filtroTexto = ref('')
-const categoriaSeleccionada = ref(null)
+const filtroTexto = searchText
+const categoriaSeleccionada = selectedCategory
 const mostrarModalCrear = ref(false)
-const elementosPersonalizados = ref([])
 
 // Formulario para nuevo elemento
 const nuevoElemento = ref({
@@ -255,80 +258,25 @@ const nuevoElemento = ref({
 
 // Computed: título dinámico según el contexto
 const tituloContextual = computed(() => {
-  const contexto = canvasStore.contextoActual.tipo
-
-  if (contexto === 'plantas') {
+  if (catalogContext.value.mode === 'root') {
     return 'Catálogo de Elementos'
-  } else if (contexto === 'elementos') {
+  } else if (catalogContext.value.mode === 'detail-element') {
     return 'Catálogo de Contenedores'
-  } else if (contexto === 'contenedores') {
+  } else if (catalogContext.value.mode === 'detail-container') {
     return 'Catálogo (Elementos + Contenedores)'
   }
-
   return 'Catálogo de Elementos'
 })
 
 // Computed: determina si se pueden crear elementos personalizados
-const puedeCrearElementosPersonalizados = computed(() => {
-  return true
-  // const contexto = canvasStore.contextoActual.tipo
-  // Solo permitir creación personalizada en plantas (elementos)
-  // Los contenedores son solo predefinidos
-  // return contexto === 'plantas'
-})
+const puedeCrearElementosPersonalizados = computed(
+  () => catalogContext.value.mode !== 'root',
+)
 
 // Computed: categorías disponibles según el contexto
 const categoriasDisponibles = computed(() => {
-  return TODAS_LAS_CATEGORIAS.filter((cat) => cat.tipo === 'elementos')
-  // const contexto = canvasStore.contextoActual.tipo
-  // if (contexto === 'plantas') {
-  //   // En plantas solo se pueden crear elementos
-  //   return TODAS_LAS_CATEGORIAS.filter((cat) => cat.tipo === 'elementos')
-  // } else if (contexto === 'elementos') {
-  //   // En elementos solo se pueden crear contenedores
-  //   return TODAS_LAS_CATEGORIAS.filter((cat) => cat.tipo === 'contenedores')
-  // } else if (contexto === 'contenedores') {
-  //   // En contenedores se pueden crear elementos Y contenedores
-  //   return TODAS_LAS_CATEGORIAS.filter(
-  //     (cat) => cat.tipo === 'elementos' || cat.tipo === 'contenedores',
-  //   )
-  // }
-
-  // return TODAS_LAS_CATEGORIAS
-})
-
-// Computed: elementos filtrados según contexto y filtros
-const elementosFiltrados = computed(() => {
-  let elementos = [...ELEMENTOS_PREDEFINIDOS, ...elementosPersonalizados.value]
-
-  // Filtrar por contexto (solo mostrar elementos apropiados)
-  const contexto = canvasStore.contextoActual.tipo
-  if (contexto === 'plantas') {
-    elementos = elementos.filter((el) => el.tipo === 'elementos')
-  } else if (contexto === 'elementos') {
-    elementos = elementos.filter((el) => el.tipo === 'contenedores')
-  } else if (contexto === 'contenedores') {
-    // Los contenedores pueden contener elementos Y otros contenedores
-    elementos = elementos.filter((el) => el.tipo === 'elementos' || el.tipo === 'contenedores')
-  }
-
-  // Filtrar por texto
-  if (filtroTexto.value) {
-    const texto = filtroTexto.value.toLowerCase()
-    elementos = elementos.filter(
-      (elemento) =>
-        elemento.nombre.toLowerCase().includes(texto) ||
-        elemento.descripcion.toLowerCase().includes(texto) ||
-        elemento.categoria.includes(texto),
-    )
-  }
-
-  // Filtrar por categoría
-  if (categoriaSeleccionada.value) {
-    elementos = elementos.filter((elemento) => elemento.categoria === categoriaSeleccionada.value)
-  }
-
-  return elementos
+  const tipos = catalogStore.allowedTypesForContext(catalogContext.value)
+  return TODAS_LAS_CATEGORIAS.filter((cat) => tipos.includes(cat.tipo))
 })
 
 const onGuardarElemento = (elemento) => {
@@ -340,7 +288,7 @@ const onGuardarElemento = (elemento) => {
     // Asegurar que tenga la propiedad tipo basada en la categoría
     tipo: elemento.categoria === 'contenedores' ? 'contenedores' : 'elementos',
   }
-  elementosPersonalizados.value.push(elementoNuevo)
+  items.value.push(elementoNuevo)
   cerrarModal()
   categoriaSeleccionada.value = elementoNuevo.categoria
   filtroTexto.value = ''
@@ -423,7 +371,7 @@ onMounted(() => {
   const elementosGuardados = localStorage.getItem('elementos-personalizados')
   if (elementosGuardados) {
     try {
-      elementosPersonalizados.value = JSON.parse(elementosGuardados)
+      JSON.parse(elementosGuardados).forEach((el) => items.value.push(el))
     } catch (error) {
       console.error('Error cargando elementos personalizados:', error)
     }
@@ -432,12 +380,13 @@ onMounted(() => {
 
 // Guardar elementos personalizados en localStorage
 const guardarElementosPersonalizados = () => {
-  localStorage.setItem('elementos-personalizados', JSON.stringify(elementosPersonalizados.value))
+  const personalizados = items.value.filter((el) => el.personalizado)
+  localStorage.setItem('elementos-personalizados', JSON.stringify(personalizados))
 }
 
 // Observar cambios en elementos personalizados para guardar
 watch(
-  () => elementosPersonalizados.value,
+  () => items.value,
   () => {
     guardarElementosPersonalizados()
   },
@@ -446,9 +395,24 @@ watch(
 
 // Observar cambios en el contexto para verificar validez del filtro de categoría
 watch(
-  () => canvasStore.contextoActual.tipo,
-  (_nuevoContexto) => {
-    categoriaSeleccionada.value = null
-  }
+  () => canvasStore.contextoActual,
+  (ctx) => {
+    if (ctx.tipo === 'plantas') {
+      catalogStore.setCatalogContext({ mode: 'root' })
+    } else if (ctx.tipo === 'elementos') {
+      catalogStore.setCatalogContext({
+        mode: 'detail-element',
+        currentId: ctx.id,
+        currentType: 'element',
+      })
+    } else if (ctx.tipo === 'contenedores') {
+      catalogStore.setCatalogContext({
+        mode: 'detail-container',
+        currentId: ctx.id,
+        currentType: 'container',
+      })
+    }
+  },
+  { immediate: true },
 )
 </script>

--- a/src/stores/catalog.js
+++ b/src/stores/catalog.js
@@ -1,0 +1,63 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import { ELEMENTOS_PREDEFINIDOS, JERARQUIA_PERMITIDA, CATALOGO } from '@/utils/constants'
+
+export const useCatalogStore = defineStore('catalog', () => {
+  const items = ref(ELEMENTOS_PREDEFINIDOS)
+  const searchText = ref('')
+  const selectedCategory = ref(null)
+
+  const catalogContext = ref({ mode: 'root', currentId: undefined, currentType: undefined })
+
+  const baseSystemGuard = (item) =>
+    item?.props?.system === true && item?.props?.catalogVisible !== false
+
+  const allowedTypesForContext = (context) => {
+    const map = {
+      root: 'plantas',
+      'detail-element': 'elementos',
+      'detail-container': 'contenedores',
+    }
+    const parent = map[context.mode]
+    return parent ? JERARQUIA_PERMITIDA[parent] || [] : []
+  }
+
+  const match = (texto) => (e) =>
+    e?.nombre?.toLowerCase?.().includes(texto?.toLowerCase?.() ?? '')
+
+  const filteredCatalogItems = computed(() => {
+    let result = items.value.filter(baseSystemGuard)
+
+    if (catalogContext.value.mode === 'root') {
+      result = result.filter((item) => CATALOGO.SISTEMA_BASE_KEYS.includes(item.id))
+    } else {
+      const allowed = allowedTypesForContext(catalogContext.value)
+      result = result.filter((item) => allowed.includes(item.tipo))
+    }
+
+    if (searchText.value) {
+      result = result.filter(match(searchText.value))
+    }
+
+    if (selectedCategory.value) {
+      result = result.filter((item) => item.categoria === selectedCategory.value)
+    }
+
+    return result
+  })
+
+  const setCatalogContext = (ctx) => {
+    catalogContext.value = ctx
+  }
+
+  return {
+    items,
+    searchText,
+    selectedCategory,
+    catalogContext,
+    setCatalogContext,
+    allowedTypesForContext,
+    baseSystemGuard,
+    filteredCatalogItems,
+  }
+})

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,6 +17,11 @@ export const JERARQUIA_PERMITIDA = {
   contenedores: ['elementos', 'contenedores'], // Los contenedores pueden contener elementos Y otros contenedores
 }
 
+export const CATALOGO = {
+  // Tipos base visibles en el catálogo raíz (plantas)
+  SISTEMA_BASE_KEYS: ['anaquel_metalico_grande', 'estante_pared_pequeno', 'barril_basico'],
+}
+
 export const ELEMENTOS_PREDEFINIDOS = [
   // === ELEMENTOS (solo pueden ir en plantas) ===
 
@@ -37,6 +42,7 @@ export const ELEMENTOS_PREDEFINIDOS = [
     ubicacion: 'suelo',
     descripcion: 'Anaquel metálico de alta capacidad para almacenamiento pesado',
     icono: 'rack',
+    props: { system: true },
   },
 
   // Estante de pared
@@ -57,6 +63,7 @@ export const ELEMENTOS_PREDEFINIDOS = [
     alturaRespectoAlSuelo: 150, // cm - altura típica para estantes de pared
     descripcion: 'Estante montado en pared para almacenamiento ligero',
     icono: 'shelf',
+    props: { system: true },
   },
 
   // Armario de pared
@@ -77,6 +84,27 @@ export const ELEMENTOS_PREDEFINIDOS = [
     alturaRespectoAlSuelo: 50, // cm - altura moderada para armarios
     descripcion: 'Armario montado en pared para almacenamiento vertical',
     icono: 'cabinet',
+    props: { system: true },
+  },
+
+  // Barril
+  {
+    id: 'barril_basico',
+    nombre: 'Barril',
+    tipo: 'elementos',
+    categoria: 'contenedores',
+    forma: 'circular',
+    colorBase: '#f97316',
+    dimensiones: {
+      ancho: 60,
+      largo: 60,
+      alto: 90,
+    },
+    pesoMaximo: 200, // kg
+    ubicacion: 'suelo',
+    descripcion: 'Barril estándar de madera',
+    icono: 'barrel',
+    props: { system: true },
   },
 
   // === CONTENEDORES (solo pueden ir en elementos) ===
@@ -98,6 +126,7 @@ export const ELEMENTOS_PREDEFINIDOS = [
     ubicacion: 'interior',
     descripcion: 'Contenedor básico para almacenamiento organizado (redimensionable)',
     icono: 'box',
+    props: { system: true },
   },
 ]
 


### PR DESCRIPTION
## Summary
- centralize catalog context in new Pinia store
- filter catalog items by hierarchy, text and category
- hide add controls on root and surface allowed types per view

## Testing
- `npm run lint` *(fails: 'process' is not defined)*
- `npm run test:unit` *(fails: getActivePinia was called but there was no active Pinia, 29 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ba009108321a37e3cc6124bee98