### PR TITLE
feat: contexto catalogo en store

### DIFF
--- a/src/__tests__/catalog-store.spec.js
+++ b/src/__tests__/catalog-store.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useCatalogStore } from '@/stores/catalog'
+import { JERARQUIA_PERMITIDA, CATALOGO } from '@/utils/constants'
+
+describe('Catalog store', () => {
+  let store
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useCatalogStore()
+    store.items = [
+      {
+        id: 'anaquel_metalico_grande',
+        nombre: 'Anaquel',
+        tipo: 'elementos',
+        categoria: 'anaqueles',
+        props: { system: true },
+      },
+      {
+        id: 'estante_pared_pequeno',
+        nombre: 'Estante de Pared',
+        tipo: 'elementos',
+        categoria: 'estantes',
+        props: { system: true },
+      },
+      {
+        id: 'barril_plastico_200l',
+        nombre: 'Barril',
+        tipo: 'elementos',
+        categoria: 'barriles',
+        props: { system: true },
+      },
+      {
+        id: 'contenedor_base',
+        nombre: 'Contenedor Base',
+        tipo: 'contenedores',
+        categoria: 'contenedores',
+        props: { system: true },
+      },
+    ]
+    store.searchText = ''
+    store.selectedCategory = null
+    store.setContext({ mode: 'root', currentId: undefined, currentType: undefined })
+  })
+
+  it('baseSystemGuard respects system and catalogVisible', () => {
+    expect(store.baseSystemGuard({ props: { system: true } })).toBe(true)
+    expect(store.baseSystemGuard({ props: { system: false } })).toBe(false)
+    expect(
+      store.baseSystemGuard({ props: { system: true, catalogVisible: false } }),
+    ).toBe(false)
+  })
+
+  it('allowedTypesForContext derives from hierarchy', () => {
+    expect(store.allowedTypesForContext({ mode: 'root' })).toEqual(
+      JERARQUIA_PERMITIDA.plantas,
+    )
+    expect(store.allowedTypesForContext({ mode: 'detail-element' })).toEqual(
+      JERARQUIA_PERMITIDA.elementos,
+    )
+    expect(store.allowedTypesForContext({ mode: 'detail-container' })).toEqual(
+      JERARQUIA_PERMITIDA.contenedores,
+    )
+  })
+
+  it('filters root catalog to base system keys', () => {
+    const ids = store.filteredCatalogItems.map((i) => i.id)
+    expect(ids.sort()).toEqual(CATALOGO.SISTEMA_BASE_KEYS.slice().sort())
+  })
+
+  it('filters by hierarchy and text', () => {
+    store.setContext({ mode: 'detail-container' })
+    store.searchText = 'barril'
+    const ids = store.filteredCatalogItems.map((i) => i.id)
+    expect(ids).toEqual(['barril_plastico_200l'])
+  })
+
+  it('applies category filter in pipeline', () => {
+    store.setContext({ mode: 'detail-container' })
+    store.selectedCategory = 'anaqueles'
+    const ids = store.filteredCatalogItems.map((i) => i.id)
+    expect(ids).toEqual(['anaquel_metalico_grande'])
+  })
+})

--- a/src/components/ElementosCatalogo.vue
+++ b/src/components/ElementosCatalogo.vue
@@ -20,7 +20,7 @@
       <div class="flex items-center justify-between mb-3">
         <h2 class="text-base font-semibold text-gray-800 m-0">{{ tituloContextual }}</h2>
         <button
-          v-if="puedeCrearElementosPersonalizados"
+          v-if="!esModoRaiz && puedeCrearElementosPersonalizados"
           @click="mostrarModalCrear = true"
           type="button"
           class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-blue-500 hover:bg-blue-600 text-white shadow focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
@@ -42,7 +42,7 @@
         <!-- Barra de búsqueda -->
         <div class="relative">
           <input
-            v-model="filtroTexto"
+            v-model="catalogStore.searchText"
             type="text"
             placeholder="Buscar elementos..."
             class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-100"
@@ -63,11 +63,11 @@
         </div>
 
         <!-- Filtro por categoría (select) -->
-        <div>
+        <div v-if="!esModoRaiz">
           <label for="filtroCategoria" class="sr-only">Categoría</label>
           <select
             id="filtroCategoria"
-            v-model="categoriaSeleccionada"
+            v-model="catalogStore.selectedCategory"
             class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-100"
           >
             <option :value="null">Todas las categorías</option>
@@ -87,7 +87,7 @@
     <div class="elementos-lista flex-1 overflow-y-auto p-4">
       <div class="grid grid-cols-1 gap-3">
         <div
-          v-for="elemento in elementosFiltrados"
+          v-for="elemento in catalogStore.filteredCatalogItems"
           :key="elemento.id"
           :draggable="true"
           @dragstart="iniciarArrastre(elemento, $event)"
