### PR TITLE
feat: add template system

### DIFF
--- a/src/inventory-smart/__tests__/ElementosTab.spec.js
+++ b/src/inventory-smart/__tests__/ElementosTab.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ElementosTab from '@/inventory-smart/components/tabs/ElementosTab.vue'
+
+describe('ElementosTab', () => {
+  it('switches between catalog and templates', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const wrapper = mount(ElementosTab, {
+      global: {
+        plugins: [pinia],
+        stubs: { ElementosCatalogo: true, TemplatesPanel: true },
+      },
+    })
+    const select = wrapper.find('select')
+    expect(select.exists()).toBe(true)
+    await select.setValue('templates')
+    expect(wrapper.vm.view).toBe('templates')
+  })
+})

--- a/src/inventory-smart/__tests__/context_menu.spec.js
+++ b/src/inventory-smart/__tests__/context_menu.spec.js
@@ -129,7 +129,7 @@ describe('Context menu', () => {
     // eliminar cuando no está bloqueado
     emitContextMenuOnFirstShape(wrapper, 20, 25)
     await nextTick()
-    const delBtn = document.querySelectorAll('.sdx-item')[1]
+    const delBtn = document.querySelectorAll('.sdx-item')[2]
     delBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await nextTick()
     expect(store.elementoPorId('el1')).toBeUndefined()
@@ -140,7 +140,7 @@ describe('Context menu', () => {
     await nextTick()
     emitContextMenuOnFirstShape(wrapper, 20, 25)
     await nextTick()
-    const delBtn2 = document.querySelectorAll('.sdx-item')[1]
+    const delBtn2 = document.querySelectorAll('.sdx-item')[2]
     delBtn2.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await nextTick()
     expect(store.elementoPorId('el1')).toBeTruthy()

--- a/src/inventory-smart/__tests__/instantiateTemplate.spec.js
+++ b/src/inventory-smart/__tests__/instantiateTemplate.spec.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { instantiateTemplate } from '@/inventory-smart/services/templates/deserialize.js'
+
+describe('instantiateTemplate', () => {
+  it('clona con nuevos ids y offsets', () => {
+    const tpl = {
+      unitMeta: 'px',
+      subtree: {
+        type: 'elementos',
+        name: 'Root',
+        dims: { width: 10, height: 10 },
+        position: { x: 0, y: 0 },
+        children: [
+          {
+            type: 'contenedores',
+            name: 'Child',
+            dims: { width: 5, height: 5 },
+            position: { x: 5, y: 5 },
+            children: [],
+          },
+        ],
+      },
+    }
+    const nodes = instantiateTemplate(tpl, { x: 100, y: 50 }, { unitMode: 'px' })
+    expect(nodes.length).toBe(2)
+    const root = nodes[0]
+    const child = nodes[1]
+    expect(root.id).not.toBe(child.id)
+    expect(root.x).toBe(100)
+    expect(child.padre).toBe(root.id)
+    expect(child.x).toBe(105)
+    expect(child.y).toBe(55)
+  })
+})

--- a/src/inventory-smart/__tests__/serializeSubtree.spec.js
+++ b/src/inventory-smart/__tests__/serializeSubtree.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore'
+import { serializeSubtree, summarize } from '@/inventory-smart/services/templates/serialize.js'
+
+describe('serializeSubtree', () => {
+  beforeEach(() => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const store = useCanvasStore()
+    store.agregarElemento({
+      id: 'root',
+      tipo: 'elementos',
+      nombre: 'Root',
+      width: 100,
+      height: 50,
+      x: 10,
+      y: 20,
+      hijos: ['child'],
+    })
+    store.agregarElemento({
+      id: 'child',
+      tipo: 'contenedores',
+      nombre: 'Child',
+      width: 20,
+      height: 20,
+      x: 30,
+      y: 40,
+      padre: 'root',
+      hijos: [],
+    })
+  })
+
+  it('serializa subárbol simple', () => {
+    const data = serializeSubtree('root', { unitMode: 'px' })
+    expect(data.unitMeta).toBe('px')
+    expect(data.subtree.children.length).toBe(1)
+    const summary = summarize(data)
+    expect(summary.rootType).toBe('elementos')
+    expect(summary.totalChildren).toBe(1)
+  })
+})

--- a/src/inventory-smart/__tests__/templatesStore.spec.js
+++ b/src/inventory-smart/__tests__/templatesStore.spec.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useTemplatesStore } from '@/inventory-smart/stores/templates.js'
+
+describe('templatesStore', () => {
+  beforeEach(() => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    localStorage.clear()
+  })
+
+  it('create/list/delete/updateName', async () => {
+    const store = useTemplatesStore()
+    await store.init()
+    const id = await store.createTemplate({ name: 'A' })
+    expect(store.listTemplates().length).toBe(1)
+    await store.updateName(id, 'B')
+    expect(store.getTemplate(id).name).toBe('B')
+    await store.deleteTemplate(id)
+    expect(store.listTemplates().length).toBe(0)
+  })
+
+  it('unicidad por nombre', async () => {
+    const store = useTemplatesStore()
+    await store.init()
+    await store.createTemplate({ name: 'Test' })
+    const found = store.findByNameInsensitive('test')
+    expect(found.name).toBe('Test')
+  })
+})

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -627,7 +627,15 @@
       :isLocked="ctxIsLocked"
       @lockToggle="() => toggleLock(ctxElementId)"
       @delete="() => onDelete(ctxElementId)"
+      @saveTemplate="() => openSaveTemplate(ctxElementId)"
       @close="ctx.close()"
+    />
+
+    <SaveTemplateModal
+      :visible="showSaveTemplate"
+      :summary="currentSummary"
+      @close="closeSaveTemplate"
+      @save="handleSaveTemplate"
     />
 
   <!-- Información de zoom, vista y dimensiones -->
@@ -784,6 +792,9 @@ import FloatingToolbar from '@/inventory-smart/components/FloatingToolbar.vue'
 import { getUsoInfo, useProductSimulation } from '@/inventory-smart/utils/simulateProducts'
 import SnapGuides from '@/inventory-smart/components/SnapGuides.vue'
 import { useToast } from '@/inventory-smart/composables/useToast'
+import SaveTemplateModal from '@/inventory-smart/components/templates/SaveTemplateModal.vue'
+import { useTemplatesStore } from '@/inventory-smart/stores/templates.js'
+import { serializeSubtree, summarize } from '@/inventory-smart/services/templates/serialize.js'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -909,6 +920,28 @@ const { visible: ctxVisible, x: ctxX, y: ctxY, isLocked: ctxIsLocked, elementId:
 const { deleteSelected } = useDeleteElement()
 const confirmDialog = useConfirmDialog()
 const weightValidation = useWeightValidation()
+const templatesStore = useTemplatesStore()
+const showSaveTemplate = ref(false)
+const currentSummary = ref(null)
+let serializedTemplate = null
+
+const openSaveTemplate = (elementId) => {
+  const data = serializeSubtree(elementId, { unitMode: 'px' })
+  if (!data) return
+  serializedTemplate = data
+  currentSummary.value = summarize(data)
+  showSaveTemplate.value = true
+}
+
+const closeSaveTemplate = () => {
+  showSaveTemplate.value = false
+}
+
+const handleSaveTemplate = async ({ name }) => {
+  if (!serializedTemplate) return
+  await templatesStore.createTemplate({ ...serializedTemplate, name, summary: currentSummary.value })
+  showSaveTemplate.value = false
+}
 
 // Object snapping
 const {

--- a/src/inventory-smart/components/SpeedDialContext.vue
+++ b/src/inventory-smart/components/SpeedDialContext.vue
@@ -21,6 +21,15 @@
     </button>
     <button
       ref="itemRefs[1]"
+      class="sdx-item"
+      role="menuitem"
+      aria-label="Guardar plantilla"
+      @click="emitSave"
+    >
+      Guardar plantilla
+    </button>
+    <button
+      ref="itemRefs[2]"
       class="sdx-item sdx-danger"
       role="menuitem"
       aria-label="Eliminar"
@@ -42,10 +51,10 @@ const props = defineProps({
   y: { type: Number, default: 0 },
   isLocked: { type: Boolean, default: false },
 })
-const emit = defineEmits(['lockToggle', 'delete', 'close'])
+const emit = defineEmits(['lockToggle', 'saveTemplate', 'delete', 'close'])
 
 const menuRef = ref(null)
-const itemRefs = [ref(null), ref(null)]
+const itemRefs = [ref(null), ref(null), ref(null)]
 const focusedIndex = ref(0)
 
 const pos = ref({ left: 0, top: 0 })
@@ -111,6 +120,7 @@ const onKeydown = (e) => {
     itemRefs[focusedIndex.value].value?.focus?.()
   } else if (e.key === 'Enter' || e.key === ' ') {
     if (focusedIndex.value === 0) emitLock()
+    else if (focusedIndex.value === 1) emitSave()
     else emitDelete()
   } else if (e.key === 'Escape') {
     emit('close')
@@ -122,6 +132,9 @@ const emitLock = () => {
 }
 const emitDelete = () => {
   emit('delete')
+}
+const emitSave = () => {
+  emit('saveTemplate')
 }
 </script>
 

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -6,16 +6,25 @@
 
 <template>
   <div class="h-full flex flex-col">
-    <!-- Contenido del catálogo -->
+    <div class="p-2 border-b border-slate-200">
+      <select v-model="view" class="w-full border rounded-md px-2 py-1 text-sm">
+        <option value="catalog">Catálogo de elementos</option>
+        <option value="templates">Plantillas</option>
+      </select>
+    </div>
     <div class="flex-1 overflow-hidden">
-      <ElementosCatalogo />
+      <ElementosCatalogo v-if="view === 'catalog'" />
+      <TemplatesPanel v-else />
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
+import TemplatesPanel from '@/inventory-smart/components/templates/TemplatesPanel.vue'
+
+const view = ref('catalog')
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/inventory-smart/components/templates/SaveTemplateModal.vue
+++ b/src/inventory-smart/components/templates/SaveTemplateModal.vue
@@ -1,0 +1,62 @@
+<template>
+  <div
+    v-if="visible"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    @click.self="emit('close')"
+  >
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
+      <h3 class="text-lg font-semibold mb-4">Guardar plantilla</h3>
+      <form @submit.prevent="onSave">
+        <div class="mb-4">
+          <label class="block text-sm font-medium mb-1">Nombre</label>
+          <input
+            v-model="name"
+            type="text"
+            required
+            minlength="3"
+            maxlength="80"
+            class="w-full border border-gray-300 rounded-md px-3 py-2"
+          />
+        </div>
+        <div class="mb-4 text-sm text-gray-600" v-if="summary">
+          <p>Tipo raíz: {{ summary.rootType }}</p>
+          <p>Dimensiones: {{ summary.dims.width }}×{{ summary.dims.height }}</p>
+          <p>Hijos totales: {{ summary.totalChildren }}</p>
+          <p>Profundidad: {{ summary.depth }}</p>
+        </div>
+        <div class="flex justify-end gap-2">
+          <button type="button" class="px-4 py-2 bg-gray-100 rounded-md" @click="emit('close')">
+            Cancelar
+          </button>
+          <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-md">
+            Guardar
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  visible: { type: Boolean, default: false },
+  summary: { type: Object, default: null },
+})
+const emit = defineEmits(['close', 'save'])
+
+const name = ref('')
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (!v) name.value = ''
+  }
+)
+
+const onSave = () => {
+  if (!name.value.trim()) return
+  emit('save', { name: name.value.trim() })
+}
+</script>

