### PR TITLE
feat: focus and select elements from layers

### DIFF
--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -816,6 +816,13 @@ const { deleteSelected } = useDeleteElement()
 const confirmDialog = useConfirmDialog()
 const weightValidation = useWeightValidation()
 
+onMounted(() => {
+  const stageNode = stageRef.value?.getNode?.()
+  const layerNode = layerRef.value?.getNode?.()
+  if (stageNode) canvasStore.setStageRef(stageNode)
+  if (layerNode) canvasStore.setLayerRef(layerNode)
+})
+
 // Object snapping
 const {
   activeGuides: snapGuides,

--- a/src/components/tabs/CapasTab.vue
+++ b/src/components/tabs/CapasTab.vue
@@ -148,7 +148,7 @@
           <!-- Controles -->
           <div class="flex items-center gap-2">
             <button
-              @click.stop="canvasStore.destacarElemento(elemento.id)"
+              @click.stop="focusElemento(elemento.id)"
               class="p-0 text-gray-400 hover:text-blue-600 cursor-pointer"
               title="Encontrar en el canvas"
             >
@@ -237,6 +237,7 @@ import TagFilter from '@/components/TagFilter.vue'
 import CreateTagModal from '@/components/CreateTagModal.vue'
 import {useDeleteElement} from '@/composables/useDeleteElement'
 import { useConfirmDialog } from '@/composables/useConfirmDialog'
+import { focusAndSelectById } from '@/utils/focusAndSelectById'
 
 // Composables
 const canvasStore = useCanvasStore()
@@ -312,6 +313,10 @@ const limpiarFiltros = () => {
   filtroUbicacion.value = ''
   filtroNombre.value = '';
   canvasStore.limpiarSeleccion()
+}
+
+const focusElemento = (id) => {
+  focusAndSelectById({ stage: canvasStore.stage, layer: canvasStore.layer, id })
 }
 
 const onDelete = async (id) => {

--- a/src/composables/useCanvasStore.js
+++ b/src/composables/useCanvasStore.js
@@ -84,6 +84,10 @@ export const useCanvasStore = defineStore('canvas', () => {
 
   const elementoSeleccionado = ref(null)
   const mostrarPropiedades = ref(false);
+  const selectedIds = ref([])
+  const activeTool = ref('select')
+  const stage = ref(null)
+  const layer = ref(null)
   const vistaActiva = computed(() => {
     // Vista automática según el contexto
     if (estaEnPlanta.value) {
@@ -119,6 +123,14 @@ export const useCanvasStore = defineStore('canvas', () => {
     const e = Number(epsPx)
     if (!Number.isFinite(e)) return
     snapGridEps.value = Math.max(0, Math.min(50, e))
+  }
+
+  const setStageRef = (node) => {
+    stage.value = node
+  }
+
+  const setLayerRef = (node) => {
+    layer.value = node
   }
 
   // === NAVEGACIÓN JERÁRQUICA ===
@@ -610,6 +622,7 @@ export const useCanvasStore = defineStore('canvas', () => {
   // Actions
   const seleccionarElemento = (id) => {
     elementoSeleccionado.value = id
+    selectedIds.value = id ? [id] : []
   }
 
   const actualizarPosicion = (id, x, y, saveHistory = false, description = null) => {
@@ -1549,6 +1562,10 @@ export const useCanvasStore = defineStore('canvas', () => {
     plantas,
     plantaActiva,
     elementoSeleccionado,
+    selectedIds,
+    activeTool,
+    stage,
+    layer,
     vistaActiva,
     zoom,
     panX,
@@ -1594,6 +1611,8 @@ export const useCanvasStore = defineStore('canvas', () => {
     configurarPan,
     setGridSize,
     setSnapGridEps,
+    setStageRef,
+    setLayerRef,
 
     // Actions - Plantas
     seleccionarPlanta,

--- a/src/utils/focusAndSelectById.js
+++ b/src/utils/focusAndSelectById.js
@@ -1,0 +1,94 @@
+import Konva from 'konva'
+import { useCanvasStore } from '@/composables/useCanvasStore'
+import { useToast } from '@/composables/useToast'
+
+/**
+ * Focus an element by id in the canvas and attach a transformer
+ * @param {Object} params
+ * @param {Konva.Stage} params.stage - Stage instance
+ * @param {Konva.Layer} params.layer - Layer instance
+ * @param {string} params.id - Element id
+ * @param {number} [params.paddingPx=24] - Padding around element when focusing
+ * @param {number} [params.duration=280] - Tween duration in ms
+ * @param {boolean} [params.openProperties=true] - Whether to open properties panel
+ */
+export function focusAndSelectById({
+  stage,
+  layer,
+  id,
+  paddingPx = 24,
+  duration = 280,
+  openProperties = true,
+}) {
+  const { showError } = useToast()
+  const canvasStore = useCanvasStore()
+
+  if (!stage || !layer || !id) {
+    showError('No se pudo enfocar el elemento')
+    return
+  }
+
+  // Try to find the node either with prefix node- or plain id
+  const node =
+    stage.findOne(`#node-${id}`) || stage.findOne(`#${id}`) || layer.findOne(`#node-${id}`) || layer.findOne(`#${id}`)
+
+  const elemento = canvasStore.elementoPorId?.(id)
+
+  // Validate existence and state
+  if (
+    !node ||
+    !elemento ||
+    elemento.visible === false ||
+    elemento.bloqueado === true ||
+    elemento.locked === true
+  ) {
+    showError('Elemento no encontrado, oculto o bloqueado')
+    return
+  }
+
+  const box = node.getClientRect({ skipTransform: false })
+  const stageWidth = stage.width()
+  const stageHeight = stage.height()
+
+  const scale = Math.min(
+    (stageWidth - paddingPx * 2) / box.width,
+    (stageHeight - paddingPx * 2) / box.height,
+  )
+
+  const targetX = -box.x * scale + (stageWidth - box.width * scale) / 2
+  const targetY = -box.y * scale + (stageHeight - box.height * scale) / 2
+
+  // Tween stage to new position and scale
+  new Konva.Tween({
+    node: stage,
+    duration: duration / 1000,
+    x: targetX,
+    y: targetY,
+    scaleX: scale,
+    scaleY: scale,
+    easing: Konva.Easings.EaseInOut,
+  }).play()
+
+  // Update selection state
+  canvasStore.seleccionarElemento(id)
+  if (Array.isArray(canvasStore.selectedIds)) {
+    canvasStore.selectedIds = [id]
+  }
+  if (typeof canvasStore.activeTool !== 'undefined') {
+    canvasStore.activeTool = 'select'
+  }
+
+  // Manage transformer
+  layer.find('Transformer').forEach((tr) => tr.destroy())
+  const tr = new Konva.Transformer()
+  layer.add(tr)
+  tr.nodes([node])
+  layer.draw()
+
+  if (openProperties && canvasStore.toggleMostrarPropiedades) {
+    canvasStore.toggleMostrarPropiedades(true)
+  }
+}
+
+export default focusAndSelectById
+


### PR DESCRIPTION
## Summary
- add focusAndSelectById utility to center and select canvas nodes
- expose stage and layer references in canvas store
- integrate focus feature into Layers panel magnifying glass button

## Testing
- `npm run lint --silent`
- `npm run test:unit --silent -- --run` *(fails: Test Files 2 failed | Tests 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b77b5ca68083219bb38c77938f2bb4