### PR TITLE
refactor properties panel

### DIFF
--- a/src/__tests__/tokens.spec.js
+++ b/src/__tests__/tokens.spec.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -1,830 +1,353 @@
-<!--
-  PropiedadesPanel.vue
-  Panel de propiedades del elemento seleccionado en el canvas.
--->
-
 <template>
   <div class="h-full flex flex-col bg-white border-l border-gray-200" data-properties-panel>
-    <!-- Header -->
-    <div class="p-4 border-b border-gray-200">
+    <div class="p-4 border-b border-gray-200 flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-800">Propiedades</h2>
+      <div v-if="isDirty" class="space-x-2">
+        <button
+          class="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+          @click="revertir"
+          :disabled="isSaving"
+        >
+          Revertir
+        </button>
+        <button
+          class="px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600 disabled:opacity-50"
+          @click="guardar"
+          :disabled="guardarDeshabilitado"
+        >
+          Guardar
+        </button>
+      </div>
     </div>
 
-    <!-- Contenido (scroll) -->
-    <div class="flex-1 overflow-y-auto p-4">
-      <!-- Sin elemento seleccionado -->
-   <!--  <div v-if="!elementoSeleccionado" class="text-center py-12">
-        <svg
-          class="w-12 h-12 text-gray-300 mx-auto mb-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM21 5a2 2 0 00-2-2h-4a2 2 0 00-2 2v12a4 4 0 004 4h4a4 4 0 004-4V5z"
-          />
-        </svg>
-        <p class="text-gray-500 text-sm">
-          Selecciona un elemento en el canvas<br />
-          para ver sus propiedades
-        </p>
-   </div> -->
-
-      <!-- Panel de propiedades -->
-      <div class="space-y-6">
-        <!-- Información básica -->
-        <div class="bg-gray-50 rounded-lg p-4">
-          <h3 class="text-sm font-medium text-gray-700 mb-3">Información Básica</h3>
-
-          <!-- ID (solo lectura) -->
-          <div class="mb-4">
-            <label class="block text-xs font-medium text-gray-600 mb-1"> ID del Elemento </label>
-            <input
-              :value="elementoSeleccionado.id"
-              type="text"
-              disabled
-              class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
-            />
-          </div>
-
-          <TagFilter
-            class="pb-3"
-            :selected-ids="elementoSeleccionado.etiquetas || []"
-            @add="handleAgregarEtiqueta"
-            @remove="handleQuitarEtiqueta"
-            @create="abrirModalCrearEtiqueta"
-          />
-
-          <!-- Tipo y Categoría -->
-          <div class="grid grid-cols-2 gap-3 mb-4">
+    <div v-if="elementoSeleccionado" class="flex-1 overflow-y-auto p-4">
+      <div class="space-y-4">
+        <!-- Información general -->
+        <details open class="bg-gray-50 rounded-lg p-4">
+          <summary class="text-sm font-medium text-gray-700 cursor-pointer">Información general</summary>
+          <div class="mt-3 space-y-3">
             <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1">Tipo</label>
+              <label class="block text-xs font-medium text-gray-600 mb-1">Nombre</label>
               <input
-                :value="getTipoNombre(elementoSeleccionado.tipo)"
+                v-model="edited.nombre"
                 type="text"
-                disabled
-                class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
+                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Nombre del elemento"
+                :disabled="isSaving"
               />
             </div>
-            <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1">Categoría</label>
-              <input
-                :value="getCategoriaDisplay(elementoSeleccionado.categoria)"
-                type="text"
-                disabled
-                class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed capitalize"
-              />
-            </div>
-          </div>
-
-          <!-- Nombre editable -->
-          <div class="mb-4">
-            <label class="block text-xs font-medium text-gray-600 mb-1"> Nombre </label>
-            <input
-              v-model="propiedadesEditables.nombre"
-              type="text"
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Nombre del elemento"
-              @input="actualizarPropiedad('nombre', $event.target.value)"
-            />
-          </div>
-
-          <!-- Color editable -->
-          <div class="mb-4">
-            <label class="block text-xs font-medium text-gray-600 mb-1"> Color </label>
-            <div class="flex items-center gap-3">
-              <input
-                v-model="propiedadesEditables.color"
-                type="color"
-                class="!w-12 h-10 border border-gray-300 rounded-lg cursor-pointer"
-                @input="actualizarPropiedad('color', $event.target.value)"
-              />
-              <input
-                v-model="propiedadesEditables.color"
-                type="text"
-                class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="#3B82F6"
-                @input="actualizarPropiedad('color', $event.target.value)"
-              />
-            </div>
-          </div>
-        </div>
-
-        <!-- Posición y dimensiones -->
-        <div class="bg-gray-50 rounded-lg p-4">
-          <h3 class="text-sm font-medium text-gray-700 mb-3">Posición y Dimensiones</h3>
-
-          <div class="grid grid-cols-2 gap-3">
-            <!-- Posición X -->
-            <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1"> X (px) </label>
-              <input
-                :value="Math.round(elementoSeleccionado.x)"
-                type="number"
-                disabled
-                class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
-              />
-            </div>
-
-            <!-- Posición Y -->
-            <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1"> Y (px) </label>
-              <input
-                :value="Math.round(elementoSeleccionado.y)"
-                type="number"
-                disabled
-                class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
-              />
-            </div>
-
-            <!-- Ancho -->
-            <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1"> Ancho (px) </label>
-              <input
-                :value="elementoSeleccionado.width"
-                type="number"
-                disabled
-                class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
-              />
-            </div>
-
-            <!-- Largo -->
-            <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1"> Largo (px) </label>
-              <input
-                :value="elementoSeleccionado.height"
-                type="number"
-                disabled
-                class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
-              />
-            </div>
-          </div>
-
-          <p class="text-xs text-gray-500 mt-2">
-            Vista desde arriba: Ancho=X, Largo=Y.
-            Vista de frente: Ancho=X, Largo=Z.
-          </p>
-
-            <!-- Dimensiones físicas adicionales (si están disponibles) -->
-          <div class="mt-6">
-            <h4 class="font-semibold text-gray-700 mb-3">
-              Dimensiones Físicas (cm)
-              <span v-if="hayCambiosPendientesDimensiones" class="ml-2 text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded-full">
-                Cambios pendientes
-              </span>
-            </h4>
-            <div class="space-y-3">
-              <!-- Campo Ancho -->
-              <div class="grid grid-cols-2 items-center">
-                <label for="prop-ancho" class="text-sm text-gray-500">Ancho</label>
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="block text-xs font-medium text-gray-600 mb-1">Tipo</label>
                 <input
-                  id="prop-ancho"
-                  type="number"
-                  :value="cambiosPendientes.dimensiones.ancho !== null ? cambiosPendientes.dimensiones.ancho : (elementoSeleccionado.dimensiones?.ancho || '')"
-                  @change="actualizarDimension('ancho', $event.target.value)"
-                  class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                  :value="getTipoNombre(elementoSeleccionado.tipo)"
+                  type="text"
+                  disabled
+                  class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
                 />
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-600 mb-1">Categoría</label>
+                <input
+                  :value="getCategoriaDisplay(elementoSeleccionado.categoria)"
+                  type="text"
+                  disabled
+                  class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed capitalize"
+                />
+              </div>
             </div>