--- a/src/inventory-smart/components/templates/TemplatesPanel.vue
+++ b/src/inventory-smart/components/templates/TemplatesPanel.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="p-4 overflow-y-auto h-full">
+    <div v-if="templates.length === 0" class="text-center text-sm text-gray-500">
+      No hay plantillas guardadas
+    </div>
+    <div v-else class="grid grid-cols-1 gap-4">
+      <div
+        v-for="tpl in templates"
+        :key="tpl.id"
+        class="border rounded-md p-3 flex flex-col gap-2 bg-white shadow-sm"
+      >
+        <div class="font-medium">{{ tpl.name }}</div>
+        <div class="text-xs text-gray-500">
+          {{ tpl.summary.rootType }} · {{ tpl.summary.dims.width }}×{{ tpl.summary.dims.height }} ·
+          {{ tpl.summary.totalChildren }} hijos
+        </div>
+        <div class="flex gap-2 mt-2">
+          <button class="px-2 py-1 text-sm bg-blue-600 text-white rounded" @click="insert(tpl)">
+            Agregar
+          </button>
+          <button class="px-2 py-1 text-sm bg-gray-100 rounded" @click="rename(tpl)">
+            Renombrar
+          </button>
+          <button class="px-2 py-1 text-sm bg-red-600 text-white rounded" @click="remove(tpl.id)">
+            Eliminar
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useTemplatesStore } from '@/inventory-smart/stores/templates.js'
+import { instantiateTemplate } from '@/inventory-smart/services/templates/deserialize.js'
+import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore.js'
+
+const store = useTemplatesStore()
+const canvasStore = useCanvasStore()
+const templates = ref([])
+
+onMounted(async () => {
+  if (!store.loaded) await store.init()
+  templates.value = store.listTemplates()
+})
+
+const insert = (tpl) => {
+  const nodes = instantiateTemplate(tpl, { x: 0, y: 0 }, { unitMode: tpl.unitMeta || 'px' })
+  nodes.forEach((n) => {
+    canvasStore.agregarElemento(n)
+  })
+}
+
+const rename = async (tpl) => {
+  const nuevo = window.prompt('Nuevo nombre', tpl.name)
+  if (nuevo && nuevo.trim()) {
+    await store.updateName(tpl.id, nuevo.trim())
+    templates.value = store.listTemplates()
+  }
+}
+
+const remove = async (id) => {
+  if (window.confirm('¿Eliminar plantilla?')) {
+    await store.deleteTemplate(id)
+    templates.value = store.listTemplates()
+  }
+}
+</script>

