### PR TITLE
feat: centralize view labels in i18n

### DIFF
--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -634,11 +634,11 @@
     <!-- Información de zoom, vista y dimensiones -->
     <div class="canvas-info">
       <span>Zoom: {{ Math.round(canvasStore.zoom * 100) }}%</span>
-      <span>Vista: {{ canvasStore.vistaActiva }}</span>
+      <span>Vista: {{ vistaLabel }}</span>
       <span v-if="canvasStore.estaEnPlanta && canvasStore.plantaActivaData">
         Planta: {{ canvasStore.plantaActivaData.dimensiones.ancho }}×{{
           canvasStore.plantaActivaData.dimensiones.largo
-        }}cm (Vista desde arriba)
+        }}cm ({{ t('views.aerial') }})
       </span>
       <span
         v-if="
@@ -649,7 +649,7 @@
         {{ canvasStore.estaEnElemento ? 'Elemento' : 'Contenedor' }}:
         {{ canvasStore.elementoContenedorActual.nombre }}
         <template v-if="canvasStore.vistaActiva === 'XZ' && canvasStore.elementoContenedorActual.dimensiones">
-          ({{ canvasStore.elementoContenedorActual.dimensiones.ancho }}×{{ canvasStore.elementoContenedorActual.dimensiones.alto }}cm - Vista de frente)
+          ({{ canvasStore.elementoContenedorActual.dimensiones.ancho }}×{{ canvasStore.elementoContenedorActual.dimensiones.alto }}cm - {{ t('views.front') }})
         </template>
         <template v-else>
           ({{ canvasStore.canvasAdaptativo.width }}×{{ canvasStore.canvasAdaptativo.height }}px)
@@ -756,6 +756,7 @@ import FloatingToolbar from './FloatingToolbar.vue'
 import { getUsoInfo, useProductSimulation } from '@/utils/simulateProducts'
 import SnapGuides from './SnapGuides.vue'
 import { useToast } from '@/composables/useToast'
+import { t, viewLabels } from '@/i18n'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -826,6 +827,8 @@ const {
 
 // Estado para controlar si el snapping está habilitado (por defecto desactivado — evita alineado automático)
 const isSnappingEnabled = ref(true)
+
+const vistaLabel = computed(() => viewLabels[canvasStore.vistaActiva] || canvasStore.vistaActiva)
 
 // === HELPERS DE CONVERSIÓN ===
 /**

--- a/src/components/modals/ElementEditor.vue
+++ b/src/components/modals/ElementEditor.vue
@@ -19,9 +19,6 @@
       </div>
       <div class="flex flex-col md:flex-row gap-6 p-6">
         <!-- Columna izquierda: Canvas Vue-Konva -->
-        <!-- <div class="w-full md:w-2/3 flex flex-col items-center justify-start relative">
-          <h3 class="text-lg font-medium text-gray-800 mb-3">Vista de frente</h3>
-        </div> -->
         <!-- Columna derecha: Formulario y preview -->
         <form @submit.prevent="handleSubmit" class="w-full">
           <div class="max-h-[70vh] overflow-y-auto pr-2">
@@ -186,7 +183,7 @@
             </div>
             <!-- Preview del nuevo elemento -->
             <div class="bg-gray-50 rounded-lg p-4 mb-6">
-              <h3 class="text-lg font-medium text-gray-800 mb-3">Vista Previa (desde arriba)</h3>
+              <h3 class="text-lg font-medium text-gray-800 mb-3">Vista Previa ({{ t('views.aerial') }})</h3>
               <div class="flex items-center p-3 bg-white rounded border">
                 <div
                   :class="[
@@ -242,6 +239,7 @@ import {
   errorsPlacement,
 } from '@/validation/placementOrchestrator'
 import { useToast } from '@/composables/useToast'
+import { t } from '@/i18n'
 const { showToast } = useToast()
 
 const props = defineProps({

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -26,6 +26,7 @@ import {
   validateZStacking,
   errorsPlacement,
 } from '@/validation/placementOrchestrator'
+import { viewLabels } from '@/i18n'
 
 export const useCanvasStore = defineStore('canvas', () => {
   const { showToast } = useToast()
@@ -527,11 +528,11 @@ export const useCanvasStore = defineStore('canvas', () => {
     let elementWidthPx, elementHeightPx
 
     if (elemento.dimensiones) {
-      // Para elementos/contenedores usamos vista XZ: ancho × alto
+      // Para elementos/contenedores usamos vista frontal (XZ): ancho × alto
       // (ya que navegamos "dentro" del elemento, vemos su vista frontal)
       elementWidthPx = elemento.dimensiones.ancho * CM_TO_PX
       elementHeightPx = elemento.dimensiones.alto * CM_TO_PX
-      console.log('Usando dimensiones en cm (Vista XZ - ancho × alto):', {
+      console.log(`Usando dimensiones en cm (${viewLabels.XZ} - ancho × alto):`, {
         anchoCm: elemento.dimensiones.ancho,
         altoCm: elemento.dimensiones.alto,
         widthPx: elementWidthPx,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,15 @@
+export const messages = {
+  views: {
+    front: 'Vista de frente',
+    aerial: 'Vista aérea',
+  },
+};
+
+export function t(path) {
+  return path.split('.').reduce((acc, key) => (acc ? acc[key] : undefined), messages) || path;
+}
+
+export const viewLabels = {
+  XZ: messages.views.front,
+  XY: messages.views.aerial,
+};


### PR DESCRIPTION
## Summary
- add basic i18n helper with labels for views
- use translation for front/aerial view labels in CanvasView and ElementEditor
- log canvas dimensions using translated view names

## Testing
- `npx vitest run -u --reporter=default` *(fails: getActivePinia and other test errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b775e975908321a300f7daee7f7e96