### PR TITLE
feat: add zoom controls and viewport store

### DIFF
--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -616,6 +616,7 @@
       @fill-container="() => simularLlenadoContenedor(canvasStore.elementoSeleccionado)"
       @toggle-snapping="toggleSnapping"
       @delete="() => onDelete(canvasStore.elementoSeleccionadoCompleto.id)"
+      @recenter="centrarPlantaEnCanvas"
     />
 
     <!-- Menú contextual -->
@@ -738,6 +739,8 @@ import { dimsCmFor, clampInsideArea } from '@/utils/bounds'
 import { handleCanvasHotkeys } from '@/utils/canvasHotkeys'
 import { polygonInset } from '@/utils/polygonInset'
 import { GRID_SIZE, CM_TO_PX, DIMENSIONS, CATALOGO, OFFSETS } from '@/utils/constants'
+import { useViewportStore } from '@/stores/viewport'
+import { createPinia, getActivePinia, setActivePinia } from 'pinia'
 import { computeDimsByAxisScale, toCanvasSizePx } from '@/utils/dimensionPolicy'
 import { getActiveBounds } from '@/utils/activeBounds'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
@@ -803,6 +806,10 @@ function scheduleDraw() {
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
+if (!getActivePinia()) {
+  setActivePinia(createPinia())
+}
+const viewport = useViewportStore()
 const {
   onDragStartGuard,
   onDragMoveGuard,
@@ -826,6 +833,24 @@ const {
 
 // Estado para controlar si el snapping está habilitado (por defecto desactivado — evita alineado automático)
 const isSnappingEnabled = ref(true)
+
+watch(
+  () => viewport.zoom,
+  (z) => {
+    if (canvasStore.zoom !== z) {
+      canvasStore.configurarZoom(z)
+    }
+  },
+)
+
+watch(
+  () => canvasStore.zoom,
+  (z) => {
+    if (viewport.zoom !== z) {
+      viewport.setZoom(z)
+    }
+  },
+)
 
 // === HELPERS DE CONVERSIÓN ===
 /**
@@ -1083,7 +1108,7 @@ const handleWheel = (e) => {
 
   const scaleBy = 1.1
   const newScale = e.evt.deltaY > 0 ? oldScale / scaleBy : oldScale * scaleBy
-  const clampedScale = Math.max(0.1, Math.min(5, newScale))
+  const clampedScale = Math.max(viewport.minZoom, Math.min(viewport.maxZoom, newScale))
 
   const mousePointTo = {
     x: (pointer.x - stage.x()) / oldScale,
@@ -1095,7 +1120,7 @@ const handleWheel = (e) => {
     y: pointer.y - mousePointTo.y * clampedScale,
   }
 
-  canvasStore.configurarZoom(clampedScale)
+  viewport.setZoom(clampedScale)
   canvasStore.configurarPan(newPos.x, newPos.y)
   try { canvasStore.view.hasUserZoomPan = true } catch { /* ignore */ }
 }

--- a/src/components/FloatingToolbar.vue
+++ b/src/components/FloatingToolbar.vue
@@ -59,6 +59,49 @@
       </UiIconButton>
     </div>
 
+    <!-- Grupo de zoom -->
+    <div class="flex items-center h-[40px] gap-1" role="group" aria-label="Controles de zoom">
+      <UiIconButton
+        class="hover:bg-black/[.05] dark:hover:bg-white/[.06]"
+        aria-label="Alejar"
+        :disabled="!canZoomOut"
+        @click.stop="() => { viewport.zoomOut(); $emit('recenter') }"
+      >
+        <svg viewBox="0 0 24 24" class="h-[20px] w-[20px] fill-current" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M15.5 14h-.79l-.28-.27A6 6 0 1 0 9 15a6 6 0 0 0 9.33 5l.27.28v.79l5 5L24 24l-5-5zm-6.5 0a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9m-2-4.5h4v-1h-4z"
+          />
+        </svg>
+      </UiIconButton>
+      <UiIconButton
+        class="hover:bg-black/[.05] dark:hover:bg-white/[.06]"
+        aria-label="Restablecer zoom"
+        :disabled="!canReset"
+        @click.stop="() => { viewport.resetZoom(); $emit('recenter') }"
+      >
+        <svg viewBox="0 0 24 24" class="h-[20px] w-[20px] fill-current" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M12 6v3l4-4l-4-4v3c-4.418 0-8 3.582-8 8c0 1.59.469 3.069 1.268 4.318l1.516-1.316A5.97 5.97 0 0 1 6 14c0-3.309 2.691-6 6-6m6.732 1.682l-1.516 1.316A5.97 5.97 0 0 1 18 14c0 3.309-2.691 6-6 6v-3l-4 4l4 4v-3c4.418 0 8-3.582 8-8c0-1.59-.469-3.069-1.268-4.318"
+          />
+        </svg>
+      </UiIconButton>
+      <UiIconButton
+        class="hover:bg-black/[.05] dark:hover:bg-white/[.06]"
+        aria-label="Acercar"
+        :disabled="!canZoomIn"
+        @click.stop="() => { viewport.zoomIn(); $emit('recenter') }"
+      >
+        <svg viewBox="0 0 24 24" class="h-[20px] w-[20px] fill-current" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M15.5 14h-.79l-.28-.27A6 6 0 1 0 9 15a6 6 0 0 0 9.33 5l.27.28v.79l5 5L24 24l-5-5zm-6.5 0a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9m2-4h-1.5v1.5h-1v-1.5H7v-1h1.5V8h1v1.5H11v1z"
+          />
+        </svg>
+      </UiIconButton>
+    </div>
+
     <!-- Divider between group and secondary actions -->
     <div class="h-6 w-px bg-white/10 dark:bg-white/10 mx-1.5" aria-hidden="true" />
 
@@ -138,7 +181,10 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import UiIconButton from './ui/UiIconButton.vue'
+import { useViewportStore } from '@/stores/viewport'
+import { createPinia, getActivePinia, setActivePinia } from 'pinia'
 defineProps({
   activeMode: { type: String, default: 'drag' },
   isElementSelected: { type: Boolean, default: false },
@@ -148,8 +194,15 @@ defineProps({
   isSnapping: { type: Boolean, default: false },
   avoidOverlap: { type: Boolean, default: false },
 })
+if (!getActivePinia()) {
+  setActivePinia(createPinia())
+}
+const viewport = useViewportStore()
+const canZoomIn = computed(() => viewport.zoom < viewport.maxZoom)
+const canZoomOut = computed(() => viewport.zoom > viewport.minZoom)
+const canReset = computed(() => viewport.zoom !== 1)
 
-defineEmits(['set-mode', 'toggle-lock', 'toggle-snapping', 'fill-container', 'delete'])
+defineEmits(['set-mode', 'toggle-lock', 'toggle-snapping', 'fill-container', 'delete', 'recenter'])
 </script>
 
 <style>

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -1,0 +1,20 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useViewportStore = defineStore('viewport', () => {
+  const zoom = ref(1)
+  const minZoom = 0.2
+  const maxZoom = 4
+  const step = 0.2
+
+  const setZoom = (value) => {
+    const clamped = Math.max(minZoom, Math.min(maxZoom, value))
+    zoom.value = clamped
+  }
+
+  const zoomIn = () => setZoom(zoom.value + step)
+  const zoomOut = () => setZoom(zoom.value - step)
+  const resetZoom = () => setZoom(1)
+
+  return { zoom, minZoom, maxZoom, setZoom, zoomIn, zoomOut, resetZoom }
+})


### PR DESCRIPTION
## Summary
- add pinia viewport store for zoom limits
- add zoom in/out/reset buttons to floating toolbar
- sync viewport zoom with canvas stage and recenter

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: injection "Symbol(pinia)" not found and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b7759fe7788321be99013f8619a69e