@@ -180,7 +180,7 @@
       </div>
 
       <!-- Mensaje cuando no hay elementos -->
-      <div v-if="elementosFiltrados.length === 0" class="text-center py-12">
+      <div v-if="catalogStore.filteredCatalogItems.length === 0" class="text-center py-12">
         <svg
           class="w-12 h-12 text-gray-300 mx-auto mb-4"
           fill="none"
@@ -215,9 +215,8 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { useCanvasStore } from '@/composables/useCanvasStore'
+import { useCatalogStore } from '@/stores/catalog'
 import {
-  ELEMENTOS_PREDEFINIDOS,
   TODAS_LAS_CATEGORIAS,
   TIPOS_ENTIDAD,
   getColorPorTipo,
@@ -228,13 +227,10 @@ import {
 import ElementEditor from './modals/ElementEditor.vue'
 
 // Store
-const canvasStore = useCanvasStore()
+const catalogStore = useCatalogStore()
 
 // Estado local
-const filtroTexto = ref('')
-const categoriaSeleccionada = ref(null)
 const mostrarModalCrear = ref(false)
-const elementosPersonalizados = ref([])
 
 // Formulario para nuevo elemento
 const nuevoElemento = ref({
@@ -255,18 +251,20 @@ const nuevoElemento = ref({
 
 // Computed: título dinámico según el contexto
 const tituloContextual = computed(() => {
-  const contexto = canvasStore.contextoActual.tipo
-
-  if (contexto === 'plantas') {
+  const mode = catalogStore.catalogContext.mode
+  if (mode === 'root') {
     return 'Catálogo de Elementos'
-  } else if (contexto === 'elementos') {
+  }
+  if (mode === 'detail-element') {
     return 'Catálogo de Contenedores'
-  } else if (contexto === 'contenedores') {
+  }
+  if (mode === 'detail-container') {
     return 'Catálogo (Elementos + Contenedores)'
   }
-
   return 'Catálogo de Elementos'
 })
+
+const esModoRaiz = computed(() => catalogStore.catalogContext.mode === 'root')
 
 // Computed: determina si se pueden crear elementos personalizados
 const puedeCrearElementosPersonalizados = computed(() => {
@@ -298,38 +296,6 @@ const categoriasDisponibles = computed(() => {
 })
 
 // Computed: elementos filtrados según contexto y filtros
-const elementosFiltrados = computed(() => {
-  let elementos = [...ELEMENTOS_PREDEFINIDOS, ...elementosPersonalizados.value]
-
-  // Filtrar por contexto (solo mostrar elementos apropiados)
-  const contexto = canvasStore.contextoActual.tipo
-  if (contexto === 'plantas') {
-    elementos = elementos.filter((el) => el.tipo === 'elementos')
-  } else if (contexto === 'elementos') {
-    elementos = elementos.filter((el) => el.tipo === 'contenedores')
-  } else if (contexto === 'contenedores') {
-    // Los contenedores pueden contener elementos Y otros contenedores
-    elementos = elementos.filter((el) => el.tipo === 'elementos' || el.tipo === 'contenedores')
-  }
-
-  // Filtrar por texto
-  if (filtroTexto.value) {
-    const texto = filtroTexto.value.toLowerCase()
-    elementos = elementos.filter(
-      (elemento) =>
-        elemento.nombre.toLowerCase().includes(texto) ||
-        elemento.descripcion.toLowerCase().includes(texto) ||
-        elemento.categoria.includes(texto),
-    )
-  }
-
-  // Filtrar por categoría
-  if (categoriaSeleccionada.value) {
-    elementos = elementos.filter((elemento) => elemento.categoria === categoriaSeleccionada.value)
-  }
-
-  return elementos
-})
 
 const onGuardarElemento = (elemento) => {
   const elementoNuevo = {
@@ -340,10 +306,13 @@ const onGuardarElemento = (elemento) => {
     // Asegurar que tenga la propiedad tipo basada en la categoría
     tipo: elemento.categoria === 'contenedores' ? 'contenedores' : 'elementos',
   }
-  elementosPersonalizados.value.push(elementoNuevo)
+  catalogStore.addCustomItem({
+    ...elementoNuevo,
+    props: { system: true },
+  })
   cerrarModal()
-  categoriaSeleccionada.value = elementoNuevo.categoria
-  filtroTexto.value = ''
+  catalogStore.selectedCategory = elementoNuevo.categoria
+  catalogStore.searchText = ''
 }
 
 // Métodos
@@ -355,6 +324,11 @@ const getTipoNombre = (tipo) => {
 const getCategoriaName = (categoriaId) => {
   const categoria = TODAS_LAS_CATEGORIAS.find((c) => c.id === categoriaId)
   return categoria ? categoria.nombre : 'Sin categoría'
+}
+
+const getColorCategoria = (categoriaId) => {
+  const categoria = TODAS_LAS_CATEGORIAS.find((c) => c.id === categoriaId)
+  return categoria?.color || '#6b7280'
 }
 
 const getIconComponent = (iconType) => {
@@ -423,32 +397,24 @@ onMounted(() => {
   const elementosGuardados = localStorage.getItem('elementos-personalizados')
   if (elementosGuardados) {
     try {
-      elementosPersonalizados.value = JSON.parse(elementosGuardados)
+      const cargados = JSON.parse(elementosGuardados)
+      cargados.forEach((el) => catalogStore.addCustomItem(el))
     } catch (error) {
       console.error('Error cargando elementos personalizados:', error)
     }
   }
 })
 
-// Guardar elementos personalizados en localStorage
 const guardarElementosPersonalizados = () => {
-  localStorage.setItem('elementos-personalizados', JSON.stringify(elementosPersonalizados.value))
+  const personalizados = catalogStore.items.filter((el) => el.personalizado)
+  localStorage.setItem('elementos-personalizados', JSON.stringify(personalizados))
 }
 
-// Observar cambios en elementos personalizados para guardar
 watch(
-  () => elementosPersonalizados.value,
+  () => catalogStore.items,
   () => {
     guardarElementosPersonalizados()
   },
   { deep: true },
-)
-
-// Observar cambios en el contexto para verificar validez del filtro de categoría
-watch(
-  () => canvasStore.contextoActual.tipo,
-  (_nuevoContexto) => {
-    categoriaSeleccionada.value = null
-  }
 )
 </script>

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -17,6 +17,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { CM_TO_PX } from '@/utils/constants'
+import { useCatalogStore } from '@/stores/catalog'
 import {
   validateWallZBaseRequired,
   validateHeightWithinWarehouse,
@@ -120,6 +121,22 @@ export const useCanvasStore = defineStore('canvas', () => {
     id: 'planta_1', // ID de la planta, elemento o contenedor actual
     path: [], // Array de objetos: [{ tipo: 'plantas', id: 'planta_1', nombre: 'Planta Baja' }]
   })
+
+  const catalogStore = useCatalogStore()
+
+  watch(
+    contextoNavegacion,
+    (ctx) => {
+      if (ctx.tipo === 'plantas') {
+        catalogStore.setContext({ mode: 'root', currentId: ctx.id, currentType: undefined })
+      } else if (ctx.tipo === 'elementos') {
+        catalogStore.setContext({ mode: 'detail-element', currentId: ctx.id, currentType: 'element' })
+      } else if (ctx.tipo === 'contenedores') {
+        catalogStore.setContext({ mode: 'detail-container', currentId: ctx.id, currentType: 'container' })
+      }
+    },
+    { immediate: true, deep: true },
+  )
 
   // Tamaño del canvas adaptativo según el contexto
   const canvasAdaptativo = ref({

--- a/src/stores/catalog.js
+++ b/src/stores/catalog.js
@@ -1,0 +1,75 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { ELEMENTOS_PREDEFINIDOS, JERARQUIA_PERMITIDA, CATALOGO } from '@/utils/constants'
+
+export const useCatalogStore = defineStore('catalog', () => {
+  const items = ref([...ELEMENTOS_PREDEFINIDOS])
+  const searchText = ref('')
+  const selectedCategory = ref(null)
+  const catalogContext = ref({ mode: 'root', currentId: undefined, currentType: undefined })
+
+  const baseSystemGuard = (item) =>
+    item?.props?.system === true && item?.props?.catalogVisible !== false
+
+  const allowedTypesForContext = (context) => {
+    switch (context.mode) {
+      case 'root':
+        return JERARQUIA_PERMITIDA.plantas || []
+      case 'detail-element':
+        return JERARQUIA_PERMITIDA.elementos || []
+      case 'detail-container':
+        return JERARQUIA_PERMITIDA.contenedores || []
+      default:
+        return []
+    }
+  }
+
+  const isOneOfSystemBaseTypes = (item) =>
+    CATALOGO.SISTEMA_BASE_KEYS.includes(item.id)
+
+  const isAllowedByHierarchy = (context) => (item) =>
+    allowedTypesForContext(context).includes(item.tipo)
+
+  const match = (texto) => (e) =>
+    e?.nombre?.toLowerCase?.().includes(texto?.toLowerCase?.() ?? '')
+
+  const filteredCatalogItems = computed(() => {
+    let result = items.value.filter(baseSystemGuard)
+
+    if (catalogContext.value.mode === 'root') {
+      result = result.filter(isOneOfSystemBaseTypes)
+    } else {
+      result = result.filter(isAllowedByHierarchy(catalogContext.value))
+    }
+
+    if (searchText.value) {
+      result = result.filter(match(searchText.value))
+    }
+
+    if (selectedCategory.value) {
+      result = result.filter((item) => item.categoria === selectedCategory.value)
+    }
+
+    return result
+  })
+
+  const setContext = (ctx) => {
+    catalogContext.value = { ...catalogContext.value, ...ctx }
+  }
+
+  const addCustomItem = (item) => {
+    items.value.push(item)
+  }
+
+  return {
+    items,
+    searchText,
+    selectedCategory,
+    catalogContext,
+    baseSystemGuard,
+    allowedTypesForContext,
+    filteredCatalogItems,
+    setContext,
+    addCustomItem,
+  }
+})

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -10,6 +10,14 @@ export const TIPOS_ENTIDAD = [
   { id: 'contenedores', nombre: 'Contenedores', color: '#dc2626', icono: '🗃️' },
 ]
 
+export const CATALOGO = {
+  SISTEMA_BASE_KEYS: [
+    'anaquel_metalico_grande',
+    'estante_pared_pequeno',
+    'barril_plastico_200l',
+  ],
+}
+
 // === REGLAS DE JERARQUÍA ===
 export const JERARQUIA_PERMITIDA = {
   plantas: ['elementos'], // Las plantas pueden contener elementos
@@ -37,6 +45,7 @@ export const ELEMENTOS_PREDEFINIDOS = [
     ubicacion: 'suelo',
     descripcion: 'Anaquel metálico de alta capacidad para almacenamiento pesado',
     icono: 'rack',
+    props: { system: true },
   },
 
   // Estante de pared
@@ -57,6 +66,7 @@ export const ELEMENTOS_PREDEFINIDOS = [
     alturaRespectoAlSuelo: 150, // cm - altura típica para estantes de pared
     descripcion: 'Estante montado en pared para almacenamiento ligero',
     icono: 'shelf',
+    props: { system: true },
   },
 
   // Armario de pared
@@ -77,6 +87,27 @@ export const ELEMENTOS_PREDEFINIDOS = [
     alturaRespectoAlSuelo: 50, // cm - altura moderada para armarios
     descripcion: 'Armario montado en pared para almacenamiento vertical',
     icono: 'cabinet',
+    props: { system: true },
+  },
+
+  // Barril
+  {
+    id: 'barril_plastico_200l',
+    nombre: 'Barril 200L',
+    tipo: 'elementos',
+    categoria: 'barriles',
+    forma: 'circular',
+    colorBase: '#f97316',
+    dimensiones: {
+      ancho: 60,
+      largo: 60,
+      alto: 90,
+    },
+    pesoMaximo: 200,
+    ubicacion: 'suelo',
+    descripcion: 'Barril plástico de 200 litros',
+    icono: 'box',
+    props: { system: true },
   },
 
   // === CONTENEDORES (solo pueden ir en elementos) ===
@@ -98,6 +129,7 @@ export const ELEMENTOS_PREDEFINIDOS = [
     ubicacion: 'interior',
     descripcion: 'Contenedor básico para almacenamiento organizado (redimensionable)',
     icono: 'box',
+    props: { system: true },
   },
 ]
 
@@ -107,6 +139,7 @@ export const CATEGORIAS_ELEMENTOS = [
   { id: 'estantes', nombre: 'Estantes', color: '#10b981', tipo: 'elementos' },
   { id: 'mesas', nombre: 'Mesas', color: '#f59e0b', tipo: 'elementos' },
   { id: 'armarios', nombre: 'Armarios', color: '#7c3aed', tipo: 'elementos' },
+  { id: 'barriles', nombre: 'Barriles', color: '#f97316', tipo: 'elementos' },
 ]
 
 export const CATEGORIAS_CONTENEDORES = [
@@ -119,6 +152,7 @@ export const CATEGORIAS = [
   { id: 'estantes', nombre: 'Estantes', color: '#10b981' },
   { id: 'mesas', nombre: 'Mesas', color: '#f59e0b' },
   { id: 'armarios', nombre: 'Armarios', color: '#7c3aed' },
+  { id: 'barriles', nombre: 'Barriles', color: '#f97316' },
   { id: 'contenedores', nombre: 'Contenedores', color: '#dc2626' },
 ]
 


### PR DESCRIPTION
## Summary
- agrega constantes de catalogo y nuevo barril base
- crea store de catalogo con contexto y filtros jerárquicos
- sincroniza navegación del canvas con contexto de catálogo
- ajusta ElementosCatalogo para usar el store y ocultar controles en raíz
- añade pruebas unitarias del store

## Testing
- `npm run test:unit -- --run` *(fails: [🍍]: "getActivePinia()" was called but there was no active Pinia. Are you trying to use a store before calling "app.use(pinia)"? ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ba009108321a37e3cc6124bee98