-            <!-- Campo Largo -->
-            <div class="grid grid-cols-2 items-center">
-              <label for="prop-largo" class="text-sm text-gray-500">Largo</label>
-              <input
-                id="prop-largo"
-                type="number"
-                :value="cambiosPendientes.dimensiones.largo !== null ? cambiosPendientes.dimensiones.largo : (elementoSeleccionado.dimensiones?.largo || '')"
-                @change="actualizarDimension('largo', $event.target.value)"
-                class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-              />
-            </div>
-            <!-- Campo Alto -->
-            <div class="grid grid-cols-2 items-center">
-              <label for="prop-alto" class="text-sm text-gray-500">Alto</label>
-              <input
-                id="prop-alto"
-                type="number"
-                :value="cambiosPendientes.dimensiones.alto !== null ? cambiosPendientes.dimensiones.alto : (elementoSeleccionado.dimensiones?.alto || '')"
-                @change="actualizarDimension('alto', $event.target.value)"
-                class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-              />
-            </div>
-            <p class="text-xs text-gray-500 mt-2">
-            Vista desde arriba: Ancho y Largo del elemento.
-            <br />
-            Vista de frente: Ancho y Alto del elemento.
-          </p>
-      </div>
-    </div>
-
-    <!-- === NUEVA SECCIÓN DE PROPIEDADES ADICIONALES === -->
-    <div class="mt-6">
-      <h4 class="font-semibold text-gray-700 mb-3">Propiedades Adicionales</h4>
-      <div class="space-y-3">
-        <!-- Campo Capacidad de Carga -->
-        <div class="grid grid-cols-2 items-center">
-          <label for="prop-peso-max" class="text-sm text-gray-500">Capacidad de Carga (kg)</label>
-          <input
-            id="prop-peso-max"
-            type="number"
-            :value="cambiosPendientes.pesoMaximo !== null ? cambiosPendientes.pesoMaximo : (elementoSeleccionado.pesoMaximo || '')"
-            @change="actualizarPropiedadSimple('pesoMaximo', $event.target.value)"
-            class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-            placeholder="Ej: 100"
-          />
-        </div>
-        <p class="text-xs text-gray-500">
-          Peso máximo teórico que este elemento puede soportar
-        </p>
-
-        <!-- Información de peso total si tiene elementos hijos -->
-        <!-- <div v-if="elementoSeleccionado.hijos && elementoSeleccionado.hijos.length > 0" class="bg-blue-50 border border-blue-200 text-blue-700 px-4 py-3 rounded-md text-sm">
-          Este elemento contiene {{ elementoSeleccionado.hijos.length }} elementos con una capacidad de carga total requerida.
-        </div> -->
-
-        <!-- Información sobre capacidad del padre o planta contenedora -->
-        <!-- <div v-if="infoPesoContenedor.mostrar" class="mt-2 bg-amber-50 border border-amber-200 text-amber-800 px-4 py-3 rounded-md text-sm">
-          {{ infoPesoContenedor.mensaje }}
-        </div> -->
-        <div class="grid grid-cols-2 items-center">
-          <label for="prop-volumen-max" class="text-sm text-gray-500">Volumen (m³)</label>
-          <input
-            id="prop-volumen-max"
-            type="number"
-            :value="volumen"
-            disabled
-            @change="actualizarPropiedadSimple('pesoMaximo', $event.target.value)"
-            class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-            placeholder="Ej: 100"
-          />
-        </div>
-      </div>
-    </div>
-
-          <!-- Información específica para elementos de pared -->
-          <div
-            v-if="
-              elementoSeleccionado.ubicacion === 'pared' &&
-              elementoSeleccionado.alturaRespectoAlSuelo !== undefined
-            "
-            class="mt-3 pt-3 border-t border-gray-200"
-          >
-            <h4 class="text-xs font-medium text-gray-600 mb-2">Posicionamiento en Pared</h4>
-            <div class="text-xs text-gray-500">
-              <div>Altura del suelo: {{ elementoSeleccionado.alturaRespectoAlSuelo }}cm</div>
-              <div class="text-xs text-gray-400 mt-1">
-                Base del elemento a {{ elementoSeleccionado.alturaRespectoAlSuelo }}cm del suelo
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">Color</label>
+              <div class="flex items-center gap-3">
+                <input
+                  v-model="edited.color"
+                  type="color"
+                  class="!w-12 h-10 border border-gray-300 rounded-lg cursor-pointer"
+                  :disabled="isSaving"
+                />
+                <input
+                  v-model="edited.color"
+                  type="text"
+                  class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="#3B82F6"
+                  :disabled="isSaving"
+                />
               </div>
             </div>
           </div>
-        </div>
+        </details>
 
-        <!-- Jerarquía -->
-        <div
-          v-if="elementoSeleccionado.padre || elementoSeleccionado.hijos?.length"
-          class="bg-gray-50 rounded-lg p-4"
-        >
-          <h3 class="text-sm font-medium text-gray-700 mb-3">Jerarquía</h3>
-
-          <!-- Elemento padre -->
-          <div v-if="elementoSeleccionado.padre" class="mb-3">
-            <label class="block text-xs font-medium text-gray-600 mb-1"> Elemento Padre </label>
-            <div
-              class="flex items-center gap-2 px-3 py-2 bg-blue-50 border border-blue-200 rounded-lg"
-            >
-              <svg class="w-4 h-4 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
-                <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <span class="text-sm text-blue-700">{{
-                obtenerNombreElementoPorId(elementoSeleccionado.padre)
-              }}</span>
+        <!-- Dimensiones -->
+        <details v-if="mostrarDimensiones" open class="bg-gray-50 rounded-lg p-4">
+          <summary class="text-sm font-medium text-gray-700 cursor-pointer">Dimensiones (cm)</summary>
+          <div class="mt-3 space-y-3">
+            <div v-if="!ocultarAnchoLargo" class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="text-sm text-gray-500">Ancho</label>
+                <div class="flex items-center">
+                  <input
+                    type="number"
+                    min="0"
+                    v-model.number="edited.dimensiones.ancho"
+                    @change="validarDimension('ancho')"
+                    class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                    :disabled="isSaving"
+                  />
+                  <span class="ml-1 text-sm text-gray-500">cm</span>
+                </div>
+              </div>
+              <div>
+                <label class="text-sm text-gray-500">Largo</label>
+                <div class="flex items-center">
+                  <input
+                    type="number"
+                    min="0"
+                    v-model.number="edited.dimensiones.largo"
+                    @change="validarDimension('largo')"
+                    class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                    :disabled="isSaving"
+                  />
+                  <span class="ml-1 text-sm text-gray-500">cm</span>
+                </div>
+              </div>
             </div>
+            <div>
+              <label class="text-sm text-gray-500">Alto</label>
+              <div class="flex items-center">
+                <input
+                  type="number"
+                  min="0"
+                    v-model.number="edited.dimensiones.alto"
+                    @change="validarDimension('alto')"
+                    class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                    :disabled="isSaving"
+                  />
+                <span class="ml-1 text-sm text-gray-500">cm</span>
+              </div>
+            </div>
+            <p v-if="advertenciaAltura" class="text-xs text-amber-600">{{ advertenciaAltura }}</p>
           </div>
+        </details>
 
-          <!-- Elementos hijos -->
-          <div v-if="elementoSeleccionado.hijos?.length" class="mb-3">
-            <label class="block text-xs font-medium text-gray-600 mb-1">
-              Elementos Hijos ({{ elementoSeleccionado.hijos.length }})
-            </label>
-            <div class="space-y-1">
-              <div
-                v-for="hijoId in elementoSeleccionado.hijos"
-                :key="hijoId"
-                class="flex items-center gap-2 px-3 py-2 bg-green-50 border border-green-200 rounded-lg"
-              >
-                <svg class="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20">
-                  <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <span class="text-sm text-green-700">{{ obtenerNombreElementoPorId(hijoId) }}</span>
+        <!-- Capacidad -->
+        <details v-if="mostrarCapacidad" open class="bg-gray-50 rounded-lg p-4">
+          <summary class="text-sm font-medium text-gray-700 cursor-pointer">Capacidad</summary>
+          <div class="mt-3 space-y-3">
+            <div>
+              <label class="text-sm text-gray-500">Capacidad de carga</label>
+              <div class="flex items-center">
+                <input
+                  type="number"
+                  min="0"
+                  v-model.number="edited.pesoMaximo"
+                  @change="validarPeso"
+                  class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                  :disabled="isSaving"
+                />
+                <span class="ml-1 text-sm text-gray-500">kg</span>
+              </div>
+            </div>
+            <div v-if="volumen !== null">
+              <label class="text-sm text-gray-500">Volumen</label>
+              <div class="flex items-center">
+                <input
+                  :value="volumen"
+                  disabled
+                  class="w-full px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-500"
+                />
+                <span class="ml-1 text-sm text-gray-500">m³</span>
               </div>
             </div>
           </div>
-        </div>
+        </details>
       </div>
     </div>
 
-    <!-- Footer fijo con acciones -->
     <div v-if="elementoSeleccionado" class="p-4 border-t border-gray-200 bg-white">
