### PR TITLE
feat: add catalog switch for elements and templates

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -230,6 +230,59 @@ onUnmounted(() => {
   background: var(--ui-bg-dark);
   border: 1px solid var(--ui-border-dark);
 }
+
+/* ====== INVENTORY: Estilos para el conmutador de Catálogo (Elementos | Plantillas) ======
+   Contexto: pestaña Elementos — controla catálogo visible.
+   NOTA: no mover ni duplicar en otros archivos. Mantener aquí.
+======================================================================================== */
+.catalog-switch {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.catalog-tab {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--ui-border);
+  background: var(--ui-bg);
+  color: var(--muted);
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.catalog-tab + .catalog-tab {
+  margin-left: 0.5rem;
+}
+
+.catalog-tab:hover {
+  background: #f1f5f9;
+}
+
+.catalog-tab.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.catalog-tab.kb-focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.catalog-switch select {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--ui-border);
+  background: var(--ui-bg);
+  color: var(--muted);
+  border-radius: 9999px;
+  font-size: 0.875rem;
+}
+
+.catalog-switch--compact select {
+  width: 100%;
+}
 </style>
 
 <style scoped>

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -6,15 +6,148 @@
 
 <template>
   <div class="h-full flex flex-col">
+    <!-- Conmutador de catálogo -->
+    <div
+      class="catalog-switch"
+      :class="{ 'catalog-switch--compact': isCompact }"
+    >
+      <!-- Tabs para pantallas ≥480px -->
+      <div v-if="!isCompact" role="tablist" class="flex gap-2">
+        <button
+          id="catalog-tab-elementos"
+          role="tab"
+          :aria-selected="selectedCatalog === 'elementos'"
+          :tabindex="selectedCatalog === 'elementos' ? 0 : -1"
+          :class="['catalog-tab', { 'is-active': selectedCatalog === 'elementos' }]"
+          @click="selectCatalog('elementos')"
+          @keydown="onTabKeydown"
+          @focus="onFocus"
+          @blur="onBlur"
+        >
+          📦 Catálogo de Elementos
+        </button>
+        <button
+          id="catalog-tab-plantillas"
+          role="tab"
+          :aria-selected="selectedCatalog === 'plantillas'"
+          :tabindex="selectedCatalog === 'plantillas' ? 0 : -1"
+          :class="['catalog-tab', { 'is-active': selectedCatalog === 'plantillas' }]"
+          @click="selectCatalog('plantillas')"
+          @keydown="onTabKeydown"
+          @focus="onFocus"
+          @blur="onBlur"
+        >
+          📝 Catálogo de Plantillas
+        </button>
+      </div>
+      <!-- Dropdown para pantallas <480px -->
+      <select
+        v-else
+        v-model="selectedCatalog"
+        aria-label="Catálogo"
+      >
+        <option value="elementos">Catálogo de Elementos</option>
+        <option value="plantillas">Catálogo de Plantillas</option>
+      </select>
+    </div>
+
     <!-- Contenido del catálogo -->
     <div class="flex-1 overflow-hidden">
-      <ElementosCatalogo />
+      <ElementosCatalogo v-if="selectedCatalog === 'elementos'" />
+      <div
+        v-else
+        class="h-full flex items-center justify-center text-sm text-gray-500"
+      >
+        No hay plantillas aún
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref, watch, onMounted, onUnmounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const selectedCatalog = ref('elementos')
+
+// Inicializar desde query param
+const initial = route.query.catalog
+if (initial === 'plantillas' || initial === 'elementos') {
+  selectedCatalog.value = initial
+}
+
+// Persistir en la URL
+watch(
+  selectedCatalog,
+  (val) => {
+    router.replace({ query: { ...route.query, catalog: val } })
+  },
+  { immediate: true }
+)
+
+const selectCatalog = (val) => {
+  selectedCatalog.value = val
+}
+
+const tabs = ['elementos', 'plantillas']
+
+const onTabKeydown = (e) => {
+  const idx = tabs.indexOf(selectedCatalog.value)
+  if (e.key === 'ArrowRight') {
+    e.preventDefault()
+    const next = tabs[(idx + 1) % tabs.length]
+    selectedCatalog.value = next
+    focusTab(next)
+  } else if (e.key === 'ArrowLeft') {
+    e.preventDefault()
+    const prev = tabs[(idx - 1 + tabs.length) % tabs.length]
+    selectedCatalog.value = prev
+    focusTab(prev)
+  } else if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    selectCatalog(selectedCatalog.value)
+  }
+}
+
+const focusTab = (val) => {
+  const el = document.getElementById(`catalog-tab-${val}`)
+  el?.focus()
+}
+
+const onFocus = (e) => e.target.classList.add('kb-focus')
+const onBlur = (e) => e.target.classList.remove('kb-focus')
+
+// Responsive: detectar si pantalla es compacta
+const isCompact = ref(false)
+let mediaQuery
+
+const updateCompact = (e) => {
+  isCompact.value = e.matches
+}
+
+onMounted(() => {
+  mediaQuery = window.matchMedia('(max-width: 479px)')
+  updateCompact(mediaQuery)
+  if (mediaQuery.addEventListener) {
+    mediaQuery.addEventListener('change', updateCompact)
+  } else {
+    mediaQuery.addListener(updateCompact)
+  }
+})
+
+onUnmounted(() => {
+  if (mediaQuery) {
+    if (mediaQuery.removeEventListener) {
+      mediaQuery.removeEventListener('change', updateCompact)
+    } else {
+      mediaQuery.removeListener(updateCompact)
+    }
+  }
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add responsive catalog switch with tabs and mobile select fallback
- persist selection in ?catalog query param and support keyboard navigation
- style catalog switch within InventorySmart.vue

## Testing
- `npm run lint` (fails: Cannot find package 'eslint')
- `npm run test:unit` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b9b8485cc88321b321576d4280dac8