### PR TITLE
feat: contextual catalog filtering and store

### DIFF
--- a/src/__tests__/catalog-store.spec.js
+++ b/src/__tests__/catalog-store.spec.js
@@ -1,0 +1,90 @@
+import { describe, expect, test, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { nextTick } from 'vue'
+import {
+  useCatalogStore,
+  baseSystemGuard,
+  allowedTypesForContext,
+} from '@/stores/catalog'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import { CATALOGO, JERARQUIA_PERMITIDA } from '@/utils/constants'
+
+describe('baseSystemGuard', () => {
+  test('allows system items visible in catalog', () => {
+    const item = { props: { system: true } }
+    expect(baseSystemGuard(item)).toBe(true)
+  })
+
+  test('rejects items with catalogVisible false', () => {
+    const item = { props: { system: true, catalogVisible: false } }
+    expect(baseSystemGuard(item)).toBe(false)
+  })
+})
+
+describe('allowedTypesForContext', () => {
+  test('root returns system base keys', () => {
+    expect(allowedTypesForContext({ mode: 'root' })).toEqual(
+      CATALOGO.SISTEMA_BASE_KEYS,
+    )
+  })
+
+  test('detail-element returns contenedores', () => {
+    expect(allowedTypesForContext({ mode: 'detail-element' })).toEqual(
+      JERARQUIA_PERMITIDA.elementos,
+    )
+  })
+
+  test('detail-container returns elementos y contenedores', () => {
+    expect(allowedTypesForContext({ mode: 'detail-container' })).toEqual(
+      JERARQUIA_PERMITIDA.contenedores,
+    )
+  })
+})
+
+describe('filteredCatalogItems', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  test('filters by context, text and category', async () => {
+    const canvas = useCanvasStore()
+    const catalog = useCatalogStore()
+
+    catalog.items = [
+      {
+        id: 'anaquel_metalico_grande',
+        nombre: 'Anaquel',
+        tipo: 'elementos',
+        categoria: 'anaqueles',
+        props: { system: true },
+      },
+      {
+        id: 'estante_pared_pequeno',
+        nombre: 'Estante',
+        tipo: 'elementos',
+        categoria: 'estantes',
+        props: { system: true },
+      },
+      {
+        id: 'contenedor_base',
+        nombre: 'Contenedor',
+        tipo: 'contenedores',
+        categoria: 'contenedores',
+        props: { system: true },
+      },
+    ]
+
+    canvas.contextoNavegacion = { tipo: 'plantas', id: 'p1', path: [] }
+    await nextTick()
+    catalog.searchText = 'est'
+    expect(catalog.filteredCatalogItems).toHaveLength(1)
+    expect(catalog.filteredCatalogItems[0].id).toBe('estante_pared_pequeno')
+
+    canvas.contextoNavegacion = { tipo: 'elementos', id: 'e1', path: [] }
+    await nextTick()
+    catalog.searchText = ''
+    catalog.selectedCategory = 'contenedores'
+    expect(catalog.filteredCatalogItems).toHaveLength(1)
+    expect(catalog.filteredCatalogItems[0].id).toBe('contenedor_base')
+  })
+})

--- a/src/components/ElementosCatalogo.vue
+++ b/src/components/ElementosCatalogo.vue
@@ -63,7 +63,7 @@
         </div>
 
         <!-- Filtro por categoría (select) -->
-        <div>
+        <div v-if="!esModoRoot">
           <label for="filtroCategoria" class="sr-only">Categoría</label>
           <select
             id="filtroCategoria"
