### PR TITLE
feat: add unit helpers and remove px labels

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4173'
+  }
+})

--- a/cypress/e2e/no_px.cy.js
+++ b/cypress/e2e/no_px.cy.js
@@ -1,0 +1,8 @@
+/* global cy, describe, it */
+describe('No px texts', () => {
+  it('should not display px in editor or panel', () => {
+    cy.visit('/')
+    // eslint-disable-next-line no-restricted-syntax
+    cy.contains('px').should('not.exist')
+  })
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,14 @@ export default defineConfig([
 
   {
     rules: {
-      'no-unused-vars': 'off'
+      'no-unused-vars': 'off',
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: "Literal[value='px']",
+          message: 'Avoid hardcoded px literals; use unit helpers'
+        }
+      ]
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "test:unit": "vitest",
     "lint": "eslint . --fix",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "test:e2e": "cypress run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
@@ -31,6 +32,7 @@
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.31.0",
     "eslint-plugin-vue": "~10.3.0",
+    "cypress": "^13.15.0",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
     "prettier": "3.6.2",

--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -519,8 +519,8 @@
             y: -(39 / canvasStore.zoom),
             text:
               canvasStore.estaEnElemento || canvasStore.estaEnContenedor
-                ? `${canvasStore.elementoContenedorActual?.nombre || 'Elemento'} - ${layerConfig.width}x${layerConfig.height}px (Adaptativo)`
-                : `${canvasStore.plantaActivaData?.nombre || 'Planta'} - ${layerConfig.width}x${layerConfig.height}px (${canvasStore.plantaActivaData?.dimensiones.ancho}x${canvasStore.plantaActivaData?.dimensiones.largo}cm)`,
+                ? `${canvasStore.elementoContenedorActual?.nombre || 'Elemento'} - ${fmtCm(pxToCm(layerConfig.width, viewport.cmPerPx))}x${fmtCm(pxToCm(layerConfig.height, viewport.cmPerPx))} (Adaptativo)`
+                : `${canvasStore.plantaActivaData?.nombre || 'Planta'} - ${fmtCm(pxToCm(layerConfig.width, viewport.cmPerPx))}x${fmtCm(pxToCm(layerConfig.height, viewport.cmPerPx))} (${fmtCm(canvasStore.plantaActivaData?.dimensiones.ancho)}x${fmtCm(canvasStore.plantaActivaData?.dimensiones.largo)})`,
             fontSize: 12 / canvasStore.zoom,
             fontFamily: 'Arial',
             fill: '#3b82f6',
@@ -636,9 +636,9 @@
       <span>Zoom: {{ Math.round(canvasStore.zoom * 100) }}%</span>
       <span>Vista: {{ canvasStore.vistaActiva }}</span>
       <span v-if="canvasStore.estaEnPlanta && canvasStore.plantaActivaData">
-        Planta: {{ canvasStore.plantaActivaData.dimensiones.ancho }}×{{
-          canvasStore.plantaActivaData.dimensiones.largo
-        }}cm (Vista desde arriba)
+        Planta: {{ fmtCm(canvasStore.plantaActivaData.dimensiones.ancho) }}×{{
+          fmtCm(canvasStore.plantaActivaData.dimensiones.largo)
+        }} (Vista desde arriba)
       </span>
       <span
         v-if="
@@ -649,10 +649,10 @@
         {{ canvasStore.estaEnElemento ? 'Elemento' : 'Contenedor' }}:
         {{ canvasStore.elementoContenedorActual.nombre }}
         <template v-if="canvasStore.vistaActiva === 'XZ' && canvasStore.elementoContenedorActual.dimensiones">
-          ({{ canvasStore.elementoContenedorActual.dimensiones.ancho }}×{{ canvasStore.elementoContenedorActual.dimensiones.alto }}cm - Vista de frente)
+          ({{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.ancho) }}×{{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.alto) }} - Vista de frente)
         </template>
         <template v-else>
-          ({{ canvasStore.canvasAdaptativo.width }}×{{ canvasStore.canvasAdaptativo.height }}px)
+          ({{ fmtCm(pxToCm(canvasStore.canvasAdaptativo.width, viewport.cmPerPx)) }}×{{ fmtCm(pxToCm(canvasStore.canvasAdaptativo.height, viewport.cmPerPx)) }})
         </template>
       </span>
       <span v-if="canvasStore.elementoSeleccionado">
@@ -739,6 +739,8 @@ import { handleCanvasHotkeys } from '@/utils/canvasHotkeys'
 import { polygonInset } from '@/utils/polygonInset'
 import { GRID_SIZE, CM_TO_PX, DIMENSIONS, CATALOGO, OFFSETS } from '@/utils/constants'
 import { computeDimsByAxisScale, toCanvasSizePx } from '@/utils/dimensionPolicy'
+import { cmToPx, pxToCm, fmtCm } from '@/utils/units'
+import { useViewportStore } from '@/stores/viewport'
 import { getActiveBounds } from '@/utils/activeBounds'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
 import { useContextMenu } from '@/composables/useContextMenu'
@@ -833,6 +835,7 @@ const isSnappingEnabled = ref(true)
  * @param {Object} elemento - El elemento del cual obtener dimensiones
  * @returns {Object} - { width: number, height: number } en píxeles
  */
+const viewport = useViewportStore()
 const getElementPixelDimensions = (elemento) => {
   // Si ya tiene width/height en píxeles, usarlos solo si no tiene dimensiones en cm
   // Esto es para compatibilidad con elementos legacy que solo tienen width/height
@@ -846,21 +849,21 @@ const getElementPixelDimensions = (elemento) => {
 
     if (canvasStore.vistaActiva === 'XY') {
       // Vista superior (XY): width = ancho, height = largo
-      widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
-      heightCm = elemento.dimensiones.largo || (elemento.height ? elemento.height / CM_TO_PX : 6)
+      widthCm = elemento.dimensiones.ancho || (elemento.width ? pxToCm(elemento.width, viewport.cmPerPx) : 10)
+      heightCm = elemento.dimensiones.largo || (elemento.height ? pxToCm(elemento.height, viewport.cmPerPx) : 6)
     } else if (canvasStore.vistaActiva === 'XZ') {
       // Vista frontal (XZ): width = ancho, height = alto
-      widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
-      heightCm = elemento.dimensiones.alto || (elemento.height ? elemento.height / CM_TO_PX : 6)
+      widthCm = elemento.dimensiones.ancho || (elemento.width ? pxToCm(elemento.width, viewport.cmPerPx) : 10)
+      heightCm = elemento.dimensiones.alto || (elemento.height ? pxToCm(elemento.height, viewport.cmPerPx) : 6)
     } else {
       // Fallback a vista XY
-      widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
-      heightCm = elemento.dimensiones.largo || (elemento.height ? elemento.height / CM_TO_PX : 6)
+      widthCm = elemento.dimensiones.ancho || (elemento.width ? pxToCm(elemento.width, viewport.cmPerPx) : 10)
+      heightCm = elemento.dimensiones.largo || (elemento.height ? pxToCm(elemento.height, viewport.cmPerPx) : 6)
     }
 
     return {
-      width: Math.round(widthCm * CM_TO_PX),
-      height: Math.round(heightCm * CM_TO_PX),
+      width: Math.round(cmToPx(widthCm, viewport.cmPerPx)),
+      height: Math.round(cmToPx(heightCm, viewport.cmPerPx)),
     }
   }
 

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -60,7 +60,7 @@
 
         <!-- Dimensiones -->
         <details v-if="mostrarDimensiones" open class="bg-gray-50 rounded-lg p-4">
-          <summary class="text-sm font-medium text-gray-700 cursor-pointer">Dimensiones (cm)</summary>
+          <summary class="text-sm font-medium text-gray-700 cursor-pointer">Dimensiones ({{ t('units.cm') }})</summary>
           <div class="mt-3 space-y-3">
             <!-- Para formas no circulares, mostrar ancho/largo -->
             <div v-if="!ocultarAnchoLargo" class="grid grid-cols-2 gap-3">
@@ -71,7 +71,7 @@
                     @change="validarDimension('ancho')"
                     class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                     :disabled="isSaving" />
-                  <span class="ml-1 text-sm text-gray-500">cm</span>
+                  <span class="ml-1 text-sm text-gray-500">{{ t('units.cm') }}</span>
                 </div>
               </div>
               <div>
@@ -81,7 +81,7 @@
                     @change="validarDimension('largo')"
                     class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                     :disabled="isSaving" />
-                  <span class="ml-1 text-sm text-gray-500">cm</span>
+                  <span class="ml-1 text-sm text-gray-500">{{ t('units.cm') }}</span>
                 </div>
               </div>
             </div>
@@ -91,7 +91,7 @@
                 <input type="number" min="0" v-model.number="edited.dimensiones.alto" @change="validarDimension('alto')"
                   class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                   :disabled="isSaving" />
-                <span class="ml-1 text-sm text-gray-500">cm</span>
+                <span class="ml-1 text-sm text-gray-500">{{ t('units.cm') }}</span>
               </div>
             </div>
             <!-- Diámetro para circulares -->
@@ -102,7 +102,7 @@
                   @change="validarDiametro"
                   class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                   :disabled="isSaving" />
-                <span class="ml-1 text-sm text-gray-500">cm</span>
+                <span class="ml-1 text-sm text-gray-500">{{ t('units.cm') }}</span>
               </div>
               <p v-if="advertenciaDiametroLimite" class="text-xs text-amber-600">{{ advertenciaDiametroLimite }}</p>
               <p v-if="advertenciaDiametroContencion" class="text-xs text-amber-600">{{ advertenciaDiametroContencion }}
@@ -128,7 +128,7 @@
                   @change="validarAlturaSobreSuelo"
                   class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                   :disabled="isSaving || !esPared" />
-                <span class="ml-1 text-sm text-gray-500">cm</span>
+                <span class="ml-1 text-sm text-gray-500">{{ t('units.cm') }}</span>
               </div>
               <p v-if="advertenciaZBase" class="text-xs text-amber-600">{{ advertenciaZBase }}</p>
             </div>
@@ -196,6 +196,7 @@ import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useWeightValidation } from '@/composables/useWeightValidation.js'
 import { useDimensionValidation } from '@/composables/useDimensionValidation.js'
 import { EPSILON } from '@/utils/geometry.js'
+import { t } from '@/utils/i18n.js'
 import TagFilter from '@/components/TagFilter.vue'
 import CreateTagModal from '@/components/CreateTagModal.vue'
 

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -1,0 +1,11 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useViewportStore = defineStore('viewport', () => {
+  const scale = ref(1)
+  const cmPerPxBase = ref(0.1)
+
+  const cmPerPx = computed(() => cmPerPxBase.value / scale.value)
+
+  return { scale, cmPerPxBase, cmPerPx }
+})

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -1,0 +1,4 @@
+export const t = (key) => {
+  const dict = { 'units.cm': 'cm' }
+  return dict[key] || key
+}

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,0 +1,15 @@
+export const cmToPx = (valueCm, cmPerPx) => {
+  return valueCm / cmPerPx
+}
+
+export const pxToCm = (valuePx, cmPerPx) => {
+  return valuePx * cmPerPx
+}
+
+export const fmtCm = (valueCm, { decimals = 1 } = {}) => {
+  const factor = Math.pow(10, decimals)
+  const rounded = Math.round(valueCm * factor) / factor
+  return `${rounded.toFixed(decimals)} cm`
+}
+
+export default { cmToPx, pxToCm, fmtCm }


### PR DESCRIPTION
## Summary
- add cm<->px utils and viewport store with scale and cmPerPx
- replace px labels with formatted cm in canvas and panel
- add eslint rule against px literals and cypress check for px absence

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: getActivePinia not active, other failing tests)*
- `npm run test:e2e` *(fails: cypress: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b779f5f2408321b4034102016fe079