### PR TITLE
feat: notify shape collisions during resize

### DIFF
--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -179,6 +179,18 @@
                 shadowOpacity: getElementShadow(elemento).opacity,
               }"
             />
+            <v-circle
+              v-if="resizingElementId === elemento.id && notifier.overlapState === 'overlapping'"
+              :config="{
+                x: elemento.width,
+                y: 0,
+                radius: 6 / canvasStore.zoom,
+                fill: '#ef4444',
+                stroke: '#fff',
+                strokeWidth: 1 / canvasStore.zoom,
+                listening: false,
+              }"
+            />
           </v-group>
           <!-- Icono de candado para elemento bloqueado -->
           <v-group
@@ -274,6 +286,18 @@
                 strokeWidth: 0,
               }"
             />
+            <v-circle
+              v-if="resizingElementId === elemento.id && notifier.overlapState === 'overlapping'"
+              :config="{
+                x: elemento.width,
+                y: 0,
+                radius: 6 / canvasStore.zoom,
+                fill: '#ef4444',
+                stroke: '#fff',
+                strokeWidth: 1 / canvasStore.zoom,
+                listening: false,
+              }"
+            />
           </v-group>
 
           <!-- Elementos circulares en vista XZ se muestran como rectángulos (cilindro visto de frente) -->
@@ -326,6 +350,18 @@
                 shadowColor: 'black',
                 shadowBlur: 4,
                 shadowOpacity: 0.3,
+              }"
+            />
+            <v-circle
+              v-if="resizingElementId === elemento.id && notifier.overlapState === 'overlapping'"
+              :config="{
+                x: elemento.width,
+                y: 0,
+                radius: 6 / canvasStore.zoom,
+                fill: '#ef4444',
+                stroke: '#fff',
+                strokeWidth: 1 / canvasStore.zoom,
+                listening: false,
               }"
             />
           </v-group>
@@ -756,6 +792,8 @@ import FloatingToolbar from './FloatingToolbar.vue'
 import { getUsoInfo, useProductSimulation } from '@/utils/simulateProducts'
 import SnapGuides from './SnapGuides.vue'
 import { useToast } from '@/composables/useToast'
+import { clampResizeDeltaToContact } from '@/utils/collision'
+import { useCollisionNotifier } from '@/composables/useCollisionNotifier'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -826,6 +864,9 @@ const {
 
 // Estado para controlar si el snapping está habilitado (por defecto desactivado — evita alineado automático)
 const isSnappingEnabled = ref(true)
+const notifier = useCollisionNotifier()
+const resizingElementId = ref(null)
+let lastResizeCheck = 0
 
 // === HELPERS DE CONVERSIÓN ===
 /**
@@ -2496,6 +2537,7 @@ const handleTransformStart = (e, elementId) => {
     const state = { x, y, width, height, rotation: node.rotation?.() || 0 }
     transformInitialState.set(elementId, state)
     console.debug('[transform-debug] start', elementId, state)
+    resizingElementId.value = elementId
   } catch { /* ignore */ }
 }
 
@@ -2617,6 +2659,28 @@ const handleTransformMove = (e, elementId) => {
 
     const neighbors = canvasStore.elementosVisibles.filter(e => e.id !== elementId)
     const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height }
+
+    const now = performance.now()
+    let overlaps = false
+    if (now - lastResizeCheck > 1000 / 60) {
+      lastResizeCheck = now
+      overlaps = !isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
+      notifier.onOverlapChange(overlaps)
+      if (overlaps) {
+        const delta = {
+          dx: x - elemento.x,
+          dy: y - elemento.y,
+          dw: width - elemento.width,
+          dh: height - elemento.height,
+        }
+        const clamped = clampResizeDeltaToContact(elemento, delta, neighbors)
+        x = elemento.x + clamped.dx
+        y = elemento.y + clamped.dy
+        width = elemento.width + clamped.dw
+        height = elemento.height + clamped.dh
+      }
+    }
+
     const valid = isPlacementValid({ pos: { x, y }, movingEl: { ...elemento, width, height }, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
 
     // Aplicar stroke rojo si inválido, volver al color habitual si válido
@@ -2981,6 +3045,8 @@ const onShapePointerDown = (evt, elemento) => {
 }
 const onShapePointerUp = () => {
   clearTimeout(longPressTimer)
+  notifier.reset()
+  resizingElementId.value = null
 }
 
 // Acción bloquear/desbloquear desde el menú contextual

--- a/src/composables/useCollisionNotifier.js
+++ b/src/composables/useCollisionNotifier.js
@@ -1,0 +1,33 @@
+import { ref } from 'vue'
+
+export function useCollisionNotifier() {
+  const overlapState = ref('none')
+  const cooldown = 800
+  let lastToast = 0
+  const toastId = 'collision-overlap'
+
+  function showToast() {
+    if (typeof window === 'undefined' || !window.__toasts?.show) return
+    const now = Date.now()
+    if (now - lastToast < cooldown) return
+    lastToast = now
+    try {
+      window.__toasts.show('Elementos solapados', { id: toastId, type: 'warning', timeout: cooldown })
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function onOverlapChange(overlaps) {
+    const next = overlaps ? 'overlapping' : 'none'
+    if (next === overlapState.value) return
+    overlapState.value = next
+    if (next === 'overlapping') showToast()
+  }
+
+  function reset() {
+    overlapState.value = 'none'
+  }
+
+  return { overlapState, onOverlapChange, reset }
+}

--- a/src/utils/collision.js
+++ b/src/utils/collision.js
@@ -286,3 +286,44 @@ export function resolveCandidateWithBoundary(movingEl, allElements, W, H, iterat
   }
   return { x, y, fellBack: false }
 }
+
+export function clampResizeDeltaToContact(rect, delta, neighbors) {
+  let x = rect.x + (delta.dx || 0)
+  let y = rect.y + (delta.dy || 0)
+  let w = rect.width + (delta.dw || 0)
+  let h = rect.height + (delta.dh || 0)
+
+  for (const n of neighbors) {
+    const overlaps = !(x + w <= n.x || n.x + n.width <= x || y + h <= n.y || n.y + n.height <= y)
+    if (!overlaps) continue
+    const { dx, dy } = computeMTD(x, y, w, h, n.x, n.y, n.width, n.height)
+    if (dx !== 0) {
+      if (delta.dw > 0 && dx < 0) {
+        w += dx
+      } else if (delta.dw < 0 && dx > 0) {
+        w -= dx
+        x += dx
+      } else {
+        x += dx
+      }
+    }
+    if (dy !== 0) {
+      if (delta.dh > 0 && dy < 0) {
+        h += dy
+      } else if (delta.dh < 0 && dy > 0) {
+        h -= dy
+        y += dy
+      } else {
+        y += dy
+      }
+    }
+  }
+
+  return {
+    dx: x - rect.x,
+    dy: y - rect.y,
+    dw: w - rect.width,
+    dh: h - rect.height,
+  }
+}
+


### PR DESCRIPTION
## Summary
- add collision notifier composable with cooldown and toast reuse
- clamp resize delta to contact when overlap
- show red badge on overlapping shapes during resize

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: Invalid vnode type, Pinia store not set, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b7771b7028832191637ce3be62bfa7