### PR TITLE
feat: translate view labels via i18n

### DIFF
--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -222,7 +222,7 @@
               />
           </v-group>
 
-          <!-- Elementos circulares: en vista XY son círculos, en vista XZ son rectángulos -->
+          <!-- Elementos circulares: en vista aérea (XY) son círculos, en vista de frente (XZ) son rectángulos -->
           <v-group
             v-else-if="elemento.forma === 'circular' && canvasStore.vistaActiva === 'XY'"
             :config="{
@@ -276,7 +276,7 @@
             />
           </v-group>
 
-          <!-- Elementos circulares en vista XZ se muestran como rectángulos (cilindro visto de frente) -->
+          <!-- Elementos circulares en vista de frente (XZ) se muestran como rectángulos (cilindro visto de frente) -->
           <v-group
             v-else-if="elemento.forma === 'circular' && canvasStore.vistaActiva === 'XZ'"
             :config="{
@@ -329,7 +329,7 @@
               }"
             />
           </v-group>
-          <!-- Icono de candado para elemento circular bloqueado en vista XY -->
+          <!-- Icono de candado para elemento circular bloqueado en vista aérea (XY) -->
           <v-group
             v-if="isElementLocked(elemento.id) && elemento.forma === 'circular' && canvasStore.vistaActiva === 'XY'"
             :config="{
@@ -369,7 +369,7 @@
             />
           </v-group>
 
-          <!-- Icono de candado para elemento circular bloqueado en vista XZ (rectangular) -->
+          <!-- Icono de candado para elemento circular bloqueado en vista de frente (XZ) (rectangular) -->
           <v-group
             v-if="isElementLocked(elemento.id) && elemento.forma === 'circular' && canvasStore.vistaActiva === 'XZ'"
             :config="{
@@ -634,11 +634,11 @@
     <!-- Información de zoom, vista y dimensiones -->
     <div class="canvas-info">
       <span>Zoom: {{ Math.round(canvasStore.zoom * 100) }}%</span>
-      <span>Vista: {{ canvasStore.vistaActiva }}</span>
+      <span>{{ t('views.label') }}: {{ t(`views.${canvasStore.vistaActiva}`) }}</span>
       <span v-if="canvasStore.estaEnPlanta && canvasStore.plantaActivaData">
         Planta: {{ canvasStore.plantaActivaData.dimensiones.ancho }}×{{
           canvasStore.plantaActivaData.dimensiones.largo
-        }}cm (Vista desde arriba)
+        }}cm (Vista aérea)
       </span>
       <span
         v-if="
@@ -714,6 +714,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue'
+import { t } from '@/i18n'
 import { useCacheOnDrag } from '@/composables/useCacheOnDrag'
 import { setupRafDrag } from '@/composables/useRafDrag'
 import { enablePerfMode } from '@/composables/usePerfMode'
