### PR TITLE
Sort clipboard and layer lists descending

### DIFF
--- a/src/components/tabs/CapasTab.vue
+++ b/src/components/tabs/CapasTab.vue
@@ -262,7 +262,9 @@ const categorias = computed(() => CATEGORIAS)
 const elementosFiltrados = computed(() => {
   // --- CAMBIO CLAVE AQUÍ ---
   // Usamos la nueva computed property segura del store
-  let elementos = canvasStore.elementosVisiblesParaCapas
+  let elementos = [...canvasStore.elementosVisiblesParaCapas].sort(
+    (a, b) => (b.zIndex ?? 0) - (a.zIndex ?? 0)
+  )
 
   if (filtroNombre.value) {
     elementos = elementos.filter((elemento) => elemento.nombre.toLowerCase().includes(filtroNombre.value.toLowerCase()));

--- a/src/composables/useCanvasBuffer.js
+++ b/src/composables/useCanvasBuffer.js
@@ -602,7 +602,9 @@ export const useCanvasBuffer = () => {
 
   return {
     // Estado
-    bufferItems: computed(() => bufferItems.value),
+    bufferItems: computed(() =>
+      [...bufferItems.value].sort((a, b) => b.addedToBuffer - a.addedToBuffer)
+    ),
     hasItems,
     itemCount,
 

--- a/src/composables/useCanvasBuffer.js
+++ b/src/composables/useCanvasBuffer.js
@@ -571,7 +571,8 @@ export const useCanvasBuffer = () => {
    * Obtener todos los elementos del buffer
    */
   const getBufferItems = () => {
-    return bufferItems.value
+    // Retornar siempre los elementos más recientes primero
+    return [...bufferItems.value].sort((a, b) => b.addedToBuffer - a.addedToBuffer)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Show newest clipboard entries first
- Sort layers panel by element z-index in descending order

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: getActivePinia was called but there was no active Pinia, and multiple test assertions failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b77a2d9bc88321bbc15a23dbb42563