### PR TITLE
Orden descendente de portapapeles y capas

### DIFF
--- a/src/composables/useCanvasBuffer.js
+++ b/src/composables/useCanvasBuffer.js
@@ -54,6 +54,7 @@ export const useCanvasBuffer = () => {
         ...sourceInfo,
       },
       addedToBuffer: currentTimestamp,
+      createdAt: currentTimestamp,
     }
   }
 
@@ -602,7 +603,9 @@ export const useCanvasBuffer = () => {
 
   return {
     // Estado
-    bufferItems: computed(() => bufferItems.value),
+    bufferItems: computed(() =>
+      [...bufferItems.value].sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))
+    ),
     hasItems,
     itemCount,
 

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -1391,7 +1391,10 @@ export const useCanvasStore = defineStore('canvas', () => {
     if (contextoNavegacion.value.tipo === 'plantas') {
       const plantaId = contextoNavegacion.value.id
       const elementosEnEstaPlanta = elementosLimpios.filter((el) => el.plantaId === plantaId)
-      return elementosEnEstaPlanta.filter((el) => !el.padre && el.tipo === 'elementos')
+      return elementosEnEstaPlanta
+        .filter((el) => !el.padre && el.tipo === 'elementos')
+        .slice()
+        .reverse()
     }
 
     // Si estamos dentro de un elemento, mostrar solo contenedores hijos
@@ -1401,6 +1404,8 @@ export const useCanvasStore = defineStore('canvas', () => {
         return elementoPadre.hijos
           .map((hijoId) => elementosLimpios.find((el) => el.id === hijoId))
           .filter((hijo) => hijo && hijo.tipo === 'contenedores')
+          .slice()
+          .reverse()
       }
     }
 
@@ -1411,6 +1416,8 @@ export const useCanvasStore = defineStore('canvas', () => {
         return contenedorPadre.hijos
           .map((hijoId) => elementosLimpios.find((el) => el.id === hijoId))
           .filter((hijo) => hijo && (hijo.tipo === 'elementos' || hijo.tipo === 'contenedores'))
+          .slice()
+          .reverse()
       }
     }
 


### PR DESCRIPTION
## Resumen
- Ordena los elementos del portapapeles por fecha de creación para mostrar el más reciente primero.
- Ajusta la lista de capas para reflejar el orden Z real, invirtiendo la proyección de elementos visibles.

## Testing
- `npm run lint`
- `npm run test:unit` *(fallan varias pruebas, ej. falta de Pinia activa y validaciones de peso)*

------
https://chatgpt.com/codex/tasks/task_e_68b77a2d9bc88321bbc15a23dbb42563