### PR TITLE
Force front view in element detail

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -647,8 +647,12 @@
       >
         {{ canvasStore.estaEnElemento ? 'Elemento' : 'Contenedor' }}:
         {{ canvasStore.elementoContenedorActual.nombre }}
-        <template v-if="canvasStore.vistaActiva === 'XZ' && canvasStore.elementoContenedorActual.dimensiones">
-          ({{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.ancho) }}×{{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.alto) }} - Vista de frente)
+        <template
+          v-if="canvasStore.vistaActiva === 'XZ' && canvasStore.elementoContenedorActual.dimensiones"
+        >
+          ({{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.ancho) }} ancho ×
+          {{ fmtCm(canvasStore.elementoContenedorActual.dimensiones.alto) }} altura - Vista de
+          frente)
         </template>
         <template v-else>
           ({{ fmtCm(pxToCm(canvasStore.canvasAdaptativo.width, viewport.cmPerPx)) }}×{{ fmtCm(pxToCm(canvasStore.canvasAdaptativo.height, viewport.cmPerPx)) }})

--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -84,7 +84,11 @@ export const useCanvasStore = defineStore('canvas', () => {
   const etiquetasSeleccionadas = ref([])
 
   const elementoSeleccionado = ref(null)
+  // Permite forzar un modo de vista específico. 'auto' utiliza la lógica
+  // basada en el contexto (planta/elemento/contenedor).
+  const viewMode = ref('auto') // 'auto' | 'XY' | 'XZ'
   const vistaActiva = computed(() => {
+    if (viewMode.value !== 'auto') return viewMode.value
     // Vista automática según el contexto
     if (estaEnPlanta.value) {
       return 'XY' // Vista superior para plantas
@@ -119,6 +123,12 @@ export const useCanvasStore = defineStore('canvas', () => {
     const e = Number(epsPx)
     if (!Number.isFinite(e)) return
     snapGridEps.value = Math.max(0, Math.min(50, e))
+  }
+
+  const setViewMode = (mode) => {
+    if (['auto', 'XY', 'XZ'].includes(mode)) {
+      viewMode.value = mode
+    }
   }
 
   // === NAVEGACIÓN JERÁRQUICA ===
@@ -448,6 +458,13 @@ export const useCanvasStore = defineStore('canvas', () => {
       path: path,
     }
 
+    // Forzar vista de frente cuando se navega a elementos/contenedores
+    if (tipo === 'plantas') {
+      setViewMode('XY')
+    } else {
+      setViewMode('XZ')
+    }
+
     // Actualizar canvas adaptativo según el nuevo contexto
     if (tipo === 'plantas') {
       const planta = plantaPorId.value(id)
@@ -491,6 +508,9 @@ export const useCanvasStore = defineStore('canvas', () => {
         },
       ],
     }
+
+    // Vista aérea para plantas
+    setViewMode('XY')
 
     // Actualizar planta activa
     plantaActiva.value = plantaId
@@ -1387,6 +1407,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     plantaActiva,
     elementoSeleccionado,
     vistaActiva,
+    viewMode,
     zoom,
     panX,
     panY,
@@ -1430,6 +1451,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     configurarPan,
     setGridSize,
     setSnapGridEps,
+    setViewMode,
 
     // Actions - Plantas
     seleccionarPlanta,

--- a/src/inventory-smart/utils/activeBounds.js
+++ b/src/inventory-smart/utils/activeBounds.js
@@ -1,4 +1,5 @@
 import { CM_TO_PX } from '@/inventory-smart/utils/constants'
+import { cmToPx } from '@/inventory-smart/utils/units'
 
 // Map physical dimensions (cm) to width/height depending on active view
 // dims: {ancho, largo, alto}
@@ -25,8 +26,9 @@ export function getActiveBounds(canvasStore) {
     const dims = elem.dimensiones || {}
     let { widthCm, heightCm } = mapDimsByView(dims, canvasStore.vistaActiva)
 
-    let widthPx = widthCm * CM_TO_PX
-    let heightPx = heightCm * CM_TO_PX
+    // Convertir dimensiones a píxeles usando la relación cm→px
+    let widthPx = cmToPx(widthCm, 1 / CM_TO_PX)
+    let heightPx = cmToPx(heightCm, 1 / CM_TO_PX)
 
     // Fallback to legacy pixel dimensions if cm dims missing
     if (!widthPx || !heightPx) {
@@ -57,8 +59,8 @@ export function getActiveBounds(canvasStore) {
 
   const ancho = planta.dimensiones?.ancho || 0
   const largo = planta.dimensiones?.largo || 0
-  const width = ancho * CM_TO_PX
-  const height = largo * CM_TO_PX
+  const width = cmToPx(ancho, 1 / CM_TO_PX)
+  const height = cmToPx(largo, 1 / CM_TO_PX)
   const polygonPx = [
     { x: 0, y: 0 },
     { x: width, y: 0 },


### PR DESCRIPTION
## Summary
- allow forcing view mode in canvas store
- use front-view dimensions and cmToPx conversion for active bounds
- show ancho x altura labels in canvas info

## Testing
- `npm run lint --silent`
- `npm run test:unit --silent` *(fails: Cannot find module '/workspace/canvas-editor/src/__tests__/test-setup.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b8b6768e648321a0b1293ad6a01638