### PR TITLE
Detalle de elementos en vista frontal

### DIFF
--- a/src/components/CanvasView.vue
+++ b/src/components/CanvasView.vue
@@ -648,8 +648,8 @@
       >
         {{ canvasStore.estaEnElemento ? 'Elemento' : 'Contenedor' }}:
         {{ canvasStore.elementoContenedorActual.nombre }}
-        <template v-if="canvasStore.vistaActiva === 'XZ' && canvasStore.elementoContenedorActual.dimensiones">
-          ({{ canvasStore.elementoContenedorActual.dimensiones.ancho }}×{{ canvasStore.elementoContenedorActual.dimensiones.alto }}cm - Vista de frente)
+        <template v-if="canvasStore.elementoContenedorActual.dimensiones">
+          ({{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.ancho) }}×{{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.alto) }} - Vista de frente)
         </template>
         <template v-else>
           ({{ canvasStore.canvasAdaptativo.width }}×{{ canvasStore.canvasAdaptativo.height }}px)
@@ -738,6 +738,7 @@ import { dimsCmFor, clampInsideArea } from '@/utils/bounds'
 import { handleCanvasHotkeys } from '@/utils/canvasHotkeys'
 import { polygonInset } from '@/utils/polygonInset'
 import { GRID_SIZE, CM_TO_PX, DIMENSIONS, CATALOGO, OFFSETS } from '@/utils/constants'
+import { cmToPx, fmtCm } from '@/utils/units'
 import { computeDimsByAxisScale, toCanvasSizePx } from '@/utils/dimensionPolicy'
 import { getActiveBounds } from '@/utils/activeBounds'
 import SpeedDialContext from '@/components/SpeedDialContext.vue'
@@ -840,27 +841,23 @@ const getElementPixelDimensions = (elemento) => {
     return { width: elemento.width, height: elemento.height }
   }
 
-  // Priorizar dimensiones en cm y convertir según la vista
+  // Priorizar dimensiones en cm y convertir según el contexto
   if (elemento.dimensiones) {
     let widthCm, heightCm
 
-    if (canvasStore.vistaActiva === 'XY') {
-      // Vista superior (XY): width = ancho, height = largo
+    if (canvasStore.estaEnPlanta) {
+      // Vista superior en planta: width = ancho, height = largo
       widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
       heightCm = elemento.dimensiones.largo || (elemento.height ? elemento.height / CM_TO_PX : 6)
-    } else if (canvasStore.vistaActiva === 'XZ') {
-      // Vista frontal (XZ): width = ancho, height = alto
+    } else {
+      // Detalle de elemento/contenedor: vista de frente
       widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
       heightCm = elemento.dimensiones.alto || (elemento.height ? elemento.height / CM_TO_PX : 6)
-    } else {
-      // Fallback a vista XY
-      widthCm = elemento.dimensiones.ancho || (elemento.width ? elemento.width / CM_TO_PX : 10)
-      heightCm = elemento.dimensiones.largo || (elemento.height ? elemento.height / CM_TO_PX : 6)
     }
 
     return {
-      width: Math.round(widthCm * CM_TO_PX),
-      height: Math.round(heightCm * CM_TO_PX),
+      width: cmToPx(widthCm),
+      height: cmToPx(heightCm),
     }
   }
 

--- a/src/components/PlantasPanel.vue
+++ b/src/components/PlantasPanel.vue
@@ -265,7 +265,7 @@
                 />
               </div>
               <div>
-                <label for="alto" class="block mb-1 text-xs font-medium text-gray-600">Alto</label>
+                <label for="alto" class="block mb-1 text-xs font-medium text-gray-600">Altura</label>
                 <input
                   id="alto"
                   v-model.number="formularioPlanta.dimensiones.alto"

--- a/src/components/PropiedadesPanel.vue
+++ b/src/components/PropiedadesPanel.vue
@@ -86,7 +86,7 @@
               </div>
             </div>
             <div v-if="!esCircular">
-              <label class="text-sm text-gray-500">Alto</label>
+              <label class="text-sm text-gray-500">Altura</label>
               <div class="flex items-center">
                 <input type="number" min="0" v-model.number="edited.dimensiones.alto" @change="validarDimension('alto')"
                   class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"

--- a/src/components/WorkspaceEditor.vue
+++ b/src/components/WorkspaceEditor.vue
@@ -108,7 +108,7 @@
                   v-model.number="localRectLMeters" />
               </div>
               <div class="col-span-2">
-                <label class="mb-1 block text-xs text-slate-600">Alto (m)</label>
+                <label class="mb-1 block text-xs text-slate-600">Altura (m)</label>
                 <input type="number"
                   class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30"
                   :class="{'border-rose-500 ring-2 ring-rose-500/60': errors.dimensions}"

--- a/src/components/modals/ElementEditor.vue
+++ b/src/components/modals/ElementEditor.vue
@@ -128,7 +128,7 @@
                   />
                 </div>
                 <div class="mb-2">
-                  <label class="block text-sm font-medium text-gray-700">Alto</label>
+                <label class="block text-sm font-medium text-gray-700">Altura</label>
                   <input
                     v-model.number="localElemento.dimensiones.alto"
                     type="number"

--- a/src/utils/activeBounds.js
+++ b/src/utils/activeBounds.js
@@ -1,4 +1,4 @@
-import { CM_TO_PX } from '@/utils/constants'
+import { cmToPx } from '@/utils/units'
 
 // Map physical dimensions (cm) to width/height depending on active view
 // dims: {ancho, largo, alto}
@@ -23,10 +23,8 @@ export function getActiveBounds(canvasStore) {
   if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
     const elem = canvasStore.elementoContenedorActual || {}
     const dims = elem.dimensiones || {}
-    let { widthCm, heightCm } = mapDimsByView(dims, canvasStore.vistaActiva)
-
-    let widthPx = widthCm * CM_TO_PX
-    let heightPx = heightCm * CM_TO_PX
+    let widthPx = cmToPx(dims.ancho || 0)
+    let heightPx = cmToPx(dims.alto || 0)
 
     // Fallback to legacy pixel dimensions if cm dims missing
     if (!widthPx || !heightPx) {
@@ -57,8 +55,8 @@ export function getActiveBounds(canvasStore) {
 
   const ancho = planta.dimensiones?.ancho || 0
   const largo = planta.dimensiones?.largo || 0
-  const width = ancho * CM_TO_PX
-  const height = largo * CM_TO_PX
+  const width = cmToPx(ancho)
+  const height = cmToPx(largo)
   const polygonPx = [
     { x: 0, y: 0 },
     { x: width, y: 0 },

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,0 +1,5 @@
+import { CM_TO_PX } from '@/utils/constants'
+
+export const cmToPx = (cm = 0) => Math.round(cm * CM_TO_PX)
+
+export const fmtCm = (cm = 0) => `${cm} cm`


### PR DESCRIPTION
## Summary
- Vista de detalle mapea dimensiones usando ancho×altura en cm
- Se agregan utilidades cmToPx y fmtCm para conversiones y etiquetas
- Etiquetas y formularios actualizados a "Altura"

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: [🍍] "getActivePinia()" was called but there was no active Pinia...)*

------
https://chatgpt.com/codex/tasks/task_e_68b78a5f81fc8321b0513b5ebd093971