-      <div v-if="cambiosPendientes.dimensiones.ancho !== null ||
-                  cambiosPendientes.dimensiones.largo !== null ||
-                  cambiosPendientes.dimensiones.alto !== null ||
-                  cambiosPendientes.pesoMaximo !== null"
-           class="mb-2">
-        <button
-          @click="aplicarCambios"
-          class="w-full cursor-pointer px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm font-semibold"
-        >
-          Validar y Aplicar Cambios
-        </button>
-        <p class="text-xs text-gray-500 mt-1 text-center">
-          Los cambios se validarán automáticamente antes de aplicarse
-        </p>
-      </div>
-
-      <!-- <div class="flex gap-2 mb-2">
-        <button
-          @click="onDeleteClick"
-          class="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm"
-          :aria-label="isLockedSelected ? 'Elemento bloqueado — desbloquéalo para eliminar' : 'Eliminar (Supr)'"
-          :title="isLockedSelected ? 'Elemento bloqueado — desbloquéalo para eliminar' : 'Eliminar (Supr)'"
-        >
-          Eliminar
-        </button>
-      </div> -->
-
-      <div class="flex gap-2">
-        <button
-          @click="resetearPropiedades"
-          class="flex-1 cursor-pointer px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm"
-        >
-          Restablecer
-        </button>
-        <!-- <button
-          @click="cambiarBloqueo"
-          class="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm"
-        >
-        {{ elementoSeleccionado.bloqueado ? 'Desbloquear' : 'Bloquear' }}
-        </button> -->
-        <button
-          @click="deseleccionarElemento"
-          class="flex-1 cursor-pointer px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm"
-        >
-          Deseleccionar
-        </button>
-      </div>
+      <button
+        @click="deseleccionarElemento"
+        class="w-full cursor-pointer px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm"
+      >
+        Deseleccionar
+      </button>
     </div>
   </div>
-  <CreateTagModal
-    :show="modalCrearEtiquetaVisible"
-    :initial-text="textoNuevaEtiqueta"
-    @close="modalCrearEtiquetaVisible = false"
-    @save="guardarYAsignarNuevaEtiqueta"
-  />
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { onBeforeRouteLeave } from 'vue-router'
 import { useCanvasStore } from '@/composables/useCanvasStore.js'
-import { useWeightValidation } from '@/composables/useWeightValidation.js'
-import { useDimensionValidation } from '@/composables/useDimensionValidation.js'
+import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS } from '@/utils/constants'
+import { deepClone, deepEqual, makePatch } from '@/utils/object'
 import { useToast } from '@/composables/useToast.js'
-import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS, CM_TO_PX } from '@/utils/constants'
-import { useDeleteElement } from '@/composables/useDeleteElement'
-import TagFilter from './TagFilter.vue'
-import CreateTagModal from './CreateTagModal.vue'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 
-// Store
 const canvasStore = useCanvasStore()
-const { deleteSelected } = useDeleteElement()
-const weightValidation = useWeightValidation()
-const dimensionValidation = useDimensionValidation()
-const { showSuccess, showError } = useToast()
+const { showWarning, showSuccess } = useToast()
+const confirmDialog = useConfirmDialog()
 
-// Referencias reactivas
-const propiedadesEditables = ref({
-  nombre: '',
-  color: '#3B82F6',
-})
-
-// Referencias para los cambios pendientes
-const cambiosPendientes = ref({
-  dimensiones: {
-    ancho: null,
-    largo: null,
-    alto: null
-  },
-  pesoMaximo: null
-})
-
-
-const modalCrearEtiquetaVisible = ref(false)
-const textoNuevaEtiqueta = ref('')
-
-// Computed
 const elementoSeleccionado = computed(() => canvasStore.elementoSeleccionadoCompleto)
 
+const snapshotOriginal = ref(null)
+const edited = ref(null)
+const isSaving = ref(false)
 
