### PR TITLE
feat: add tooltips to toolbar buttons

### DIFF
--- a/src/__tests__/floating_toolbar_ui.spec.js
+++ b/src/__tests__/floating_toolbar_ui.spec.js
@@ -99,7 +99,7 @@ describe('FloatingToolbar UI (refactor visuals)', () => {
 
   it('secondary buttons declare strong on-state styles', () => {
     const wrapper = mountToolbar({ activeMode: 'drag', isSnappingEnabled: true })
-    const snapBtn = wrapper.get('button[aria-label="Alternar snapping"]')
+    const snapBtn = wrapper.get('button[aria-label="Alternar ajuste automático (S)"]')
     expect(snapBtn.classes()).toContain('data-[state=on]:bg-white/10')
     expect(snapBtn.classes()).toContain('data-[state=on]:ring-1')
     expect(snapBtn.classes()).toContain('data-[state=on]:ring-white/15')
@@ -110,7 +110,7 @@ describe('FloatingToolbar UI (refactor visuals)', () => {
 
   it('edit icon renders 18x18 and turns white when active', async () => {
     const wrapper = mountToolbar({ activeMode: 'edit' })
-    const editBtn = wrapper.get('button[aria-label="Modo edición"]')
+    const editBtn = wrapper.get('button[aria-label="Editar elementos (E)"]')
     const editSvg = editBtn.get('svg')
     expect(editSvg.classes()).toContain('h-[18px]')
     expect(editSvg.classes()).toContain('w-[18px]')

--- a/src/__tests__/floating_toolbar_ui.spec.ts
+++ b/src/__tests__/floating_toolbar_ui.spec.ts
@@ -74,7 +74,7 @@ describe('FloatingToolbar UI (segmented control)', () => {
 
   it('secondary buttons are 36x36 with 18px icons', () => {
     const wrapper = mountToolbar()
-    const snapBtn = wrapper.get('button[aria-label="Alternar snapping"]')
+    const snapBtn = wrapper.get('button[aria-label="Alternar ajuste automático (S)"]')
     expect(snapBtn.classes()).toContain('h-[36px]')
     expect(snapBtn.classes()).toContain('w-[36px]')
     const svg = snapBtn.get('svg')
@@ -117,7 +117,7 @@ describe('FloatingToolbar UI (segmented control)', () => {
 
   it('secondary buttons declare strong on-state styles', () => {
     const wrapper = mountToolbar({ activeMode: 'drag', isSnappingEnabled: true })
-    const snapBtn = wrapper.get('button[aria-label="Alternar snapping"]')
+    const snapBtn = wrapper.get('button[aria-label="Alternar ajuste automático (S)"]')
     expect(snapBtn.classes()).toContain('data-[state=on]:bg-white/10')
     expect(snapBtn.classes()).toContain('data-[state=on]:ring-1')
     expect(snapBtn.classes()).toContain('data-[state=on]:ring-white/15')
@@ -128,7 +128,7 @@ describe('FloatingToolbar UI (segmented control)', () => {
 
   it('edit icon renders 18x18 and turns white when active', async () => {
     const wrapper = mountToolbar({ activeMode: 'edit' })
-    const editBtn = wrapper.get('button[aria-label="Modo edición"]')
+    const editBtn = wrapper.get('button[aria-label="Editar elementos (E)"]')
     const editSvg = editBtn.get('svg')
     expect(editSvg.classes()).toContain('h-[18px]')
     expect(editSvg.classes()).toContain('w-[18px]')

--- a/src/components/FloatingToolbar.vue
+++ b/src/components/FloatingToolbar.vue
@@ -18,13 +18,13 @@
         :style="{ left: 'calc(var(--seg-index) * 50%)' }"
         aria-hidden="true"
       ></div>
-      <UiTooltip label="Modo mano (D)" :delay="200">
+      <UiTooltip label="Mover lienzo (D)" :delay="200">
         <UiIconButton
           class="relative z-10 grid h-[34px] w-[34px] place-items-center rounded-[12px] p-0 m-0 bg-transparent hover:bg-transparent leading-none transform transition data-[state=on]:scale-100 data-[state=off]:scale-95"
           @click.stop="$emit('set-mode', 'drag')"
           :state="activeMode === 'drag' ? 'on' : 'off'"
-          aria-label="Modo mano (D)"
-          title="Modo mano (D)"
+          aria-label="Mover lienzo (D)"
+          title="Mover lienzo (D)"
           :aria-pressed="activeMode === 'drag' ? 'true' : 'false'"
         >
           <!-- Icono Mano -->
@@ -40,13 +40,13 @@
           </svg>
         </UiIconButton>
       </UiTooltip>
-      <UiTooltip label="Modo edición (E)" :delay="200">
+      <UiTooltip label="Editar elementos (E)" :delay="200">
         <UiIconButton
           class="relative z-10 grid h-[34px] w-[34px] place-items-center rounded-[12px] p-0 m-0 bg-transparent hover:bg-transparent leading-none transform transition data-[state=on]:scale-100 data-[state=off]:scale-95"
           @click.stop="$emit('set-mode', 'edit')"
           :state="activeMode === 'edit' ? 'on' : 'off'"
-          aria-label="Modo edición (E)"
-          title="Modo edición (E)"
+          aria-label="Editar elementos (E)"
+          title="Editar elementos (E)"
           :aria-pressed="activeMode === 'edit' ? 'true' : 'false'"
         >
           <!-- Icono Cursor -->
@@ -69,14 +69,14 @@
     <div class="h-6 w-px bg-white/10 dark:bg-white/10 mx-1.5" aria-hidden="true" />
 
     <!-- Snapping -->
-    <UiTooltip label="Snapping (S)" :delay="200">
+    <UiTooltip label="Ajuste automático (S)" :delay="200">
       <div class="relative group">
         <UiIconButton
           class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
           @click.stop="$emit('toggle-snapping')"
           :state="isSnappingEnabled ? 'on' : 'off'"
-          aria-label="Alternar snapping (S)"
-          title="Alternar snapping (S)"
+          aria-label="Alternar ajuste automático (S)"
+          title="Alternar ajuste automático (S)"
           :aria-pressed="isSnappingEnabled ? 'true' : 'false'"
         >
           <!-- Icono Snap (imán) -->
@@ -114,11 +114,11 @@
     </UiTooltip>
 
     <!-- Delete button -->
-    <UiTooltip v-if="isElementSelected" label="Eliminar elemento (Supr)" :delay="200">
+    <UiTooltip v-if="isElementSelected" label="Borrar elemento (Supr)" :delay="200">
       <UiIconButton
         class="hover:bg-black/[0.05] dark:hover:bg-white/[0.06]"
-        aria-label="Eliminar elemento (Supr)"
-        title="Eliminar elemento (Supr)"
+        aria-label="Borrar elemento (Supr)"
+        title="Borrar elemento (Supr)"
         @click.stop="$emit('delete')"
       >
         <svg
@@ -137,15 +137,15 @@
     <!-- Fill container -->
     <UiTooltip
       v-if="isContainer && isElementSelected"
-      label="Llenar contenedor (F)"
+      label="Ajustar al contenedor (F)"
       :delay="200"
     >
       <UiIconButton
         class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
         @click.stop="$emit('fill-container')"
         state="off"
-        aria-label="Llenar contenedor (F)"
-        title="Llenar contenedor (F)"
+        aria-label="Ajustar al contenedor (F)"
+        title="Ajustar al contenedor (F)"
       >
         <!-- Icono fill -->
         <svg viewBox="0 0 48 48" class="pointer-events-none h-[18px] w-[18px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">

--- a/src/components/FloatingToolbar.vue
+++ b/src/components/FloatingToolbar.vue
@@ -18,127 +18,151 @@
         :style="{ left: 'calc(var(--seg-index) * 50%)' }"
         aria-hidden="true"
       ></div>
-      <UiIconButton
-        class="relative z-10 grid h-[34px] w-[34px] place-items-center rounded-[12px] p-0 m-0 bg-transparent hover:bg-transparent leading-none transform transition data-[state=on]:scale-100 data-[state=off]:scale-95"
-        @click.stop="$emit('set-mode', 'drag')"
-        :state="activeMode === 'drag' ? 'on' : 'off'"
-        aria-label="Modo mano (mover lienzo)"
-        :aria-pressed="activeMode === 'drag' ? 'true' : 'false'"
-      >
-        <!-- Icono Mano -->
-        <svg
-          viewBox="0 0 512 512"
-          class="block h-[14px] w-[14px] pointer-events-none fill-current align-middle transition data-[state=on]:text-white data-[state=off]:text-slate-400/70 data-[state=off]:opacity-70 drop-shadow-[0_1px_1px_rgba(0,0,0,.25)]"
-          aria-hidden="true"
+      <UiTooltip label="Modo mano (D)" :delay="200">
+        <UiIconButton
+          class="relative z-10 grid h-[34px] w-[34px] place-items-center rounded-[12px] p-0 m-0 bg-transparent hover:bg-transparent leading-none transform transition data-[state=on]:scale-100 data-[state=off]:scale-95"
+          @click.stop="$emit('set-mode', 'drag')"
+          :state="activeMode === 'drag' ? 'on' : 'off'"
+          aria-label="Modo mano (D)"
+          title="Modo mano (D)"
+          :aria-pressed="activeMode === 'drag' ? 'true' : 'false'"
         >
-          <path 
-            fill="currentColor" 
-            d="M288 32c0-17.7-14.3-32-32-32s-32 14.3-32 32v208c0 8.8-7.2 16-16 16s-16-7.2-16-16V64c0-17.7-14.3-32-32-32s-32 14.3-32 32v272c0 1.5 0 3.1.1 4.6L67.6 283c-16-15.2-41.3-14.6-56.6 1.4s-14.6 41.3 1.4 56.6l112.4 107c43.1 41.1 100.4 64 160 64H304c97.2 0 176-78.8 176-176V128c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16s-16-7.2-16-16V64c0-17.7-14.3-32-32-32s-32 14.3-32 32v176c0 8.8-7.2 16-16 16s-16-7.2-16-16z"
-          />
-        </svg>
-      </UiIconButton>
-      <UiIconButton
-        class="relative z-10 grid h-[34px] w-[34px] place-items-center rounded-[12px] p-0 m-0 bg-transparent hover:bg-transparent leading-none transform transition data-[state=on]:scale-100 data-[state=off]:scale-95"
-        @click.stop="$emit('set-mode', 'edit')"
-        :state="activeMode === 'edit' ? 'on' : 'off'"
-        aria-label="Modo edición"
-        :aria-pressed="activeMode === 'edit' ? 'true' : 'false'"
-      >
-        <!-- Icono Cursor -->
-        <svg 
-          viewBox="0 0 24 24" 
-          class="block h-[18px] w-[18px] pointer-events-none fill-current align-middle transition data-[state=on]:text-white data-[state=off]:text-slate-400/70 data-[state=off]:opacity-70 drop-shadow-[0_1px_1px_rgba(0,0,0,.25)]" 
-          aria-hidden="true">
-          <path 
-            fill="currentColor" 
-            fill-rule="evenodd" 
-            d="M4.38 3.075a1 1 0 0 0-1.305 1.306l7 17a1 1 0 0 0 1.844.013l2.685-6.265a1 1 0 0 1 .525-.525l6.265-2.685a1 1 0 0 0-.013-1.844z" 
-            clip-rule="evenodd"
-          />
-        </svg>
-      </UiIconButton>
+          <!-- Icono Mano -->
+          <svg
+            viewBox="0 0 512 512"
+            class="block h-[14px] w-[14px] pointer-events-none fill-current align-middle transition data-[state=on]:text-white data-[state=off]:text-slate-400/70 data-[state=off]:opacity-70 drop-shadow-[0_1px_1px_rgba(0,0,0,.25)]"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M288 32c0-17.7-14.3-32-32-32s-32 14.3-32 32v208c0 8.8-7.2 16-16 16s-16-7.2-16-16V64c0-17.7-14.3-32-32-32s-32 14.3-32 32v272c0 1.5 0 3.1.1 4.6L67.6 283c-16-15.2-41.3-14.6-56.6 1.4s-14.6 41.3 1.4 56.6l112.4 107c43.1 41.1 100.4 64 160 64H304c97.2 0 176-78.8 176-176V128c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16s-16-7.2-16-16V64c0-17.7-14.3-32-32-32s-32 14.3-32 32v176c0 8.8-7.2 16-16 16s-16-7.2-16-16z"
+            />
+          </svg>
+        </UiIconButton>
+      </UiTooltip>
+      <UiTooltip label="Modo edición (E)" :delay="200">
+        <UiIconButton
+          class="relative z-10 grid h-[34px] w-[34px] place-items-center rounded-[12px] p-0 m-0 bg-transparent hover:bg-transparent leading-none transform transition data-[state=on]:scale-100 data-[state=off]:scale-95"
+          @click.stop="$emit('set-mode', 'edit')"
+          :state="activeMode === 'edit' ? 'on' : 'off'"
+          aria-label="Modo edición (E)"
+          title="Modo edición (E)"
+          :aria-pressed="activeMode === 'edit' ? 'true' : 'false'"
+        >
+          <!-- Icono Cursor -->
+          <svg
+            viewBox="0 0 24 24"
+            class="block h-[18px] w-[18px] pointer-events-none fill-current align-middle transition data-[state=on]:text-white data-[state=off]:text-slate-400/70 data-[state=off]:opacity-70 drop-shadow-[0_1px_1px_rgba(0,0,0,.25)]"
+            aria-hidden="true">
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.38 3.075a1 1 0 0 0-1.305 1.306l7 17a1 1 0 0 0 1.844.013l2.685-6.265a1 1 0 0 1 .525-.525l6.265-2.685a1 1 0 0 0-.013-1.844z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </UiIconButton>
+      </UiTooltip>
     </div>
 
     <!-- Divider between group and secondary actions -->
     <div class="h-6 w-px bg-white/10 dark:bg-white/10 mx-1.5" aria-hidden="true" />
 
     <!-- Snapping -->
-    <div class="relative group">
-    <UiIconButton
-      class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
-      @click.stop="$emit('toggle-snapping')"
-      :state="isSnappingEnabled ? 'on' : 'off'"
-      :aria-label="'Alternar snapping'"
-      :aria-pressed="isSnappingEnabled ? 'true' : 'false'"
-    >
-      <!-- Icono Snap (imÃ¡n) -->
-      <svg viewBox="0 0 24 24" class="pointer-events-none h-[20px] w-[20px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
-        <path d="M20 19.88V22l-1.8-1.17l-4.79-9a4.9 4.9 0 0 0 1.78-1M15 7a3 3 0 0 1-3 3a3 3 0 0 1-.44 0L5.8 20.83L4 22v-2.12L9.79 9A3 3 0 0 1 12 4V2a1 1 0 0 1 1 1v1.18A3 3 0 0 1 15 7m-2 0a1 1 0 1 0-1 1a1 1 0 0 0 1-1m-8.78 3L6 11.8l-1.44 2.76L2.1 12.1m9.9 5.66l-1.5-1.51L9 19l3 3l3-3l-1.47-2.77M19.78 10L18 11.8l1.5 2.76l2.4-2.46Z" />
-      </svg>
-    </UiIconButton>
-    <span v-if="isSnappingEnabled" class="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full bg-[var(--primary,theme(colors.blue.600))] ring-2 ring-slate-900/60"></span>
-    </div>
+    <UiTooltip label="Snapping (S)" :delay="200">
+      <div class="relative group">
+        <UiIconButton
+          class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
+          @click.stop="$emit('toggle-snapping')"
+          :state="isSnappingEnabled ? 'on' : 'off'"
+          aria-label="Alternar snapping (S)"
+          title="Alternar snapping (S)"
+          :aria-pressed="isSnappingEnabled ? 'true' : 'false'"
+        >
+          <!-- Icono Snap (imán) -->
+          <svg viewBox="0 0 24 24" class="pointer-events-none h-[20px] w-[20px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
+            <path d="M20 19.88V22l-1.8-1.17l-4.79-9a4.9 4.9 0 0 0 1.78-1M15 7a3 3 0 0 1-3 3a3 3 0 0 1-.44 0L5.8 20.83L4 22v-2.12L9.79 9A3 3 0 0 1 12 4V2a1 1 0 0 1 1 1v1.18A3 3 0 0 1 15 7m-2 0a1 1 0 1 0-1 1a1 1 0 0 0 1-1m-8.78 3L6 11.8l-1.44 2.76L2.1 12.1m9.9 5.66l-1.5-1.51L9 19l3 3l3-3l-1.47-2.77M19.78 10L18 11.8l1.5 2.76l2.4-2.46Z" />
+          </svg>
+        </UiIconButton>
+        <span v-if="isSnappingEnabled" class="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full bg-[var(--primary,theme(colors.blue.600))] ring-2 ring-slate-900/60"></span>
+      </div>
+    </UiTooltip>
 
     <!-- Lock / Unlock -->
-    <UiIconButton
+    <UiTooltip
       v-if="isElementSelected"
-      class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
-      @click.stop="$emit('toggle-lock')"
-      :state="isElementLocked ? 'on' : 'off'"
-      :aria-label="isElementLocked ? 'Desbloquear elemento' : 'Bloquear elemento'"
-      :aria-pressed="isElementLocked ? 'true' : 'false'"
-      :class="{ 'text-amber-600 dark:text-amber-400': isElementLocked }"
+      :label="isElementLocked ? 'Desbloquear elemento (L)' : 'Bloquear elemento (L)'"
+      :delay="200"
     >
-      <!-- Icono candado -->
-      <svg v-if="isElementLocked" viewBox="0 0 512 512" class="pointer-events-none h-[18px] w-[18px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
-        <path d="M420 192h-68v-80a96 96 0 1 0-192 0v80H92a12 12 0 0 0-12 12v280a12 12 0 0 0 12 12h328a12 12 0 0 0 12-12V204a12 12 0 0 0-12-12m-106 0H198v-80.75a58 58 0 1 1 116 0Z" />
-      </svg>
-      <svg v-else viewBox="0 0 512 512" class="pointer-events-none h-[18px] w-[18px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
-        <path d="M420 192H198v-80.75a58.08 58.08 0 0 1 99.07-41.07A59.4 59.4 0 0 1 314 112h38a96 96 0 1 0-192 0v80H92a12 12 0 0 0-12 12v280a12 12 0 0 0 12 12h328a12 12 0 0 0 12-12V204a12 12 0 0 0-12-12" />
-      </svg>
-    </UiIconButton>
+      <UiIconButton
+        class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
+        @click.stop="$emit('toggle-lock')"
+        :state="isElementLocked ? 'on' : 'off'"
+        :aria-label="isElementLocked ? 'Desbloquear elemento (L)' : 'Bloquear elemento (L)'"
+        :title="isElementLocked ? 'Desbloquear elemento (L)' : 'Bloquear elemento (L)'"
+        :aria-pressed="isElementLocked ? 'true' : 'false'"
+        :class="{ 'text-amber-600 dark:text-amber-400': isElementLocked }"
+      >
+        <!-- Icono candado -->
+        <svg v-if="isElementLocked" viewBox="0 0 512 512" class="pointer-events-none h-[18px] w-[18px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
+          <path d="M420 192h-68v-80a96 96 0 1 0-192 0v80H92a12 12 0 0 0-12 12v280a12 12 0 0 0 12 12h328a12 12 0 0 0 12-12V204a12 12 0 0 0-12-12m-106 0H198v-80.75a58 58 0 1 1 116 0Z" />
+        </svg>
+        <svg v-else viewBox="0 0 512 512" class="pointer-events-none h-[18px] w-[18px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
+          <path d="M420 192H198v-80.75a58.08 58.08 0 0 1 99.07-41.07A59.4 59.4 0 0 1 314 112h38a96 96 0 1 0-192 0v80H92a12 12 0 0 0-12 12v280a12 12 0 0 0 12 12h328a12 12 0 0 0 12-12V204a12 12 0 0 0-12-12" />
+        </svg>
+      </UiIconButton>
+    </UiTooltip>
 
     <!-- Delete button -->
-    <UiIconButton
-      v-if="isElementSelected"
-      class="hover:bg-black/[0.05] dark:hover:bg-white/[0.06]"
-      aria-label="Eliminar elemento"
-      @click.stop="$emit('delete')"
-    >
-      <svg 
-        xmlns="http://www.w3.org/2000/svg" 
-        class="pointer-events-none h-[22px] w-[22px] text-slate-300"
-        viewBox="0 0 24 24"
+    <UiTooltip v-if="isElementSelected" label="Eliminar elemento (Supr)" :delay="200">
+      <UiIconButton
+        class="hover:bg-black/[0.05] dark:hover:bg-white/[0.06]"
+        aria-label="Eliminar elemento (Supr)"
+        title="Eliminar elemento (Supr)"
+        @click.stop="$emit('delete')"
       >
-        <path 
-          fill="currentColor" 
-          d="M7.616 20q-.691 0-1.153-.462T6 18.384V6H5V5h4v-.77h6V5h4v1h-1v12.385q0 .69-.462 1.153T16.384 20zm2.192-3h1V8h-1zm3.384 0h1V8h-1z"
-        />
-      </svg>
-    </UiIconButton> 
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="pointer-events-none h-[22px] w-[22px] text-slate-300"
+          viewBox="0 0 24 24"
+        >
+          <path
+            fill="currentColor"
+            d="M7.616 20q-.691 0-1.153-.462T6 18.384V6H5V5h4v-.77h6V5h4v1h-1v12.385q0 .69-.462 1.153T16.384 20zm2.192-3h1V8h-1zm3.384 0h1V8h-1z"
+          />
+        </svg>
+      </UiIconButton>
+    </UiTooltip>
 
     <!-- Fill container -->
-    <UiIconButton
+    <UiTooltip
       v-if="isContainer && isElementSelected"
-      class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
-      @click.stop="$emit('fill-container')"
-      state="off"
-      aria-label="Llenar contenedor"
+      label="Llenar contenedor (F)"
+      :delay="200"
     >
-      <!-- Icono fill -->
-      <svg viewBox="0 0 48 48" class="pointer-events-none h-[18px] w-[18px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
-        <path 
-          fill="currentColor" 
-          fill-rule="evenodd" 
-          d="m42.243 15.61l-1.183-.017c-1.586-3.963-3.464-7.44-4.637-9.472c-.964-1.67-2.742-2.621-4.61-2.621h-1.477c-.41-1.247-1.624-1.921-2.767-1.955c-.79-.023-1.963-.045-3.569-.045s-2.778.022-3.569.045c-1.143.034-2.357.708-2.767 1.955h-1.478c-1.867 0-3.645.95-4.61 2.621c-1.172 2.033-3.05 5.51-4.636 9.472l-1.183.018c-1.344.02-3.483.563-4.046 2.697C1.58 18.8 1.5 19.363 1.5 20s.081 1.2.21 1.692c.564 2.134 2.703 2.677 4.047 2.698c2.704.042 8.565.11 18.243.11s15.54-.068 18.243-.11c1.344-.021 3.483-.564 4.046-2.698c.13-.491.211-1.055.211-1.692s-.081-1.2-.21-1.692c-.564-2.134-2.703-2.677-4.047-2.698M27.57 8.456c-.79.023-1.963.045-3.569.045s-2.778-.022-3.569-.045c-1.143-.034-2.357-.708-2.767-1.955h-1.478c-.857 0-1.613.432-2.01 1.12a75 75 0 0 0-3.976 7.937c3.226-.03 7.773-.057 13.8-.057s10.574.027 13.8.057a75 75 0 0 0-3.975-7.936C33.427 6.93 32.67 6.5 31.814 6.5h-1.478c-.41 1.247-1.624 1.921-2.767 1.955M5.13 26.855l.057.44c.483 3.672 1.253 8.559 2.402 13.376a6.88 6.88 0 0 0 5.97 5.269c2.555.274 6.223.56 10.44.56s7.884-.286 10.44-.56a6.88 6.88 0 0 0 5.97-5.27c1.148-4.816 1.919-9.703 2.402-13.375l.057-.44q-.324.03-.586.034c-2.719.042-8.593.11-18.283.11s-15.564-.068-18.282-.11a8 8 0 0 1-.587-.033m10.657 3.66a1.5 1.5 0 0 1 1.697 1.273l1 7a1.5 1.5 0 1 1-2.97.424l-1-7a1.5 1.5 0 0 1 1.273-1.697m14.727 1.273a1.5 1.5 0 1 1 2.97.424l-1 7a1.5 1.5 0 1 1-2.97-.424zM24 30.5a1.5 1.5 0 0 1 1.5 1.5v7a1.5 1.5 0 0 1-3 0v-7a1.5 1.5 0 0 1 1.5-1.5" 
-          clip-rule="evenodd"/>
-      </svg>
-    </UiIconButton>
+      <UiIconButton
+        class="relative z-10 grid h-[36px] w-[36px] place-items-center rounded-[12px] bg-transparent hover:bg-black/[.05] dark:hover:bg-white/[.06] text-slate-600 dark:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary,theme(colors.blue.600))]/40 data-[state=on]:bg-white/10 data-[state=on]:ring-1 data-[state=on]:ring-white/15 data-[state=off]:opacity-70"
+        @click.stop="$emit('fill-container')"
+        state="off"
+        aria-label="Llenar contenedor (F)"
+        title="Llenar contenedor (F)"
+      >
+        <!-- Icono fill -->
+        <svg viewBox="0 0 48 48" class="pointer-events-none h-[18px] w-[18px] fill-current data-[state=on]:text-white data-[state=off]:text-slate-300" aria-hidden="true">
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="m42.243 15.61l-1.183-.017c-1.586-3.963-3.464-7.44-4.637-9.472c-.964-1.67-2.742-2.621-4.61-2.621h-1.477c-.41-1.247-1.624-1.921-2.767-1.955c-.79-.023-1.963-.045-3.569-.045s-2.778.022-3.569.045c-1.143.034-2.357.708-2.767 1.955h-1.478c-.857 0-1.613.432-2.01 1.12a75 75 0 0 0-3.976 7.937c3.226-.03 7.773-.057 13.8-.057s10.574.027 13.8.057a75 75 0 0 0-3.975-7.936C33.427 6.93 32.67 6.5 31.814 6.5h-1.478c-.41 1.247-1.624 1.921-2.767 1.955M5.13 26.855l.057.44c.483 3.672 1.253 8.559 2.402 13.376a6.88 6.88 0 0 0 5.97 5.269c2.555.274 6.223.56 10.44.56s7.884-.286 10.44-.56a6.88 6.88 0 0 0 5.97-5.27c1.148-4.816 1.919-9.703 2.402-13.375l.057-.44q-.324.03-.586.034c-2.719.042-8.593.11-18.283.11s-15.564-.068-18.282-.11a8 8 0 0 1-.587-.033m10.657 3.66a1.5 1.5 0 0 1 1.697 1.273l1 7a1.5 1.5 0 1 1-2.97.424l-1-7a1.5 1.5 0 0 1 1.273-1.697m14.727 1.273a1.5 1.5 0 1 1 2.97.424l-1 7a1.5 1.5 0 1 1-2.97-.424zM24 30.5a1.5 1.5 0 0 1 1.5 1.5v7a1.5 1.5 0 0 1-3 0v-7a1.5 1.5 0 0 1 1.5-1.5"
+            clip-rule="evenodd"/>
+        </svg>
+      </UiIconButton>
+    </UiTooltip>
   </div>
 </template>
 
 <script setup>
 import UiIconButton from './ui/UiIconButton.vue'
+import UiTooltip from './ui/UiTooltip.vue'
 defineProps({
   activeMode: { type: String, default: 'drag' },
   isElementSelected: { type: Boolean, default: false },

--- a/src/components/ui/UiTooltip.vue
+++ b/src/components/ui/UiTooltip.vue
@@ -1,0 +1,60 @@
+<template>
+  <div
+    class="relative inline-block"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+    @focus="onEnter"
+    @blur="onLeave"
+  >
+    <slot />
+    <transition name="fade">
+      <div
+        v-if="visible"
+        class="pointer-events-none absolute z-50 -top-2 left-1/2 -translate-x-1/2 -translate-y-full px-2 py-1 rounded-md bg-slate-900 text-white text-xs shadow"
+        role="tooltip"
+      >
+        {{ label }}
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup>
+import { ref, onBeforeUnmount } from 'vue'
+defineOptions({ name: 'UiTooltip' })
+
+const props = defineProps({
+  label: { type: String, required: true },
+  delay: { type: Number, default: 200 },
+})
+
+const visible = ref(false)
+let timer
+
+function onEnter() {
+  timer = setTimeout(() => {
+    visible.value = true
+  }, props.delay)
+}
+
+function onLeave() {
+  clearTimeout(timer)
+  visible.value = false
+}
+
+onBeforeUnmount(() => {
+  clearTimeout(timer)
+})
+</script>
+
+<style>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.1s;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add reusable `UiTooltip` component with delayed display
- show tooltips and fallback labels on every toolbar action

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: context menu spec, delete element spec, delete element undo, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b775c0657c8321a2f5d80b94050f4e