### PR TITLE
Show front-view dimensions in element detail

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -563,6 +563,49 @@
             listening: false,
           }"
         />
+
+        <!-- Reglas y etiquetas de dimensiones en detalle -->
+        <template v-if="canvasStore.estaEnElemento || canvasStore.estaEnContenedor">
+          <!-- Regla horizontal (ancho) -->
+          <v-line
+            :config="{
+              points: [0, floorBoundary.height + 8 / canvasStore.zoom, floorBoundary.width, floorBoundary.height + 8 / canvasStore.zoom],
+              stroke: '#94a3b8',
+              dash: [4, 4],
+              listening: false,
+            }"
+          />
+          <v-text
+            :config="{
+              x: floorBoundary.width / 2,
+              y: floorBoundary.height + 12 / canvasStore.zoom,
+              text: dimensionLabels.width,
+              fontSize: 12 / canvasStore.zoom,
+              align: 'center',
+              listening: false,
+            }"
+          />
+          <!-- Regla vertical (altura) -->
+          <v-line
+            :config="{
+              points: [floorBoundary.width + 8 / canvasStore.zoom, 0, floorBoundary.width + 8 / canvasStore.zoom, floorBoundary.height],
+              stroke: '#94a3b8',
+              dash: [4, 4],
+              listening: false,
+            }"
+          />
+          <v-text
+            :config="{
+              x: floorBoundary.width + 12 / canvasStore.zoom,
+              y: floorBoundary.height / 2,
+              text: `altura ${dimensionLabels.height}`,
+              fontSize: 12 / canvasStore.zoom,
+              rotation: 90,
+              align: 'center',
+              listening: false,
+            }"
+          />
+        </template>
       </v-layer>
       <v-layer ref="overlaysLayerRef">
         <!-- Líneas guía de object snapping -->
@@ -1097,7 +1140,7 @@ const stageConfig = computed(() => {
   }
 })
 
-const activeBounds = computed(() => getActiveBounds(canvasStore))
+const activeBounds = computed(() => getActiveBounds(canvasStore, viewport.cmPerPx))
 
 const plantPolygon = computed(() => activeBounds.value.polygonPx)
 
@@ -1106,6 +1149,7 @@ const insetPoly = computed(() => polygonInset(plantPolygon.value, 1))
 const plantPolygonFlat = computed(() => plantPolygon.value.flatMap((p) => [p.x, p.y]))
 
 const floorBoundary = computed(() => activeBounds.value.boundsPx)
+const dimensionLabels = computed(() => activeBounds.value.labels || { width: '', height: '' })
 
 // Configuración del layer - SIEMPRE USA CANVAS ADAPTATIVO
 const layerConfig = computed(() => {

--- a/src/inventory-smart/utils/activeBounds.js
+++ b/src/inventory-smart/utils/activeBounds.js
@@ -1,4 +1,5 @@
 import { CM_TO_PX } from '@/inventory-smart/utils/constants'
+import { cmToPx, fmtCm } from '@/inventory-smart/utils/units'
 
 // Map physical dimensions (cm) to width/height depending on active view
 // dims: {ancho, largo, alto}
@@ -18,15 +19,17 @@ export function mapDimsByView(dims = {}, view = 'XY') {
 
 // Determine active working bounds (rectangle) and polygon in pixels
 // depending on navigation context. Returns { boundsPx:{width,height}, polygonPx }
-export function getActiveBounds(canvasStore) {
+export function getActiveBounds(canvasStore, cmPerPx = 1 / CM_TO_PX) {
   // Inside element/container: use its dimensions
   if (canvasStore.estaEnElemento || canvasStore.estaEnContenedor) {
     const elem = canvasStore.elementoContenedorActual || {}
     const dims = elem.dimensiones || {}
-    let { widthCm, heightCm } = mapDimsByView(dims, canvasStore.vistaActiva)
+    // Siempre utilizar vista de frente para detalle de elemento
+    let { widthCm, heightCm } = mapDimsByView(dims, 'XZ')
 
-    let widthPx = widthCm * CM_TO_PX
-    let heightPx = heightCm * CM_TO_PX
+    // Convertir dimensiones a píxeles usando el helper
+    let widthPx = cmToPx(widthCm, cmPerPx)
+    let heightPx = cmToPx(heightCm, cmPerPx)
 
     // Fallback to legacy pixel dimensions if cm dims missing
     if (!widthPx || !heightPx) {
@@ -41,7 +44,11 @@ export function getActiveBounds(canvasStore) {
       { x: 0, y: heightPx },
     ]
 
-    return { boundsPx: { width: widthPx, height: heightPx }, polygonPx }
+    return {
+      boundsPx: { width: widthPx, height: heightPx },
+      polygonPx,
+      labels: { width: fmtCm(widthCm), height: fmtCm(heightCm) },
+    }
   }
 
   // Root level: active plant polygon or rectangle from dimensions
@@ -57,14 +64,18 @@ export function getActiveBounds(canvasStore) {
 
   const ancho = planta.dimensiones?.ancho || 0
   const largo = planta.dimensiones?.largo || 0
-  const width = ancho * CM_TO_PX
-  const height = largo * CM_TO_PX
+  const width = cmToPx(ancho, cmPerPx)
+  const height = cmToPx(largo, cmPerPx)
   const polygonPx = [
     { x: 0, y: 0 },
     { x: width, y: 0 },
     { x: width, y: height },
     { x: 0, y: height },
   ]
-  return { boundsPx: { width, height }, polygonPx }
+  return {
+    boundsPx: { width, height },
+    polygonPx,
+    labels: { width: fmtCm(ancho), height: fmtCm(largo) },
+  }
 }
 


### PR DESCRIPTION
## Summary
- force element detail bounds to use front-view width/height and convert via cmToPx
- display width/height labels and add vertical height ruler in element detail view

## Testing
- `npm run test:unit` *(fails: Cannot find module '/workspace/canvas-editor/src/__tests__/test-setup.js')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8b6768e648321a0b1293ad6a01638