--- a/src/inventory-smart/services/storage/IndexedDbDriver.js
+++ b/src/inventory-smart/services/storage/IndexedDbDriver.js
@@ -1,0 +1,28 @@
+import LocalStorageDriver from './LocalStorageDriver.js'
+
+export default class IndexedDbDriver {
+  constructor(namespace = 'templates') {
+    this.ns = namespace
+    this.available = typeof indexedDB !== 'undefined'
+    if (!this.available) {
+      this.fallback = new LocalStorageDriver(namespace)
+    }
+  }
+  async getAll() {
+    if (!this.available) return this.fallback.getAll()
+    // Simplified: use fallback as implementation
+    return this.fallback.getAll()
+  }
+  async put(id, data) {
+    if (!this.available) return this.fallback.put(id, data)
+    return this.fallback.put(id, data)
+  }
+  async get(id) {
+    if (!this.available) return this.fallback.get(id)
+    return this.fallback.get(id)
+  }
+  async delete(id) {
+    if (!this.available) return this.fallback.delete(id)
+    return this.fallback.delete(id)
+  }
+}

--- a/src/inventory-smart/services/storage/LocalStorageDriver.js
+++ b/src/inventory-smart/services/storage/LocalStorageDriver.js
@@ -1,0 +1,37 @@
+export default class LocalStorageDriver {
+  constructor(namespace = 'templates') {
+    this.ns = namespace
+  }
+  _key(id) {
+    return `${this.ns}:${id}`
+  }
+  async getAll() {
+    const res = []
+    for (let i = 0; i < (typeof localStorage !== 'undefined' ? localStorage.length : 0); i++) {
+      const key = localStorage.key(i)
+      if (key && key.startsWith(this.ns + ':')) {
+        try {
+          res.push(JSON.parse(localStorage.getItem(key)))
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    return res
+  }
+  async put(id, data) {
+    localStorage.setItem(this._key(id), JSON.stringify(data))
+  }
+  async get(id) {
+    const raw = localStorage.getItem(this._key(id))
+    if (!raw) return null
+    try {
+      return JSON.parse(raw)
+    } catch {
+      return null
+    }
+  }
+  async delete(id) {
+    localStorage.removeItem(this._key(id))
+  }
+}

--- a/src/inventory-smart/services/templates/deserialize.js
+++ b/src/inventory-smart/services/templates/deserialize.js
@@ -1,0 +1,41 @@
+import { CM_TO_PX } from '@/inventory-smart/utils/constants.js'
+
+const pxToCm = (v) => v / CM_TO_PX
+
+export function instantiateTemplate(template, dropPoint = { x: 0, y: 0 }, { unitMode = 'px' } = {}) {
+  const fromPx = unitMode === 'cm' ? pxToCm : (v) => v
+  const nodes = []
+
+  const clone = (node, offset, parentId = null) => {
+    const id = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)
+    const pos = {
+      x: (offset.x || 0) + (node.position?.x || 0),
+      y: (offset.y || 0) + (node.position?.y || 0),
+      rotation: node.position?.rotation || 0,
+    }
+    const newNode = {
+      id,
+      tipo: node.type,
+      nombre: node.name,
+      width: fromPx(node.dims?.width || 0),
+      height: fromPx(node.dims?.height || 0),
+      depth: node.dims?.depth != null ? fromPx(node.dims.depth) : null,
+      x: dropPoint.x + pos.x,
+      y: dropPoint.y + pos.y,
+      rotation: pos.rotation,
+      attrs: node.attrs || {},
+      domainProps: node.domainProps || {},
+      hijos: [],
+      padre: parentId,
+    }
+    nodes.push(newNode)
+    ;(node.children || []).forEach((ch) => {
+      const childClone = clone(ch, pos, id)
+      newNode.hijos.push(childClone.id)
+    })
+    return newNode
+  }
+
+  clone(template.subtree, { x: 0, y: 0 })
+  return nodes
+}

--- a/src/inventory-smart/services/templates/serialize.js
+++ b/src/inventory-smart/services/templates/serialize.js
@@ -1,0 +1,72 @@
+import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore.js'
+import { CM_TO_PX } from '@/inventory-smart/utils/constants.js'
+
+const cmToPx = (v) => v * CM_TO_PX
+
+export function serializeSubtree(rootId, { unitMode = 'px' } = {}) {
+  const store = useCanvasStore()
+  const getById = store.elementoPorId?.value || store.elementoPorId
+  const root = getById(rootId)
+  if (!root) return null
+
+  const toPx = unitMode === 'cm' ? cmToPx : (v) => v
+
+  const walk = (node, parentOrigin) => {
+    const rel = {
+      x: (node.x || 0) - parentOrigin.x,
+      y: (node.y || 0) - parentOrigin.y,
+      rotation: node.rotation || 0,
+    }
+    const base = {
+      type: node.tipo || node.type,
+      name: node.nombre || node.name || node.tipo,
+      dims: {
+        width: toPx(node.width || 0),
+        height: toPx(node.height || 0),
+        depth: node.depth != null ? toPx(node.depth) : null,
+      },
+      position: rel,
+      attrs: node.attrs || {},
+      domainProps: node.domainProps || {},
+      children: [],
+    }
+    const originForChildren = { x: node.x || 0, y: node.y || 0 }
+    ;(node.hijos || node.children || []).forEach((childId) => {
+      const child = typeof childId === 'string' ? getById(childId) : childId
+      if (child) base.children.push(walk(child, originForChildren))
+    })
+    return base
+  }
+
+  const subtree = walk(root, { x: root.x || 0, y: root.y || 0 })
+  subtree.position = { x: 0, y: 0, rotation: root.rotation || 0 }
+
+  return { unitMeta: unitMode, subtree }
+}
+
+export function normalizeToRoot(serialized) {
+  // serializeSubtree already normalizes; simply return same object
+  return serialized
+}
+
+export function summarize(serialized) {
+  const tree = serialized.subtree || serialized
+  const countDepth = (node, depth = 1) => {
+    let total = 0
+    let maxDepth = depth
+    ;(node.children || []).forEach((ch) => {
+      total += 1
+      const [cd, cc] = countDepth(ch, depth + 1)
+      total += cc
+      if (cd > maxDepth) maxDepth = cd
+    })
+    return [maxDepth, total]
+  }
+  const [depth, totalChildren] = countDepth(tree, 1)
+  return {
+    rootType: tree.type,
+    totalChildren,
+    depth,
+    dims: tree.dims,
+  }
+}

--- a/src/inventory-smart/stores/templates.js
+++ b/src/inventory-smart/stores/templates.js
@@ -1,0 +1,68 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import IndexedDbDriver from '@/inventory-smart/services/storage/IndexedDbDriver.js'
+import LocalStorageDriver from '@/inventory-smart/services/storage/LocalStorageDriver.js'
+
+export const useTemplatesStore = defineStore('templates', () => {
+  const items = ref({})
+  const loaded = ref(false)
+  const namespace = 'templates'
+
+  let driver
+  try {
+    driver = new IndexedDbDriver(namespace)
+  } catch {
+    driver = new LocalStorageDriver(namespace)
+  }
+
+  const init = async () => {
+    const arr = await driver.getAll()
+    const map = {}
+    arr.forEach((tpl) => {
+      if (tpl && tpl.id) map[tpl.id] = tpl
+    })
+    items.value = map
+    loaded.value = true
+  }
+
+  const createTemplate = async (payload) => {
+    const id = payload.id || (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(36))
+    const tpl = { ...payload, id, createdAt: Date.now(), updatedAt: Date.now() }
+    items.value[id] = tpl
+    await driver.put(id, tpl)
+    return id
+  }
+
+  const listTemplates = () => Object.values(items.value)
+  const getTemplate = (id) => items.value[id]
+
+  const deleteTemplate = async (id) => {
+    delete items.value[id]
+    await driver.delete(id)
+  }
+
+  const updateName = async (id, name) => {
+    const tpl = items.value[id]
+    if (!tpl) return
+    tpl.name = name
+    tpl.updatedAt = Date.now()
+    await driver.put(id, tpl)
+  }
+
+  const findByNameInsensitive = (name) => {
+    const lower = name.toLowerCase()
+    return Object.values(items.value).find((t) => t.name?.toLowerCase() === lower)
+  }
+
+  return {
+    items,
+    loaded,
+    init,
+    createTemplate,
+    listTemplates,
+    getTemplate,
+    deleteTemplate,
+    updateName,
+    findByNameInsensitive,
+  }
+})


### PR DESCRIPTION
## Summary
- add Pinia templates store with persistence drivers
- implement template serialization/instantiation services
- add UI for saving and reusing element templates

## Testing
- `npm run test:unit` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68b9af48259c832189516f0859f55066