@@ -845,15 +846,15 @@ const getElementPixelDimensions = (elemento) => {
     let widthCm, heightCm
 
     if (canvasStore.vistaActiva === 'XY') {
-      // Vista superior (XY): width = ancho, height = largo
+      // Vista aérea (XY): width = ancho, height = largo
       widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
       heightCm = elemento.dimensiones.largo || (elemento.height ? elemento.height / CM_TO_PX : 6)
     } else if (canvasStore.vistaActiva === 'XZ') {
-      // Vista frontal (XZ): width = ancho, height = alto
+      // Vista de frente (XZ): width = ancho, height = alto
       widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
       heightCm = elemento.dimensiones.alto || (elemento.height ? elemento.height / CM_TO_PX : 6)
     } else {
-      // Fallback a vista XY
+      // Fallback a vista aérea (XY)
       widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
       heightCm = elemento.dimensiones.largo || (elemento.height ? elemento.height / CM_TO_PX : 6)
     }
@@ -1965,10 +1966,10 @@ const createElementFromDrop = (data, dropEvent) => {
 
       // La altura en píxeles para el renderizado depende de la vista
       if (canvasStore.vistaActiva === 'XY') {
-        // En vista XY, la altura visual corresponde al largo
+        // En vista aérea (XY), la altura visual corresponde al largo
         finalHeightFinal = largoCmFinal * CM_TO_PX;
       } else if (canvasStore.vistaActiva === 'XZ') {
-        // En vista XZ, la altura visual corresponde al alto, no al largo
+        // En vista de frente (XZ), la altura visual corresponde al alto, no al largo
         // No modificamos finalHeightFinal en este caso
       }
 
@@ -2261,7 +2262,7 @@ const createElementFromBuffer = (data, dropEvent) => {
     // Obtener el elemento padre (el elemento actual donde estamos)
     const elementoPadre = canvasStore.elementoContenedorActual;
     if (elementoPadre && elementoPadre.dimensiones) {
-      // Si estamos en vista XZ (frontal), ajustar el alto según el largo del padre
+      // Si estamos en vista de frente (XZ), ajustar el alto según el largo del padre
       if (canvasStore.vistaActiva === 'XZ') {
         const largoPadreCm = elementoPadre.dimensiones.largo;
 

--- a/src/composables/useAutoPaste.js
+++ b/src/composables/useAutoPaste.js
@@ -174,7 +174,7 @@ export function useAutoPaste() {
       const planta = canvasStore.plantaPorId(contexto.id)
       // Intentar obtener el polígono de la planta primero
       if (planta?.poligono && Array.isArray(planta.poligono) && planta.poligono.length > 0) {
-        // Los puntos ya están en pixeles, y solo se usa en vista XY
+        // Los puntos ya están en pixeles, y solo se usa en vista aérea (XY)
         polygonPoints = planta.poligono.map(p => ({
           x: (p.x || 0),
           y: (p.y || 0)

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -527,11 +527,11 @@ export const useCanvasStore = defineStore('canvas', () => {
     let elementWidthPx, elementHeightPx
 
     if (elemento.dimensiones) {
-      // Para elementos/contenedores usamos vista XZ: ancho × alto
+      // Para elementos/contenedores usamos vista de frente (XZ): ancho × alto
       // (ya que navegamos "dentro" del elemento, vemos su vista frontal)
       elementWidthPx = elemento.dimensiones.ancho * CM_TO_PX
       elementHeightPx = elemento.dimensiones.alto * CM_TO_PX
-      console.log('Usando dimensiones en cm (Vista XZ - ancho × alto):', {
+      console.log('Usando dimensiones en cm (Vista de frente - ancho × alto):', {
         anchoCm: elemento.dimensiones.ancho,
         altoCm: elemento.dimensiones.alto,
         widthPx: elementWidthPx,
@@ -649,7 +649,7 @@ export const useCanvasStore = defineStore('canvas', () => {
       if (propiedades.dimensiones) {
         // Actualizar width/height dependiendo de la vista activa
         if (vistaActiva.value === 'XY') {
-          // En vista XY (superior): ancho->width, largo->height
+          // En vista aérea (XY): ancho->width, largo->height
           if (propiedades.dimensiones.ancho !== undefined) {
             elemento.width = elemento.dimensiones.ancho * CM_TO_PX
           }
@@ -657,14 +657,14 @@ export const useCanvasStore = defineStore('canvas', () => {
             elemento.height = elemento.dimensiones.largo * CM_TO_PX
           }
         } else if (vistaActiva.value === 'XZ') {
-          // En vista XZ (frontal): ancho->width, alto->height
+          // En vista de frente (XZ): ancho->width, alto->height
           if (propiedades.dimensiones.ancho !== undefined) {
             elemento.width = elemento.dimensiones.ancho * CM_TO_PX
           }
           if (propiedades.dimensiones.alto !== undefined) {
             elemento.height = elemento.dimensiones.alto * CM_TO_PX
           }
-          // Nota: largo no afecta a width/height en vista XZ
+          // Nota: largo no afecta a width/height en vista de frente (XZ)
         }
       }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,13 @@
+export const messages = {
+  es: {
+    views: {
+      label: 'Vista',
+      XY: 'Vista aérea',
+      XZ: 'Vista de frente',
+    },
+  },
+}
+
+export function t(key, locale = 'es') {
+  return key.split('.').reduce((obj, k) => (obj && obj[k] !== undefined ? obj[k] : undefined), messages[locale]) ?? key
+}


### PR DESCRIPTION
## Summary
- centralize view labels in simple i18n helper
- show "Vista aérea" or "Vista de frente" instead of raw codes
- update comments/logs to use new naming

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:unit -- -u` *(fails: [🍍]: "getActivePinia()" was called but there was no active Pinia, plus 41 failing tests overall)*

------
https://chatgpt.com/codex/tasks/task_e_68b775e975908321a300f7daee7f7e96