### PR TITLE
Open properties panel on selection and add hotkey

### DIFF
--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -756,6 +756,8 @@ import FloatingToolbar from './FloatingToolbar.vue'
 import { getUsoInfo, useProductSimulation } from '@/utils/simulateProducts'
 import SnapGuides from './SnapGuides.vue'
 import { useToast } from '@/composables/useToast'
+import { usePropertiesStore } from '@/stores/properties.js'
+import { focusPrimerCampo } from '@/utils/focusPrimerCampo.js'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -803,6 +805,7 @@ function scheduleDraw() {
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
+const propertiesStore = usePropertiesStore()
 const {
   onDragStartGuard,
   onDragMoveGuard,
@@ -1131,6 +1134,10 @@ const handleStageClick = (e) => {
 const selectElement = (elementId) => {
   console.log('Seleccionando elemento:', elementId)
   canvasStore.seleccionarElemento(elementId)
+  if (elementId) {
+    propertiesStore.openFor(elementId)
+    nextTick(() => focusPrimerCampo())
+  }
   // Si el modo arrastre global está activado y el elemento NO está bloqueado, activar edición (transformer)
   if (dragModeGlobal.value && elementId && !isElementLocked(elementId)) {
     editingElementId.value = elementId
@@ -2708,14 +2715,21 @@ const handleGlobalClick = (e) => {
 // Deseleccionar al presionar Escape
 const handleKeyDown = (e) => {
   if (!e) return
-  if (e.key === 'Escape' || e.key === 'Esc') {
-    canvasStore.toggleMostrarPropiedades();
+  const key = e.key.toLowerCase()
+  if (key === 'escape' || key === 'esc') {
+    canvasStore.toggleMostrarPropiedades()
     canvasStore.seleccionarElemento(null)
     // Asegurar que el transformer/edición se cierre
     editingElementId.value = null
     speedDialOpen.value = false
     // Limpiar guías de snapping
     clearGuides()
+  } else if (key === 'p') {
+    e.preventDefault()
+    propertiesStore.toggle()
+    if (canvasStore.mostrarPropiedades.value) {
+      nextTick(() => focusPrimerCampo())
+    }
   } else {
     handleCanvasHotkeys(e, {
       dragMode: dragModeGlobal,
@@ -2992,8 +3006,12 @@ const toggleLock = async (id) => {
 
 // Abrir las propiedades
 const openProperties = () => {
-  canvasStore.toggleMostrarPropiedades(true);
-  ctx.close();
+  const id = canvasStore.elementoSeleccionado
+  if (id) {
+    propertiesStore.openFor(id)
+    nextTick(() => focusPrimerCampo())
+  }
+  ctx.close()
 }
 
 // Acción eliminar desde el menú contextual

--- a/src/stores/properties.js
+++ b/src/stores/properties.js
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useCanvasStore } from '@/composables/useCanvasStore.js'
+
+export const usePropertiesStore = defineStore('properties', () => {
+  const currentId = ref(null)
+  const canvasStore = useCanvasStore()
+
+  const openFor = (id) => {
+    currentId.value = id
+    canvasStore.toggleMostrarPropiedades(true)
+  }
+
+  const toggle = () => {
+    canvasStore.toggleMostrarPropiedades(!canvasStore.mostrarPropiedades.value)
+  }
+
+  return { currentId, openFor, toggle }
+})

--- a/src/utils/focusPrimerCampo.js
+++ b/src/utils/focusPrimerCampo.js
@@ -1,0 +1,8 @@
+export function focusPrimerCampo() {
+  const panel = document.querySelector('[data-properties-panel]')
+  if (!panel) return
+  const first = panel.querySelector('input, select, textarea')
+  if (first && typeof first.focus === 'function') {
+    first.focus()
+  }
+}


### PR DESCRIPTION
## Summary
- Open properties panel and focus its first field when an element is selected
- Introduce a simple properties store and focus helper
- Allow toggling the properties panel with the `P` keyboard shortcut

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: getActivePinia() was called but there was no active Pinia, other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b77633d33c8321bee295e0bbe73452