@@ -214,10 +214,9 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
-import { useCanvasStore } from '@/composables/useCanvasStore'
+import { ref, computed, watch } from 'vue'
+import { useCatalogStore } from '@/stores/catalog'
 import {
-  ELEMENTOS_PREDEFINIDOS,
   TODAS_LAS_CATEGORIAS,
   TIPOS_ENTIDAD,
   getColorPorTipo,
@@ -227,14 +226,22 @@ import {
 
 import ElementEditor from './modals/ElementEditor.vue'
 
-// Store
-const canvasStore = useCanvasStore()
+// Stores
+const catalogStore = useCatalogStore()
 
 // Estado local
-const filtroTexto = ref('')
-const categoriaSeleccionada = ref(null)
+const filtroTexto = computed({
+  get: () => catalogStore.searchText,
+  set: (val) => (catalogStore.searchText = val),
+})
+const categoriaSeleccionada = computed({
+  get: () => catalogStore.selectedCategory,
+  set: (val) => (catalogStore.selectedCategory = val),
+})
 const mostrarModalCrear = ref(false)
-const elementosPersonalizados = ref([])
+const esModoRoot = computed(
+  () => catalogStore.catalogContext.mode === 'root',
+)
 
 // Formulario para nuevo elemento
 const nuevoElemento = ref({
@@ -255,81 +262,31 @@ const nuevoElemento = ref({
 
 // Computed: título dinámico según el contexto
 const tituloContextual = computed(() => {
-  const contexto = canvasStore.contextoActual.tipo
-
-  if (contexto === 'plantas') {
-    return 'Catálogo de Elementos'
-  } else if (contexto === 'elementos') {
-    return 'Catálogo de Contenedores'
-  } else if (contexto === 'contenedores') {
+  const mode = catalogStore.catalogContext.mode
+  if (mode === 'root') return 'Catálogo de Elementos'
+  if (mode === 'detail-element') return 'Catálogo de Contenedores'
+  if (mode === 'detail-container')
     return 'Catálogo (Elementos + Contenedores)'
-  }
-
   return 'Catálogo de Elementos'
 })
 
 // Computed: determina si se pueden crear elementos personalizados
 const puedeCrearElementosPersonalizados = computed(() => {
-  return true
-  // const contexto = canvasStore.contextoActual.tipo
-  // Solo permitir creación personalizada en plantas (elementos)
-  // Los contenedores son solo predefinidos
-  // return contexto === 'plantas'
+  return catalogStore.catalogContext.mode !== 'root'
 })
 
 // Computed: categorías disponibles según el contexto
 const categoriasDisponibles = computed(() => {
-  return TODAS_LAS_CATEGORIAS.filter((cat) => cat.tipo === 'elementos')
-  // const contexto = canvasStore.contextoActual.tipo
-  // if (contexto === 'plantas') {
-  //   // En plantas solo se pueden crear elementos
-  //   return TODAS_LAS_CATEGORIAS.filter((cat) => cat.tipo === 'elementos')
-  // } else if (contexto === 'elementos') {
-  //   // En elementos solo se pueden crear contenedores
-  //   return TODAS_LAS_CATEGORIAS.filter((cat) => cat.tipo === 'contenedores')
-  // } else if (contexto === 'contenedores') {
-  //   // En contenedores se pueden crear elementos Y contenedores
-  //   return TODAS_LAS_CATEGORIAS.filter(
-  //     (cat) => cat.tipo === 'elementos' || cat.tipo === 'contenedores',
-  //   )
-  // }
-
-  // return TODAS_LAS_CATEGORIAS
+  const allowed = catalogStore.allowedTypesForContext(
+    catalogStore.catalogContext,
+  )
+  return TODAS_LAS_CATEGORIAS.filter((cat) => allowed.includes(cat.tipo))
 })
 
 // Computed: elementos filtrados según contexto y filtros
-const elementosFiltrados = computed(() => {
-  let elementos = [...ELEMENTOS_PREDEFINIDOS, ...elementosPersonalizados.value]
-
-  // Filtrar por contexto (solo mostrar elementos apropiados)
-  const contexto = canvasStore.contextoActual.tipo
-  if (contexto === 'plantas') {
-    elementos = elementos.filter((el) => el.tipo === 'elementos')
-  } else if (contexto === 'elementos') {
-    elementos = elementos.filter((el) => el.tipo === 'contenedores')
-  } else if (contexto === 'contenedores') {
-    // Los contenedores pueden contener elementos Y otros contenedores
-    elementos = elementos.filter((el) => el.tipo === 'elementos' || el.tipo === 'contenedores')
-  }
-
-  // Filtrar por texto
-  if (filtroTexto.value) {
-    const texto = filtroTexto.value.toLowerCase()
-    elementos = elementos.filter(
-      (elemento) =>
-        elemento.nombre.toLowerCase().includes(texto) ||
-        elemento.descripcion.toLowerCase().includes(texto) ||
-        elemento.categoria.includes(texto),
-    )
-  }
-
-  // Filtrar por categoría
-  if (categoriaSeleccionada.value) {
-    elementos = elementos.filter((elemento) => elemento.categoria === categoriaSeleccionada.value)
-  }
-
-  return elementos
-})
+const elementosFiltrados = computed(
+  () => catalogStore.filteredCatalogItems,
+)
 
 const onGuardarElemento = (elemento) => {
   const elementoNuevo = {
@@ -340,7 +297,7 @@ const onGuardarElemento = (elemento) => {
     // Asegurar que tenga la propiedad tipo basada en la categoría
     tipo: elemento.categoria === 'contenedores' ? 'contenedores' : 'elementos',
   }
-  elementosPersonalizados.value.push(elementoNuevo)
+  catalogStore.addCustomItem(elementoNuevo)
   cerrarModal()
   categoriaSeleccionada.value = elementoNuevo.categoria
   filtroTexto.value = ''
@@ -417,37 +374,10 @@ const cerrarModal = () => {
   mostrarModalCrear.value = false
   // El formulario se resetea automáticamente al abrir el modal
 }
-
-// Cargar elementos personalizados del localStorage
-onMounted(() => {
-  const elementosGuardados = localStorage.getItem('elementos-personalizados')
-  if (elementosGuardados) {
-    try {
-      elementosPersonalizados.value = JSON.parse(elementosGuardados)
-    } catch (error) {
-      console.error('Error cargando elementos personalizados:', error)
-    }
-  }
-})
-
-// Guardar elementos personalizados en localStorage
-const guardarElementosPersonalizados = () => {
-  localStorage.setItem('elementos-personalizados', JSON.stringify(elementosPersonalizados.value))
-}
-
-// Observar cambios en elementos personalizados para guardar
-watch(
-  () => elementosPersonalizados.value,
-  () => {
-    guardarElementosPersonalizados()
-  },
-  { deep: true },
-)
-
 // Observar cambios en el contexto para verificar validez del filtro de categoría
 watch(
-  () => canvasStore.contextoActual.tipo,
-  (_nuevoContexto) => {
+  () => catalogStore.catalogContext.mode,
+  () => {
     categoriaSeleccionada.value = null
   }
 )

--- a/src/stores/catalog.js
+++ b/src/stores/catalog.js
@@ -1,0 +1,95 @@
+import { defineStore } from 'pinia'
+import { ref, computed, watch } from 'vue'
+import {
+  ELEMENTOS_PREDEFINIDOS,
+  JERARQUIA_PERMITIDA,
+  CATALOGO,
+} from '@/utils/constants'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+
+export const baseSystemGuard = (item) =>
+  item?.props?.system === true && item?.props?.catalogVisible !== false
+
+export const allowedTypesForContext = (context) => {
+  if (context.mode === 'root') {
+    return CATALOGO.SISTEMA_BASE_KEYS
+  }
+  if (context.mode === 'detail-element') {
+    return JERARQUIA_PERMITIDA.elementos || []
+  }
+  if (context.mode === 'detail-container') {
+    return JERARQUIA_PERMITIDA.contenedores || []
+  }
+  return []
+}
+
+export const match = (texto) => (e) =>
+  e?.nombre?.toLowerCase?.().includes(texto?.toLowerCase?.() ?? '')
+
+export const useCatalogStore = defineStore('catalog', () => {
+  const canvasStore = useCanvasStore()
+
+  const items = ref([...ELEMENTOS_PREDEFINIDOS])
+  const catalogContext = ref({ mode: 'root' })
+
+  const syncContext = () => {
+    const ctx = canvasStore.contextoActual
+    if (ctx.tipo === 'plantas') {
+      catalogContext.value = { mode: 'root' }
+    } else if (ctx.tipo === 'elementos') {
+      catalogContext.value = {
+        mode: 'detail-element',
+        currentId: ctx.id,
+        currentType: 'element',
+      }
+    } else if (ctx.tipo === 'contenedores') {
+      catalogContext.value = {
+        mode: 'detail-container',
+        currentId: ctx.id,
+        currentType: 'container',
+      }
+    }
+  }
+
+  syncContext()
+  watch(
+    () => canvasStore.contextoActual,
+    () => syncContext(),
+    { deep: true }
+  )
+
+  const searchText = ref('')
+  const selectedCategory = ref(null)
+
+  const filteredCatalogItems = computed(() => {
+    let result = items.value.filter(baseSystemGuard)
+    const context = catalogContext.value
+    if (context.mode === 'root') {
+      result = result.filter((e) => CATALOGO.SISTEMA_BASE_KEYS.includes(e.id))
+    } else {
+      const allowed = allowedTypesForContext(context)
+      result = result.filter((e) => allowed.includes(e.tipo))
+    }
+    if (searchText.value) {
+      result = result.filter(match(searchText.value))
+    }
+    if (selectedCategory.value) {
+      result = result.filter((e) => e.categoria === selectedCategory.value)
+    }
+    return result
+  })
+
+  const addCustomItem = (item) => {
+    items.value.push(item)
+  }
+
+  return {
+    items,
+    catalogContext,
+    searchText,
+    selectedCategory,
+    filteredCatalogItems,
+    addCustomItem,
+    allowedTypesForContext,
+  }
+})

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,6 +17,14 @@ export const JERARQUIA_PERMITIDA = {
   contenedores: ['elementos', 'contenedores'], // Los contenedores pueden contener elementos Y otros contenedores
 }
 
+export const CATALOGO = {
+  SISTEMA_BASE_KEYS: [
+    'anaquel_metalico_grande',
+    'estante_pared_pequeno',
+    'armario_pared_alto',
+  ],
+}
+
 export const ELEMENTOS_PREDEFINIDOS = [
   // === ELEMENTOS (solo pueden ir en plantas) ===
 
@@ -37,6 +45,10 @@ export const ELEMENTOS_PREDEFINIDOS = [
     ubicacion: 'suelo',
     descripcion: 'Anaquel metálico de alta capacidad para almacenamiento pesado',
     icono: 'rack',
+    props: {
+      system: true,
+      catalogVisible: true,
+    },
   },
 
   // Estante de pared
@@ -57,6 +69,10 @@ export const ELEMENTOS_PREDEFINIDOS = [
     alturaRespectoAlSuelo: 150, // cm - altura típica para estantes de pared
     descripcion: 'Estante montado en pared para almacenamiento ligero',
     icono: 'shelf',
+    props: {
+      system: true,
+      catalogVisible: true,
+    },
   },
 
   // Armario de pared
@@ -77,6 +93,10 @@ export const ELEMENTOS_PREDEFINIDOS = [
     alturaRespectoAlSuelo: 50, // cm - altura moderada para armarios
     descripcion: 'Armario montado en pared para almacenamiento vertical',
     icono: 'cabinet',
+    props: {
+      system: true,
+      catalogVisible: true,
+    },
   },
 
   // === CONTENEDORES (solo pueden ir en elementos) ===
@@ -98,6 +118,10 @@ export const ELEMENTOS_PREDEFINIDOS = [
     ubicacion: 'interior',
     descripcion: 'Contenedor básico para almacenamiento organizado (redimensionable)',
     icono: 'box',
+    props: {
+      system: true,
+      catalogVisible: true,
+    },
   },
 ]
 


### PR DESCRIPTION
## Summary
- centralize catalog context in new Pinia store with hierarchy-based filtering
- reuse constants to expose base system items and guard visibility
- adapt catalog component to hide category controls at root and use new store
- add unit tests for catalog store filtering and guards

## Testing
- `npm run test:unit` *(fails: AssertionError & TypeError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ba009108321a37e3cc6124bee98