### PR TITLE
feat: add catalog switch tabs

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -230,6 +230,62 @@ onUnmounted(() => {
   background: var(--ui-bg-dark);
   border: 1px solid var(--ui-border-dark);
 }
+
+/* ====== INVENTORY: Estilos para el conmutador de Catálogo (Elementos | Plantillas) ======
+   Contexto: pestaña Elementos — controla catálogo visible.
+   NOTA: no mover ni duplicar en otros archivos. Mantener aquí.
+======================================================================================== */
+.catalog-switch {
+  display: flex;
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+}
+
+.catalog-switch--compact {
+  display: none;
+}
+
+.catalog-tab {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--ui-border);
+  border-radius: 9999px;
+  background: var(--ui-bg);
+  color: #334155;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.catalog-tab:hover {
+  background: #f1f5f9;
+}
+
+.catalog-tab.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.catalog-tab.kb-focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+@media (max-width: 479px) {
+  .catalog-switch {
+    display: none;
+  }
+
+  .catalog-switch.catalog-switch--compact {
+    display: block;
+  }
+
+  .catalog-switch--compact select {
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+  }
+}
 </style>
 
 <style scoped>

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -6,15 +6,130 @@
 
 <template>
   <div class="h-full flex flex-col">
-    <!-- Contenido del catálogo -->
-    <div class="flex-1 overflow-hidden">
+    <div class="p-2">
+      <!-- Conmutador Catálogo de Elementos | Catálogo de Plantillas -->
+      <div
+        class="catalog-switch"
+        role="tablist"
+        aria-label="Cambiar catálogo"
+      >
+        <button
+          ref="tabElementos"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'elementos',
+            'kb-focus': focusedTab === 'elementos',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'elementos'"
+          :tabindex="selectedCatalog === 'elementos' ? 0 : -1"
+          @click="selectCatalog('elementos')"
+          @keydown="onTabKeydown($event, 'elementos')"
+          @focus="focusedTab = 'elementos'"
+          @blur="focusedTab = null"
+        >
+          📦 Catálogo de Elementos
+        </button>
+        <button
+          ref="tabPlantillas"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'plantillas',
+            'kb-focus': focusedTab === 'plantillas',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'plantillas'"
+          :tabindex="selectedCatalog === 'plantillas' ? 0 : -1"
+          @click="selectCatalog('plantillas')"
+          @keydown="onTabKeydown($event, 'plantillas')"
+          @focus="focusedTab = 'plantillas'"
+          @blur="focusedTab = null"
+        >
+          📝 Catálogo de Plantillas
+        </button>
+      </div>
+
+      <!-- Fallback móvil: dropdown -->
+      <div class="catalog-switch catalog-switch--compact">
+        <label for="catalogSelect" class="sr-only">Catálogo</label>
+        <select
+          id="catalogSelect"
+          v-model="selectedCatalog"
+          aria-label="Catálogo"
+        >
+          <option value="elementos">📦 Catálogo de Elementos</option>
+          <option value="plantillas">📝 Catálogo de Plantillas</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Contenido dinámico según catálogo -->
+    <div
+      v-if="selectedCatalog === 'elementos'"
+      class="flex-1 overflow-hidden"
+    >
       <ElementosCatalogo />
+    </div>
+    <div
+      v-else
+      class="flex-1 overflow-hidden"
+    >
+      <div class="h-full flex items-center justify-center text-slate-500 text-sm">
+        No hay plantillas aún
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted, watch, computed } from 'vue'
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
+
+const catalogStore = useCatalogStore()
+const selectedCatalog = computed({
+  get: () => catalogStore.selectedCatalog,
+  set: (val) => catalogStore.setSelectedCatalog(val),
+})
+
+const focusedTab = ref(null)
+const tabElementos = ref(null)
+const tabPlantillas = ref(null)
+
+const selectCatalog = (value) => {
+  catalogStore.setSelectedCatalog(value)
+}
+
+const onTabKeydown = (e, current) => {
+  const order = ['elementos', 'plantillas']
+  const idx = order.indexOf(current)
+  if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+    e.preventDefault()
+    const dir = e.key === 'ArrowRight' ? 1 : -1
+    const next = order[(idx + dir + order.length) % order.length]
+    selectCatalog(next)
+    const refMap = { elementos: tabElementos, plantillas: tabPlantillas }
+    refMap[next].value?.focus()
+  } else if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    selectCatalog(current)
+  }
+}
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('inventory.selectedCatalog')
+    if (stored === 'plantillas' || stored === 'elementos') {
+      catalogStore.setSelectedCatalog(stored)
+    }
+  }
+})
+
+watch(selectedCatalog, (val) => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem('inventory.selectedCatalog', val)
+  }
+})
 </script>
 
 <style scoped>

--- a/src/inventory-smart/stores/catalog.js
+++ b/src/inventory-smart/stores/catalog.js
@@ -6,6 +6,10 @@ export const useCatalogStore = defineStore('catalog', () => {
   const items = ref(ELEMENTOS_PREDEFINIDOS)
   const searchText = ref('')
   const selectedCategory = ref(null)
+  const selectedCatalog = ref('elementos')
+  const setSelectedCatalog = (val) => {
+    selectedCatalog.value = val
+  }
 
   const catalogContext = ref({ mode: 'root', currentId: undefined, currentType: undefined })
 
@@ -54,6 +58,8 @@ export const useCatalogStore = defineStore('catalog', () => {
     items,
     searchText,
     selectedCategory,
+    selectedCatalog,
+    setSelectedCatalog,
     catalogContext,
     setCatalogContext,
     allowedTypesForContext,


### PR DESCRIPTION
## Summary
- add store state for selected catalog
- implement responsive accessible catalog switch with query param persistence
- style catalog switch tabs
- manage catalog selection in store with localStorage instead of URL query params

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8485cc88321b321576d4280dac8