-const volumen = computed(() => {
-  const ancho = elementoSeleccionado.value.dimensiones?.ancho;
-  const alto = elementoSeleccionado.value.dimensiones?.alto;
-  const largo = elementoSeleccionado.value.dimensiones?.largo;
-  const v = ancho * alto * largo;
-  return (v / 1000000).toFixed(2);
-});
-
-const hayCambiosPendientesDimensiones = computed(() => {
-  return cambiosPendientes.value.dimensiones.ancho !== null ||
-         cambiosPendientes.value.dimensiones.largo !== null ||
-         cambiosPendientes.value.dimensiones.alto !== null
+const cargarDesdeStore = (el) => deepClone({
+  nombre: el.nombre || '',
+  color: el.color || '#3B82F6',
+  dimensiones: {
+    ancho: el.dimensiones?.ancho || 0,
+    largo: el.dimensiones?.largo || 0,
+    alto: el.dimensiones?.alto || 0,
+  },
+  pesoMaximo: el.pesoMaximo || 0,
 })
 
-// Watchers
-watch(
-  elementoSeleccionado,
-  (nuevoElemento) => {
-    if (nuevoElemento) {
-      // Inicializar propiedades editables con los valores actuales
-      propiedadesEditables.value = {
-        nombre: nuevoElemento.nombre || generarNombrePorDefecto(nuevoElemento),
-        color: nuevoElemento.color || '#3B82F6',
-      }
+watch(() => elementoSeleccionado.value?.id, (id) => {
+  if (id) {
+    snapshotOriginal.value = cargarDesdeStore(elementoSeleccionado.value)
+    edited.value = deepClone(snapshotOriginal.value)
+  } else {
+    snapshotOriginal.value = null
+    edited.value = null
+  }
+}, { immediate: true })
 
-      // Reinicializar cambios pendientes cuando se selecciona un nuevo elemento
-      // No preservar valores anteriores para evitar conflictos con actualizaciones del transformer
-      cambiosPendientes.value = {
-        dimensiones: {
-          ancho: null,
-          largo: null,
-          alto: null
-        },
-        pesoMaximo: null
-      }
-    }
-  },
-  { immediate: true },
-)
+const isDirty = computed(() => {
+  if (!edited.value || !snapshotOriginal.value) return false
+  return !deepEqual(edited.value, snapshotOriginal.value)
+})
 
-// Watcher adicional para sincronizar con actualizaciones del transformer en tiempo real
-watch(
-  () => elementoSeleccionado.value?.dimensiones,
-  (nuevasDimensiones) => {
-    if (nuevasDimensiones && elementoSeleccionado.value) {
-      // Solo limpiar cambios pendientes si no han sido modificados manualmente por el usuario
-      // Esto permite que las actualizaciones del transformer se reflejen inmediatamente
-      if (cambiosPendientes.value.dimensiones.ancho === null &&
-          cambiosPendientes.value.dimensiones.largo === null &&
-          cambiosPendientes.value.dimensiones.alto === null) {
-        // Las dimensiones del transformer se reflejan automáticamente a través del computed
-        // No necesitamos hacer nada aquí, el reactive system maneja la actualización
-      }
-    }
-  },
-  { deep: true }
-)
+const guardarDeshabilitado = computed(() => isSaving.value || !!advertenciaAltura.value)
 
-// Métodos
+const revertir = () => {
+  edited.value = deepClone(snapshotOriginal.value)
+}
+
+const guardar = async () => {
+  if (!elementoSeleccionado.value) return
+  if (guardarDeshabilitado.value) return
+  isSaving.value = true
+  const patch = makePatch(snapshotOriginal.value, edited.value)
+  const ok = await canvasStore.updateElementById(elementoSeleccionado.value.id, patch)
+  if (ok) {
+    snapshotOriginal.value = deepClone(edited.value)
+    showSuccess('Cambios guardados')
+  }
+  isSaving.value = false
+}
+
+const validarDimension = (prop) => {
+  const val = Number(edited.value.dimensiones[prop])
+  if (isNaN(val) || val < 0) {
+    showWarning('El valor debe ser mayor o igual a 0')
+    edited.value.dimensiones[prop] = snapshotOriginal.value.dimensiones[prop]
+  }
+}
+
+const validarPeso = () => {
+  const val = Number(edited.value.pesoMaximo)
+  if (isNaN(val) || val < 0) {
+    showWarning('El valor debe ser mayor o igual a 0')
+    edited.value.pesoMaximo = snapshotOriginal.value.pesoMaximo
+  }
+}
+
 const getTipoNombre = (tipo) => {
-  const tipoInfo = TIPOS_ENTIDAD.find((t) => t.id === tipo)
-  return tipoInfo?.nombre || tipo || 'Desconocido'
+  return TIPOS_ENTIDAD.find(t => t.id === tipo)?.nombre || tipo
 }
 
 const getCategoriaDisplay = (categoria) => {
-  const categoriaInfo = TODAS_LAS_CATEGORIAS.find((c) => c.id === categoria)
-  return categoriaInfo?.nombre || categoria || 'Sin categoría'
+  return TODAS_LAS_CATEGORIAS.find(c => c.id === categoria)?.nombre || categoria
 }
 
-const generarNombrePorDefecto = (elemento) => {
-  return `${elemento.tipo.charAt(0).toUpperCase() + elemento.tipo.slice(1)} ${elemento.id.split('_')[1] || ''}`
-}
+const esAnaquelOEstante = computed(() => {
+  const cat = elementoSeleccionado.value?.categoria
+  return cat === 'anaqueles' || cat === 'estantes'
+})
 
-// La función obtenerNombreElementoPorId se define más adelante en el componente
+const esContenedorBarril = computed(() => {
+  const el = elementoSeleccionado.value
+  return el?.tipo === 'contenedores' || el?.categoria === 'contenedores'
+})
 
-const actualizarPropiedad = (propiedad, valor) => {
-  if (!elementoSeleccionado.value) return
+const esCajaOPallet = computed(() => {
+  const cat = elementoSeleccionado.value?.categoria
+  return cat === 'cajas' || cat === 'pallets'
+})
 
-  // Actualizar el valor local
-  propiedadesEditables.value[propiedad] = valor
+const mostrarCapacidad = computed(() => esAnaquelOEstante.value || esContenedorBarril.value || esCajaOPallet.value)
+const mostrarDimensiones = computed(() => true)
+const ocultarAnchoLargo = computed(() => esContenedorBarril.value && elementoSeleccionado.value?.forma === 'circular')
 
-  // Actualizar en el store (tiempo real)
-  canvasStore.actualizarElemento(elementoSeleccionado.value.id, {
-    [propiedad]: valor,
-  })
-}
-
-const resetearPropiedades = () => {
-  if (!elementoSeleccionado.value) return
-
-  const propiedadesOriginales = {
-    nombre: generarNombrePorDefecto(elementoSeleccionado.value),
-    color: '#3B82F6',
+const volumen = computed(() => {
+  if (!esContenedorBarril.value) return null
+  const d = edited.value?.dimensiones || {}
+  if (elementoSeleccionado.value?.forma === 'circular') {
+    const diam = d.ancho || 0
+    const alto = d.alto || 0
+    return ((Math.PI * Math.pow(diam / 2, 2) * alto) / 1_000_000).toFixed(2)
   }
+  return (((d.ancho || 0) * (d.largo || 0) * (d.alto || 0)) / 1_000_000).toFixed(2)
+})
 
-  // Restaurar propiedades editables
-  propiedadesEditables.value = { ...propiedadesOriginales }
-
-  // Actualizar en tiempo real solo para el nombre y color
-  canvasStore.actualizarElemento(elementoSeleccionado.value.id, propiedadesOriginales)
-
-  // Restablecer los cambios pendientes
-  cambiosPendientes.value = {
-    dimensiones: {
-      ancho: null,
-      largo: null,
-      alto: null
-    },
-    pesoMaximo: null
-  }
-
-  showSuccess('✅ Propiedades restablecidas', { timeout: 2000 })
-}
-
-// const cambiarBloqueo = () => {
-//   canvasStore.actualizarElemento(elementoSeleccionado.value.id, { bloqueado: !elementoSeleccionado.value.bloqueado })
-// }
+const alturaPlanta = computed(() => canvasStore.plantaPorId(canvasStore.plantaActiva)?.dimensiones?.alto || 0)
+const advertenciaAltura = computed(() => {
+  if (!esAnaquelOEstante.value) return null
+  const min = alturaPlanta.value * 0.5
+  const actual = edited.value?.dimensiones?.alto || 0
+  return actual < min ? `La altura debe ser al menos ${min} cm` : null
+})
 
 const deseleccionarElemento = () => {
   canvasStore.seleccionarElemento(null)
 }
 
-// const onDeleteClick = () => {
-//   deleteSelected({ withConfirm: true })
-// }
-
-// Funciones para obtener nombres de elementos por ID
-const obtenerNombreElementoPorId = (elementoId) => {
-  const elemento = canvasStore.elementoPorId(elementoId)
-  return elemento ? elemento.nombre || generarNombrePorDefecto(elemento) : `ID: ${elementoId}`
-}
-
-const handleAgregarEtiqueta = (etiquetaId) => {
-  if (!elementoSeleccionado.value) return
-  canvasStore.agregarEtiquetaAElemento(elementoSeleccionado.value.id, etiquetaId)
-}
-
-const handleQuitarEtiqueta = (etiquetaId) => {
-  if (!elementoSeleccionado.value) return
-  console.log("Quitando propiedades")
-  canvasStore.quitarEtiquetaDeElemento(elementoSeleccionado.value.id, etiquetaId)
-  canvasStore.toggleMostrarPropiedades();
-}
-
-const abrirModalCrearEtiqueta = (texto) => {
-  textoNuevaEtiqueta.value = texto
-  modalCrearEtiquetaVisible.value = true
-}
-
-const guardarYAsignarNuevaEtiqueta = (nuevaEtiqueta) => {
-  if (!elementoSeleccionado.value) return
-  canvasStore.crearYAsignarEtiquetaAElemento(elementoSeleccionado.value.id, nuevaEtiqueta)
-  modalCrearEtiquetaVisible.value = false
-}
-
-const actualizarDimension = (dimension, valor) => {
-  if (!elementoSeleccionado.value) return
-  const valorNumerico = parseFloat(valor)
-  if (isNaN(valorNumerico)) return // Evitar enviar valores no numéricos
-
-  // Almacenar en cambios pendientes
-  cambiosPendientes.value.dimensiones[dimension] = valorNumerico
-
-  // Validación en tiempo real (solo para verificación, sin mostrar toasts)
-  if (valorNumerico > 0) {
-    const nuevasDimensiones = { [dimension]: valorNumerico }
-    const validacionPrevia = dimensionValidation.validarDimensiones(
-      elementoSeleccionado.value.id,
-      nuevasDimensiones,
-      { silencioso: true } // Validación silenciosa para evitar múltiples toasts
-    )
-
-    // Solo log para debug, sin mostrar toast aquí para evitar duplicados
-    if (!validacionPrevia.valida && validacionPrevia.accion === 'rechazar') {
-      console.log('Validación previa:', validacionPrevia.razon)
+const onKeydown = (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+    e.preventDefault()
+    if (isDirty.value && !guardarDeshabilitado.value) {
+      guardar()
     }
   }
 }
 
-const actualizarPropiedadSimple = (propiedad, valor) => {
-  if (!elementoSeleccionado.value) return
-  const valorNumerico = parseFloat(valor)
-  if (isNaN(valorNumerico)) return
+onMounted(() => {
+  window.addEventListener('keydown', onKeydown)
+})
 
-  // Almacenar en cambios pendientes
-  cambiosPendientes.value[propiedad] = valorNumerico
-}
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKeydown)
+})
 
-const aplicarCambios = () => {
-  if (!elementoSeleccionado.value) return
-
-  const nuevoPesoMaximo = cambiosPendientes.value.pesoMaximo
-
-  // 1. Validar el peso máximo si hay elementos hijos (validación hacia abajo)
-  if (elementoSeleccionado.value.hijos && elementoSeleccionado.value.hijos.length > 0 && nuevoPesoMaximo !== null) {
-    const elementoId = elementoSeleccionado.value.id
-    const tipoElemento = elementoSeleccionado.value.tipo || 'elementos'
-
-    // Calcular el peso total actual de los elementos hijos
-    const resultado = weightValidation.calcularPesoDisponible(elementoId, tipoElemento)
-    const pesoActualHijos = resultado.usado
-
-    // Si el nuevo peso máximo es menor que el peso actual de los hijos, mostrar error
-    if (resultado.limiteDePeso && nuevoPesoMaximo < pesoActualHijos) {
-      showError(`La capacidad de carga debe ser al menos ${pesoActualHijos} kg para soportar los elementos actuales contenidos.`)
-      return
-    }
+onBeforeRouteLeave(async (to, from, next) => {
+  if (!isDirty.value) {
+    next()
+    return
   }
-
-  // 2. Validar si el nuevo peso máximo excede la capacidad del padre (validación hacia arriba)
-  if (nuevoPesoMaximo !== null && elementoSeleccionado.value.padre) {
-    const padreId = elementoSeleccionado.value.padre
-    const padre = canvasStore.elementoPorId(padreId)
-
-    if (padre && padre.pesoMaximo > 0) { // Si el padre tiene límite de peso definido
-      // Obtener la diferencia entre el nuevo y viejo peso máximo
-      const pesoMaximoActual = elementoSeleccionado.value.pesoMaximo || 0
-      const diferenciaPeso = nuevoPesoMaximo - pesoMaximoActual
-
-      if (diferenciaPeso > 0) {
-        // Calcular el peso disponible en el padre
-        const tipoElementoPadre = padre.tipo || 'elementos'
-        const resultadoPadre = weightValidation.calcularPesoDisponible(padreId, tipoElementoPadre)
-
-        // Si el incremento de peso excede la capacidad disponible en el padre
-        if (resultadoPadre.limiteDePeso && diferenciaPeso > resultadoPadre.disponible) {
-          showError(`El incremento de capacidad de carga (${diferenciaPeso} kg) excede la capacidad disponible del elemento padre (${resultadoPadre.disponible} kg).`)
-          return
-        }
-      }
-    }
+  const save = await confirmDialog.confirm({
+    title: 'Cambios sin guardar',
+    message: 'Hay cambios sin guardar. ¿Guardar antes de salir?',
+    confirmLabel: 'Guardar y salir',
+    cancelLabel: 'Cancelar'
+  })
+  if (save) {
+    await guardar()
+    next()
+  } else {
+    const exit = await confirmDialog.confirm({
+      title: 'Salir sin guardar',
+      message: '¿Salir sin guardar?',
+      confirmLabel: 'Salir',
+      cancelLabel: 'Cancelar'
+    })
+    if (exit) next()
+    else next(false)
   }
-
-  // También validar si el elemento está en una planta con límite de peso
-  if (nuevoPesoMaximo !== null && !elementoSeleccionado.value.padre && elementoSeleccionado.value.plantaId) {
-    const plantaId = elementoSeleccionado.value.plantaId
-    const planta = canvasStore.plantaPorId(plantaId)
-
-    if (planta && planta.pesoMaximoSoportado > 0) {
-      // Obtener la diferencia entre el nuevo y viejo peso máximo
-      const pesoMaximoActual = elementoSeleccionado.value.pesoMaximo || 0
-      const diferenciaPeso = nuevoPesoMaximo - pesoMaximoActual
-
-      if (diferenciaPeso > 0) {
-        // Calcular el peso disponible en la planta
-        const resultadoPlanta = weightValidation.calcularPesoDisponible(plantaId, 'plantas')
-
-        // Si el incremento de peso excede la capacidad disponible en la planta
-        if (resultadoPlanta.limiteDePeso && diferenciaPeso > resultadoPlanta.disponible) {
-          showError(`El incremento de capacidad de carga (${diferenciaPeso} kg) excede la capacidad disponible de la planta (${resultadoPlanta.disponible} kg).`)
-          return
-        }
-      }
-    }
-  }
-
-  // 3. Validar dimensiones físicas si hay cambios en las dimensiones
-  if (cambiosPendientes.value.dimensiones.ancho !== null ||
-      cambiosPendientes.value.dimensiones.largo !== null ||
-      cambiosPendientes.value.dimensiones.alto !== null) {
-
-    // Construir objeto completo de dimensiones (actuales + cambios)
-    const dimensionesActuales = elementoSeleccionado.value.dimensiones || {}
-    const nuevasDimensiones = {
-      ancho: cambiosPendientes.value.dimensiones.ancho !== null
-        ? cambiosPendientes.value.dimensiones.ancho
-        : (dimensionesActuales.ancho || elementoSeleccionado.value.ancho || 50),
-      largo: cambiosPendientes.value.dimensiones.largo !== null
-        ? cambiosPendientes.value.dimensiones.largo
-        : (dimensionesActuales.largo || elementoSeleccionado.value.largo || 50),
-      alto: cambiosPendientes.value.dimensiones.alto !== null
-        ? cambiosPendientes.value.dimensiones.alto
-        : (dimensionesActuales.alto || elementoSeleccionado.value.alto || 100)
-    }
-
-    // Validar las nuevas dimensiones
-    const validacionDimensiones = dimensionValidation.validarDimensiones(
-      elementoSeleccionado.value.id,
-      nuevasDimensiones
-    )
-
-    if (!validacionDimensiones.valida) {
-      // El validador ya mostró el toast de error, no necesitamos duplicarlo
-      console.log(`❌ Error de dimensiones: ${validacionDimensiones.razon}`)
-      return
-    }
-
-    // Aplicar el resultado de la validación de dimensiones
-    const resultadoAplicacion = dimensionValidation.aplicarResultadoValidacion(
-      elementoSeleccionado.value.id,
-      validacionDimensiones
-    )
-
-    if (!resultadoAplicacion.exito) {
-      showError(`❌ Error al aplicar dimensiones: ${resultadoAplicacion.mensaje}`)
-      return
-    }
-
-    // Mostrar mensaje informativo sobre qué se aplicó
-    // Los toasts ya son manejados por el validador, no necesitamos duplicarlos aquí
-    if (validacionDimensiones.accion === 'aplicar_parcial') {
-      console.log(`⚠️ ${resultadoAplicacion.mensaje}`)
-    } else if (validacionDimensiones.accion === 'reubicar') {
-      console.log(`✅ ${resultadoAplicacion.mensaje}`)
-    } else if (validacionDimensiones.accion === 'aplicar') {
-      if (resultadoAplicacion.posicionAjustada) {
-        console.log(`✅ Dimensiones aplicadas correctamente. Posición ajustada automáticamente.`)
-      } else {
-        console.log(`✅ Dimensiones aplicadas correctamente`)
-      }
-    }
-
-    // Limpiar cambios de dimensiones después de aplicarlos exitosamente
-    setTimeout(() => {
-      cambiosPendientes.value.dimensiones = {
-        ancho: null,
-        largo: null,
-        alto: null
-      }
-    }, 2000) // 2 segundos de delay
-  }
-
-  // 4. Si no hay errores, aplicar cambios de peso máximo
-  const actualizaciones = {}
-
-  // Actualizar peso máximo si hay cambios
-  if (cambiosPendientes.value.pesoMaximo !== null) {
-    actualizaciones.pesoMaximo = cambiosPendientes.value.pesoMaximo
-  }
-
-  // Si hay actualizaciones de peso, aplicarlas
-  if (Object.keys(actualizaciones).length > 0) {
-    canvasStore.actualizarElemento(elementoSeleccionado.value.id, actualizaciones)
-    showSuccess(`✅ Propiedades actualizadas correctamente`, { timeout: 3000 })
-
-    // Limpiar cambios de peso después de aplicarlos exitosamente
-    setTimeout(() => {
-      cambiosPendientes.value.pesoMaximo = null
-    }, 2000) // 2 segundos de delay
-
-    if (actualizaciones.dimensiones) {
-      if (canvasStore.vistaActiva === 'XY') {
-        // Vista superior: ancho->width, largo->height
-        if (actualizaciones.dimensiones.ancho !== undefined) {
-          canvasStore.actualizarElemento(elementoSeleccionado.value.id, {
-            width: actualizaciones.dimensiones.ancho * CM_TO_PX
-          })
-        }
-        if (actualizaciones.dimensiones.largo !== undefined) {
-          canvasStore.actualizarElemento(elementoSeleccionado.value.id, {
-            height: actualizaciones.dimensiones.largo * CM_TO_PX
-          })
-        }
-      } else if (canvasStore.vistaActiva === 'XZ') {
-        // Vista frontal: ancho->width, alto->height
-        if (actualizaciones.dimensiones.ancho !== undefined) {
-          canvasStore.actualizarElemento(elementoSeleccionado.value.id, {
-            width: actualizaciones.dimensiones.ancho * CM_TO_PX
-          })
-        }
-        if (actualizaciones.dimensiones.alto !== undefined) {
-          canvasStore.actualizarElemento(elementoSeleccionado.value.id, {
-            height: actualizaciones.dimensiones.alto * CM_TO_PX
-          })
-        }
-      }
-    }
-  }
-}
+})
 </script>
 
 <style scoped>
-/* Estilos personalizados para mejor UX */
-input[type='color'] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  border: none;
-  cursor: pointer;
-}
-
-input[type='color']::-webkit-color-swatch-wrapper {
-  padding: 0;
-}
-
-input[type='color']::-webkit-color-swatch {
-  border: none;
-  border-radius: 0.375rem;
-}
-
-input[type='color']::-moz-color-swatch {
-  border: none;
-  border-radius: 0.375rem;
-}
-
-input[disabled] {
-  cursor: not-allowed;
-}
-
-.cursor-not-allowed {
-  cursor: not-allowed !important;
-}
+/* No custom styles */
 </style>

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -295,9 +295,9 @@ const volumen = computed(() => {
 const alturaPlanta = computed(() => canvasStore.plantaPorId(canvasStore.plantaActiva)?.dimensiones?.alto || 0)
 const advertenciaAltura = computed(() => {
   if (!esAnaquelOEstante.value) return null
-  const min = alturaPlanta.value * 0.5
+  const max = alturaPlanta.value;
   const actual = edited.value?.dimensiones?.alto || 0
-  return actual < min ? `La altura debe ser al menos ${min} cm` : null
+  return actual > max ? `La altura no debe superar ${max} cm` : null
 })
 
 const deseleccionarElemento = () => {

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -246,10 +246,16 @@ const validarDimension = (prop) => {
   }
 }
 
+const plantaActiva = computed(() => canvasStore.plantaPorId(canvasStore.plantaActiva) || 0);
+const pesoMaximoSoportado = computed(() => plantaActiva.value?.pesoMaximoSoportado || 0);
+
 const validarPeso = () => {
   const val = Number(edited.value.pesoMaximo)
   if (isNaN(val) || val < 0) {
     showWarning('El valor debe ser mayor o igual a 0')
+    edited.value.pesoMaximo = snapshotOriginal.value.pesoMaximo
+  } else if (val > pesoMaximoSoportado.value) {
+    showWarning(`El valor no debe superar ${pesoMaximoSoportado.value} kg, que es el peso máximo soportado por la planta activa.`)
     edited.value.pesoMaximo = snapshotOriginal.value.pesoMaximo
   }
 }

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -12,50 +12,30 @@
           <div class="mt-3 space-y-3">
             <div>
               <label class="block text-xs font-medium text-gray-600 mb-1">Nombre</label>
-              <input
-                v-model="edited.nombre"
-                type="text"
+              <input v-model="edited.nombre" type="text"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="Nombre del elemento"
-                :disabled="isSaving"
-              />
+                placeholder="Nombre del elemento" :disabled="isSaving" />
             </div>
             <div class="grid grid-cols-2 gap-3">
               <div>
                 <label class="block text-xs font-medium text-gray-600 mb-1">Tipo</label>
-                <input
-                  :value="getTipoNombre(elementoSeleccionado.tipo)"
-                  type="text"
-                  disabled
-                  class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed"
-                />
+                <input :value="getTipoNombre(elementoSeleccionado.tipo)" type="text" disabled
+                  class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed" />
               </div>
               <div>
                 <label class="block text-xs font-medium text-gray-600 mb-1">Categoría</label>
-                <input
-                  :value="getCategoriaDisplay(elementoSeleccionado.categoria)"
-                  type="text"
-                  disabled
-                  class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed capitalize"
-                />
+                <input :value="getCategoriaDisplay(elementoSeleccionado.categoria)" type="text" disabled
+                  class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm text-gray-500 cursor-not-allowed capitalize" />
               </div>
             </div>
             <div>
               <label class="block text-xs font-medium text-gray-600 mb-1">Color</label>
               <div class="flex items-center gap-3">
-                <input
-                  v-model="edited.color"
-                  type="color"
-                  class="!w-12 h-10 border border-gray-300 rounded-lg cursor-pointer"
-                  :disabled="isSaving"
-                />
-                <input
-                  v-model="edited.color"
-                  type="text"
+                <input v-model="edited.color" type="color"
+                  class="!w-12 h-10 border border-gray-300 rounded-lg cursor-pointer" :disabled="isSaving" />
+                <input v-model="edited.color" type="text"
                   class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  placeholder="#3B82F6"
-                  :disabled="isSaving"
-                />
+                  placeholder="#3B82F6" :disabled="isSaving" />
               </div>
             </div>
           </div>
@@ -65,32 +45,25 @@
         <details v-if="mostrarDimensiones" open class="bg-gray-50 rounded-lg p-4">
           <summary class="text-sm font-medium text-gray-700 cursor-pointer">Dimensiones (cm)</summary>
           <div class="mt-3 space-y-3">
+            <!-- Para formas no circulares, mostrar ancho/largo -->
             <div v-if="!ocultarAnchoLargo" class="grid grid-cols-2 gap-3">
               <div>
                 <label class="text-sm text-gray-500">Ancho</label>
                 <div class="flex items-center">
-                  <input
-                    type="number"
-                    min="0"
-                    v-model.number="edited.dimensiones.ancho"
+                  <input type="number" min="0" v-model.number="edited.dimensiones.ancho"
                     @change="validarDimension('ancho')"
                     class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                    :disabled="isSaving"
-                  />
+                    :disabled="isSaving" />
                   <span class="ml-1 text-sm text-gray-500">cm</span>
                 </div>
               </div>
               <div>
                 <label class="text-sm text-gray-500">Largo</label>
                 <div class="flex items-center">
-                  <input
-                    type="number"
-                    min="0"
-                    v-model.number="edited.dimensiones.largo"
+                  <input type="number" min="0" v-model.number="edited.dimensiones.largo"
                     @change="validarDimension('largo')"
                     class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                    :disabled="isSaving"
-                  />
+                    :disabled="isSaving" />
                   <span class="ml-1 text-sm text-gray-500">cm</span>
                 </div>
               </div>
@@ -98,16 +71,25 @@
             <div>
               <label class="text-sm text-gray-500">Alto</label>
               <div class="flex items-center">
-                <input
-                  type="number"
-                  min="0"
-                    v-model.number="edited.dimensiones.alto"
-                    @change="validarDimension('alto')"
-                    class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                    :disabled="isSaving"
-                  />
+                <input type="number" min="0" v-model.number="edited.dimensiones.alto" @change="validarDimension('alto')"
+                  class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                  :disabled="isSaving" />
                 <span class="ml-1 text-sm text-gray-500">cm</span>
               </div>
+            </div>
+            <!-- Diámetro para circulares -->
+            <div v-if="esCircular">
+              <label class="text-sm text-gray-500">Diámetro</label>
+              <div class="flex items-center">
+                <input type="number" min="1" step="1" :max="maxDiametroPlanta" v-model.number="edited.diametroCm"
+                  @change="validarDiametro"
+                  class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                  :disabled="isSaving" />
+                <span class="ml-1 text-sm text-gray-500">cm</span>
+              </div>
+              <p v-if="advertenciaDiametroLimite" class="text-xs text-amber-600">{{ advertenciaDiametroLimite }}</p>
+              <p v-if="advertenciaDiametroContencion" class="text-xs text-amber-600">{{ advertenciaDiametroContencion }}
+              </p>
             </div>
             <p v-if="advertenciaAltura" class="text-xs text-amber-600">{{ advertenciaAltura }}</p>
           </div>
@@ -120,15 +102,10 @@
             <div>
               <label class="text-sm text-gray-500">Altura sobre el suelo</label>
               <div class="flex items-center">
-                <input
-                  type="number"
-                  :min="0"
-                  :max="maxAlturaSobreSuelo"
-                  v-model.number="edited.alturaSobreSueloCm"
+                <input type="number" :min="0" :max="maxAlturaSobreSuelo" v-model.number="edited.alturaSobreSueloCm"
                   @change="validarAlturaSobreSuelo"
                   class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                  :disabled="isSaving || !esPared"
-                />
+                  :disabled="isSaving || !esPared" />
                 <span class="ml-1 text-sm text-gray-500">cm</span>
               </div>
               <p v-if="advertenciaZBase" class="text-xs text-amber-600">{{ advertenciaZBase }}</p>
@@ -143,25 +120,17 @@
             <div>
               <label class="text-sm text-gray-500">Capacidad de carga</label>
               <div class="flex items-center">
-                <input
-                  type="number"
-                  min="0"
-                  v-model.number="edited.pesoMaximo"
-                  @change="validarPeso"
+                <input type="number" min="0" v-model.number="edited.pesoMaximo" @change="validarPeso"
                   class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                  :disabled="isSaving"
-                />
+                  :disabled="isSaving" />
                 <span class="ml-1 text-sm text-gray-500">kg</span>
               </div>
             </div>
             <div v-if="volumen !== null">
               <label class="text-sm text-gray-500">Volumen</label>
               <div class="flex items-center">
-                <input
-                  :value="volumen"
-                  disabled
-                  class="w-full px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-500"
-                />
+                <input :value="volumen" disabled
+                  class="w-full px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-500" />
                 <span class="ml-1 text-sm text-gray-500">m³</span>
               </div>
             </div>
@@ -174,23 +143,16 @@
       <div v-if="isDirty" class="space-x-2 mb-3 flex justify-end">
         <button
           class="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
-          @click="revertir"
-          :disabled="isSaving"
-        >
+          @click="revertir" :disabled="isSaving">
           Revertir
         </button>
-        <button
-          class="px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600 disabled:opacity-50"
-          @click="guardar"
-          :disabled="guardarDeshabilitado"
-        >
+        <button class="px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600 disabled:opacity-50"
+          @click="guardar" :disabled="guardarDeshabilitado">
           Guardar
         </button>
       </div>
-      <button
-        @click="deseleccionarElemento"
-        class="w-full cursor-pointer px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm"
-      >
+      <button @click="deseleccionarElemento"
+        class="w-full cursor-pointer px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm">
         Deseleccionar
       </button>
     </div>
@@ -228,6 +190,9 @@ const cargarDesdeStore = (el) => deepClone({
   alturaSobreSueloCm: el.alturaSobreSueloCm != null
     ? Number(el.alturaSobreSueloCm)
     : (el.alturaRespectoAlSuelo != null ? Number(el.alturaRespectoAlSuelo) : 0),
+  diametroCm: (el.forma === 'circular')
+    ? Number(el.dimensiones?.ancho ?? el.dimensiones?.largo ?? 0)
+    : 0,
 })
 
 watch(() => elementoSeleccionado.value?.id, (id) => {
@@ -245,7 +210,13 @@ const isDirty = computed(() => {
   return !deepEqual(edited.value, snapshotOriginal.value)
 })
 
-const guardarDeshabilitado = computed(() => isSaving.value || !!advertenciaAltura.value || !!advertenciaZBase.value)
+const guardarDeshabilitado = computed(() =>
+  isSaving.value ||
+  !!advertenciaAltura.value ||
+  !!advertenciaZBase.value ||
+  !!advertenciaDiametroLimite.value ||
+  !!advertenciaDiametroContencion.value,
+)
 
 const revertir = () => {
   edited.value = deepClone(snapshotOriginal.value)
@@ -274,18 +245,34 @@ const guardar = async () => {
       patch.posicion = { ...(elementoSeleccionado.value?.posicion || {}), y: yTopPx }
     }
   }
+
+  // Si es circular, normalizar dimensiones con el diámetro y sincronizar px
+  if (esCircular.value) {
+    const d = Number(edited.value?.diametroCm) || 0
+    if (!patch.dimensiones) patch.dimensiones = {}
+    patch.dimensiones.ancho = d
+    patch.dimensiones.largo = d
+    // No contaminar el store con la propiedad auxiliar
+    delete patch.diametroCm
+  }
+  const diamChanged = esCircular.value && (snapshotOriginal.value?.diametroCm !== edited.value?.diametroCm)
   const ok = await canvasStore.updateElementById(elementoSeleccionado.value.id, patch)
   if (ok) {
     snapshotOriginal.value = deepClone(edited.value)
-    showSuccess('Cambios guardados')
+    showSuccess(diamChanged ? 'Diámetro actualizado' : 'Cambios guardados')
   }
   isSaving.value = false
 }
 
 const validarDimension = (prop) => {
   const val = Number(edited.value.dimensiones[prop])
+  const max = alturaPlanta.value
+
   if (isNaN(val) || val < 0) {
     showWarning('El valor debe ser mayor o igual a 0')
+    edited.value.dimensiones[prop] = snapshotOriginal.value.dimensiones[prop]
+  } else if (val > max) {
+    showWarning(`La altura no debe superar ${max} cm`)
     edited.value.dimensiones[prop] = snapshotOriginal.value.dimensiones[prop]
   }
 }
@@ -331,7 +318,8 @@ const esCajaOPallet = computed(() => {
 
 const mostrarCapacidad = computed(() => esAnaquelOEstante.value || esContenedorBarril.value || esCajaOPallet.value)
 const mostrarDimensiones = computed(() => true)
-const ocultarAnchoLargo = computed(() => esContenedorBarril.value && elementoSeleccionado.value?.forma === 'circular')
+const esCircular = computed(() => (elementoSeleccionado.value?.forma || '').toLowerCase() === 'circular' || (elementoSeleccionado.value?.forma || '').toLowerCase() === 'circle')
+const ocultarAnchoLargo = computed(() => esCircular.value)
 
 const volumen = computed(() => {
   if (!esContenedorBarril.value) return null
@@ -351,6 +339,48 @@ const advertenciaAltura = computed(() => {
   const actual = edited.value?.dimensiones?.alto || 0
   return actual > max ? `La altura no debe superar ${max} cm` : null
 })
+
+// ===== Validaciones para círculo (diametro y contención) =====
+const plantaDims = computed(() => {
+  const p = canvasStore.plantaPorId(canvasStore.plantaActiva)
+  return {
+    ancho: Number(p?.dimensiones?.ancho || 0),
+    largo: Number(p?.dimensiones?.largo || 0),
+  }
+})
+
+const maxDiametroPlanta = computed(() => Math.min(plantaDims.value.ancho, plantaDims.value.largo))
+
+const advertenciaDiametroLimite = computed(() => {
+  if (!esCircular.value) return null
+  const d = Number(edited.value?.diametroCm)
+  if (!Number.isFinite(d) || d <= 0) return 'El diámetro debe ser mayor a 0.'
+  if (d > maxDiametroPlanta.value) return 'El diámetro excede las dimensiones de la planta.'
+  return null
+})
+
+const advertenciaDiametroContencion = computed(() => {
+  if (!esCircular.value) return null
+  const d = Number(edited.value?.diametroCm)
+  if (!Number.isFinite(d) || d <= 0) return null
+  // Top-left como ancla según el modelo
+  const xPx = Number(elementoSeleccionado.value?.x || 0)
+  const yPx = Number(elementoSeleccionado.value?.y || 0)
+  const xCm = xPx / (CM_TO_PX || 10)
+  const yCm = yPx / (CM_TO_PX || 10)
+  if (xCm < 0 || yCm < 0) return 'El círculo se sale del área de trabajo con el diámetro actual.'
+  if (xCm + d > plantaDims.value.ancho || yCm + d > plantaDims.value.largo) return 'El círculo se sale del área de trabajo con el diámetro actual.'
+  return null
+})
+
+const validarDiametro = () => {
+  if (!esCircular.value) return
+  const d = Number(edited.value?.diametroCm)
+  if (!Number.isFinite(d) || d < 1) {
+    showWarning('El diámetro debe ser mayor o igual a 1 cm')
+    edited.value.diametroCm = snapshotOriginal.value.diametroCm
+  }
+}
 
 const maxAlturaSobreSuelo = computed(() => {
   const techo = Number(alturaPlanta.value) || 0

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -113,6 +113,29 @@
           </div>
         </details>
 
+        <!-- Posicionamiento en pared -->
+        <details v-if="esPared" open class="bg-gray-50 rounded-lg p-4">
+          <summary class="text-sm font-medium text-gray-700 cursor-pointer">Posicionamiento en pared</summary>
+          <div class="mt-3 space-y-3">
+            <div>
+              <label class="text-sm text-gray-500">Altura sobre el suelo</label>
+              <div class="flex items-center">
+                <input
+                  type="number"
+                  :min="0"
+                  :max="maxAlturaSobreSuelo"
+                  v-model.number="edited.alturaSobreSueloCm"
+                  @change="validarAlturaSobreSuelo"
+                  class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                  :disabled="isSaving || !esPared"
+                />
+                <span class="ml-1 text-sm text-gray-500">cm</span>
+              </div>
+              <p v-if="advertenciaZBase" class="text-xs text-amber-600">{{ advertenciaZBase }}</p>
+            </div>
+          </div>
+        </details>
+
         <!-- Capacidad -->
         <details v-if="mostrarCapacidad" open class="bg-gray-50 rounded-lg p-4">
           <summary class="text-sm font-medium text-gray-700 cursor-pointer">Capacidad</summary>
@@ -178,7 +201,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { onBeforeRouteLeave } from 'vue-router'
 import { useCanvasStore } from '@/composables/useCanvasStore.js'
-import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS } from '@/utils/constants'
+import { TIPOS_ENTIDAD, TODAS_LAS_CATEGORIAS, CM_TO_PX } from '@/utils/constants'
 import { deepClone, deepEqual, makePatch } from '@/utils/object'
 import { useToast } from '@/composables/useToast.js'
 import { useConfirmDialog } from '@/composables/useConfirmDialog'
@@ -202,6 +225,9 @@ const cargarDesdeStore = (el) => deepClone({
     alto: el.dimensiones?.alto || 0,
   },
   pesoMaximo: el.pesoMaximo || 0,
+  alturaSobreSueloCm: el.alturaSobreSueloCm != null
+    ? Number(el.alturaSobreSueloCm)
+    : (el.alturaRespectoAlSuelo != null ? Number(el.alturaRespectoAlSuelo) : 0),
 })
 
 watch(() => elementoSeleccionado.value?.id, (id) => {
@@ -219,7 +245,7 @@ const isDirty = computed(() => {
   return !deepEqual(edited.value, snapshotOriginal.value)
 })
 
-const guardarDeshabilitado = computed(() => isSaving.value || !!advertenciaAltura.value)
+const guardarDeshabilitado = computed(() => isSaving.value || !!advertenciaAltura.value || !!advertenciaZBase.value)
 
 const revertir = () => {
   edited.value = deepClone(snapshotOriginal.value)
@@ -230,6 +256,24 @@ const guardar = async () => {
   if (guardarDeshabilitado.value) return
   isSaving.value = true
   const patch = makePatch(snapshotOriginal.value, edited.value)
+
+  // Si es un elemento de pared, reflejar valores verticales y posicionar Y en px
+  if (esPared.value) {
+    const zBase = Number(edited.value?.alturaSobreSueloCm) || 0
+    patch.alturaRespectoAlSuelo = zBase
+    patch.alturaSobreSueloCm = zBase
+
+    const alturaTechoCm = Number(canvasStore.plantaPorId(canvasStore.plantaActiva)?.dimensiones?.alto || 0)
+    const altoCm = Number(edited.value?.dimensiones?.alto || elementoSeleccionado.value?.dimensiones?.alto || 0)
+    const yTopPx = (alturaTechoCm - (zBase + altoCm)) * (CM_TO_PX || 10)
+    if (Number.isFinite(yTopPx)) {
+      if (canvasStore.vistaActiva === 'XZ') {
+        patch.y = yTopPx
+      }
+      // Guardar en estructura de posición para futuras vistas XZ
+      patch.posicion = { ...(elementoSeleccionado.value?.posicion || {}), y: yTopPx }
+    }
+  }
   const ok = await canvasStore.updateElementById(elementoSeleccionado.value.id, patch)
   if (ok) {
     snapshotOriginal.value = deepClone(edited.value)
@@ -273,6 +317,8 @@ const esAnaquelOEstante = computed(() => {
   return cat === 'anaqueles' || cat === 'estantes'
 })
 
+const esPared = computed(() => (elementoSeleccionado.value?.ubicacion || '').toLowerCase() === 'pared')
+
 const esContenedorBarril = computed(() => {
   const el = elementoSeleccionado.value
   return el?.tipo === 'contenedores' || el?.categoria === 'contenedores'
@@ -305,6 +351,35 @@ const advertenciaAltura = computed(() => {
   const actual = edited.value?.dimensiones?.alto || 0
   return actual > max ? `La altura no debe superar ${max} cm` : null
 })
+
+const maxAlturaSobreSuelo = computed(() => {
+  const techo = Number(alturaPlanta.value) || 0
+  const alto = Number(edited.value?.dimensiones?.alto || 0)
+  return Math.max(0, techo - alto)
+})
+
+const advertenciaZBase = computed(() => {
+  if (!esPared.value) return null
+  const z = Number(edited.value?.alturaSobreSueloCm)
+  if (!Number.isFinite(z) || z < 0) return 'La altura sobre suelo debe ser mayor o igual a 0 cm'
+  const max = maxAlturaSobreSuelo.value
+  return z > max ? `La altura sobre el suelo no debe superar ${max} cm` : null
+})
+
+const validarAlturaSobreSuelo = () => {
+  if (!esPared.value) return
+  const z = Number(edited.value?.alturaSobreSueloCm)
+  if (!Number.isFinite(z) || z < 0) {
+    showWarning('La altura sobre el suelo debe ser mayor o igual a 0 cm')
+    edited.value.alturaSobreSueloCm = snapshotOriginal.value.alturaSobreSueloCm
+    return
+  }
+  const max = maxAlturaSobreSuelo.value
+  if (z > max) {
+    showWarning(`La altura sobre el suelo no debe superar ${max} cm`)
+    edited.value.alturaSobreSueloCm = snapshotOriginal.value.alturaSobreSueloCm
+  }
+}
 
 const deseleccionarElemento = () => {
   canvasStore.seleccionarElemento(null)

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -2,22 +2,6 @@
   <div class="h-full flex flex-col bg-white border-l border-gray-200" data-properties-panel>
     <div class="p-4 border-b border-gray-200 flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-800">Propiedades</h2>
-      <div v-if="isDirty" class="space-x-2">
-        <button
-          class="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
-          @click="revertir"
-          :disabled="isSaving"
-        >
-          Revertir
-        </button>
-        <button
-          class="px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600 disabled:opacity-50"
-          @click="guardar"
-          :disabled="guardarDeshabilitado"
-        >
-          Guardar
-        </button>
-      </div>
     </div>
 
     <div v-if="elementoSeleccionado" class="flex-1 overflow-y-auto p-4">
@@ -164,6 +148,22 @@
     </div>
 
     <div v-if="elementoSeleccionado" class="p-4 border-t border-gray-200 bg-white">
+      <div v-if="isDirty" class="space-x-2 mb-3 flex justify-end">
+        <button
+          class="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+          @click="revertir"
+          :disabled="isSaving"
+        >
+          Revertir
+        </button>
+        <button
+          class="px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600 disabled:opacity-50"
+          @click="guardar"
+          :disabled="guardarDeshabilitado"
+        >
+          Guardar
+        </button>
+      </div>
       <button
         @click="deseleccionarElemento"
         class="w-full cursor-pointer px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm"

--- a/src/components/tabs/CapasTab.vue
+++ b/src/components/tabs/CapasTab.vue
@@ -236,11 +236,13 @@ import { CATEGORIAS } from '@/utils/constants'
 import TagFilter from '@/components/TagFilter.vue'
 import CreateTagModal from '@/components/CreateTagModal.vue'
 import {useDeleteElement} from '@/composables/useDeleteElement'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 
 // Composables
 const canvasStore = useCanvasStore()
 
 const deleteElement = useDeleteElement();
+const confirmDialog = useConfirmDialog();
 
 // Estado local
 const filtroCategoria = ref('')

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -672,6 +672,29 @@ export const useCanvasStore = defineStore('canvas', () => {
     return true
   }
 
+  const persist = () => {
+    try {
+      const data = serialize()
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('canvas-data', data)
+      }
+    } catch (e) {
+      console.warn('Error persisting state', e)
+    }
+  }
+
+  const updateElementById = (id, patch) => {
+    const ok = actualizarElemento(id, patch, true, 'Editar propiedades')
+    if (ok) {
+      const el = elementos.value.find(e => e.id === id)
+      if (el) {
+        el.updatedAt = new Date().toISOString()
+      }
+      persist()
+    }
+    return ok
+  }
+
   // Variables para debounce de historial de vista
   let zoomPanDebounceTimer = null
   const ZOOM_PAN_DEBOUNCE_DELAY = 1000 // 1 segundo
@@ -1557,6 +1580,8 @@ export const useCanvasStore = defineStore('canvas', () => {
     seleccionarElemento,
     actualizarPosicion,
     actualizarElemento,
+    updateElementById,
+    persist,
     configurarZoom,
     configurarPan,
     setGridSize,

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,0 +1,19 @@
+export function deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+export function deepEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+export function makePatch(original, edited) {
+  const patch = {}
+  for (const key in edited) {
+    const val = edited[key]
+    const orig = original[key]
+    if (!deepEqual(val, orig)) {
+      patch[key] = typeof val === 'object' && val !== null ? deepClone(val) : val
+    }
+  }
+  return patch
+}

--- a/src/validation/fieldResolvers.js
+++ b/src/validation/fieldResolvers.js
@@ -1,6 +1,6 @@
 export function resolveVerticalProps(element = {}, candidate = {}) {
   const locationKeys = ['ubicacion', 'ubic', 'location']
-  const zBaseKeys = ['zBase', 'alturaRespectoAlSuelo', 'z_base', 'baseZ']
+  const zBaseKeys = ['zBase', 'alturaRespectoAlSuelo', 'alturaSobreSueloCm', 'z_base', 'baseZ']
   const heightKeys = ['alto', 'altura', 'height', 'heightCm']
 
   const coalesce = (cand, el, keys) => {

--- a/src/validation/placementOrchestrator.js
+++ b/src/validation/placementOrchestrator.js
@@ -4,8 +4,8 @@ import { narrowPhase2D } from '@/utils/collision'
 export const errorsPlacement = {
   ZBASE_REQUIRED: 'La altura respecto al suelo es obligatoria y debe ser mayor a 0.',
   HEIGHT_EXCEEDS_WAREHOUSE:
-    'Supera la altura de la bodega (zBase + alto > altura de bodega).',
-  Z_STACK_CONFLICT: 'Colisión vertical: las alturas se solapan',
+    'Su altura total excede la altura máxima de la bodega.',
+  Z_STACK_CONFLICT: 'Conflicto de altura detectado con otro elemento.',
 }
 
 export function resolveCoplanarNeighbors(element = {}, all = [], Z_LAYER_EPS = 0.5) {


### PR DESCRIPTION
## Summary
- introduce deepClone, deepEqual and makePatch utilities
- persist element updates with updateElementById and store serialization
- rework properties panel to buffer edits with save/revert, shortcut and navigation guard

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: 37 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dbe346448321b3dfde79d23050c4