### PR TITLE
feat: add catalog switch tabs

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -287,10 +287,21 @@ onUnmounted(() => {
   }
 }
 
-/* ====== INVENTORY: Estilos del modal 'Guardar como plantilla' ===========================
-   Contexto: Catálogo de Plantillas — creación desde elemento existente.
-   NOTA: mantener estos estilos aquí; no crear nuevos archivos de estilos.
-======================================================================================== */
+/* ====== INVENTORY: Ajustes visuales para equiparar modal 'Guardar como plantilla' con 'Eliminar' ======
+   NOTA: Reusar las mismas clases de botones y layout. Solo correcciones menores aquí.
+======================================================================================================= */
+.modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:1100}
+.modal{width:420px;max-width:92vw;background:#fff;border-radius:10px;box-shadow:0 10px 30px rgba(0,0,0,.25);overflow:hidden}
+.modal-header{display:flex;justify-content:space-between;align-items:center;padding:12px 16px;border-bottom:1px solid #e5e7eb}
+.modal-header .title{font-size:16px;font-weight:600;color:#111827}
+.modal-header .close{background:transparent;border:none;font-size:20px;cursor:pointer;color:#6b7280}
+.modal-body{padding:16px;color:#374151}
+.modal-footer{display:flex;gap:8px;justify-content:flex-end;padding:12px 16px;border-top:1px solid #e5e7eb}
+.btn{border:1px solid #e5e7eb;background:#fff;border-radius:6px;padding:8px 12px;font-size:14px;cursor:pointer}
+.btn-primary{background:#2563eb;color:#fff;border-color:#2563eb}
+.btn-primary:hover{background:#1d4ed8}
+.btn:disabled{opacity:.6;cursor:not-allowed}
+.btn:focus-visible{outline:2px solid #2563eb;outline-offset:2px}
 .template-modal__row { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
 .template-modal__label { font-weight: 600; font-size: 0.95rem; }
 .template-modal__input,
@@ -307,7 +318,6 @@ onUnmounted(() => {
   background: var(--bg-muted, #f7f8fa); border: 1px solid var(--border-color, #e3e6eb);
   border-radius: 8px; padding: 10px;
 }
-.template-modal__actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
 .template-modal__error { color: #c62828; font-size: 0.85rem; }
 </style>
 

--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -230,6 +230,62 @@ onUnmounted(() => {
   background: var(--ui-bg-dark);
   border: 1px solid var(--ui-border-dark);
 }
+
+/* ====== INVENTORY: Estilos para el conmutador de Catálogo (Elementos | Plantillas) ======
+   Contexto: pestaña Elementos — controla catálogo visible.
+   NOTA: no mover ni duplicar en otros archivos. Mantener aquí.
+======================================================================================== */
+.catalog-switch {
+  display: flex;
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+}
+
+.catalog-switch--compact {
+  display: none;
+}
+
+.catalog-tab {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--ui-border);
+  border-radius: 9999px;
+  background: var(--ui-bg);
+  color: #334155;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.catalog-tab:hover {
+  background: #f1f5f9;
+}
+
+.catalog-tab.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.catalog-tab.kb-focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+@media (max-width: 479px) {
+  .catalog-switch {
+    display: none;
+  }
+
+  .catalog-switch.catalog-switch--compact {
+    display: block;
+  }
+
+  .catalog-switch--compact select {
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+  }
+}
 </style>
 
 <style scoped>

--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -286,6 +286,29 @@ onUnmounted(() => {
     border-radius: 0.375rem;
   }
 }
+
+/* ====== INVENTORY: Estilos del modal 'Guardar como plantilla' ===========================
+   Contexto: Catálogo de Plantillas — creación desde elemento existente.
+   NOTA: mantener estos estilos aquí; no crear nuevos archivos de estilos.
+======================================================================================== */
+.template-modal__row { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
+.template-modal__label { font-weight: 600; font-size: 0.95rem; }
+.template-modal__input,
+.template-modal__textarea {
+  width: 100%; border: 1px solid var(--border-color, #e3e6eb); border-radius: 8px;
+  padding: 8px 10px; background: #fff; font: inherit;
+}
+.template-modal__input:focus,
+.template-modal__textarea:focus {
+  outline: none; box-shadow: 0 0 0 3px rgba(38,132,255,.25);
+}
+.template-modal__summary {
+  font-size: 0.9rem; color: var(--text-muted, #5b6473);
+  background: var(--bg-muted, #f7f8fa); border: 1px solid var(--border-color, #e3e6eb);
+  border-radius: 8px; padding: 10px;
+}
+.template-modal__actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+.template-modal__error { color: #c62828; font-size: 0.85rem; }
 </style>
 
 <style scoped>

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -634,19 +634,18 @@
     <!-- Modal Guardar como plantilla -->
     <div
       v-if="templateModalOpen"
-      class="fixed inset-0 z-50 flex items-center justify-center"
+      class="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="templateModalTitle"
+      @click.self="closeTemplateModal"
     >
-      <div class="absolute inset-0 bg-black/50" @click="closeTemplateModal"></div>
-      <div
-        class="relative bg-white rounded-lg p-4 w-[90%] max-w-md"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="templateModalTitle"
-      >
-        <form @submit.prevent="saveTemplate">
-          <h2 id="templateModalTitle" class="text-lg font-semibold mb-4">
-            Guardar como plantilla
-          </h2>
+      <form class="modal" @submit.prevent="saveTemplate">
+        <header class="modal-header">
+          <h3 id="templateModalTitle" class="title">Guardar como plantilla</h3>
+          <button type="button" class="close" @click="closeTemplateModal" aria-label="Cerrar">×</button>
+        </header>
+        <section class="modal-body">
           <div class="template-modal__row">
             <label for="templateName" class="template-modal__label">Nombre de la plantilla</label>
             <input
@@ -680,12 +679,14 @@
               rows="3"
             ></textarea>
           </div>
-          <div class="template-modal__actions">
-            <button type="button" @click="closeTemplateModal">Cancelar</button>
-            <button type="submit" :disabled="!templateName.trim()">Guardar</button>
-          </div>
-        </form>
-      </div>
+        </section>
+        <footer class="modal-footer">
+          <button type="button" class="btn" @click="closeTemplateModal">Cancelar</button>
+          <button type="submit" class="btn btn-primary" :disabled="!templateName.trim() || isSaving">
+            Guardar
+          </button>
+        </footer>
+      </form>
     </div>
 
   <!-- Información de zoom, vista y dimensiones -->
@@ -977,6 +978,7 @@ const templateError = ref('')
 const templateSummary = ref({ elementType: '', width: 0, height: 0, depth: 0, childrenCount: 0 })
 const templatePayload = ref(null)
 const templateNameInput = ref(null)
+const isSaving = ref(false)
 
 const openTemplateModal = (elementId) => {
   const el = canvasStore.elementoPorId(elementId)
@@ -1008,6 +1010,7 @@ const closeTemplateModal = () => {
 }
 
 const saveTemplate = () => {
+  if (isSaving.value) return
   const name = templateName.value.trim()
   if (!name) {
     templateError.value = 'El nombre es obligatorio'
@@ -1017,6 +1020,7 @@ const saveTemplate = () => {
     templateError.value = 'Ya existe una plantilla con ese nombre'
     return
   }
+  isSaving.value = true
   const now = new Date().toISOString()
   const template = {
     id: `tpl_${Date.now().toString(36)}`,
@@ -1037,6 +1041,7 @@ const saveTemplate = () => {
   catalogStore.addTemplate(template)
   showToast('Plantilla guardada', 'success')
   templateModalOpen.value = false
+  isSaving.value = false
 }
 
 const onTemplateKeydown = (e) => {

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -627,8 +627,66 @@
       :isLocked="ctxIsLocked"
       @lockToggle="() => toggleLock(ctxElementId)"
       @delete="() => onDelete(ctxElementId)"
+      @saveTemplate="() => openTemplateModal(ctxElementId)"
       @close="ctx.close()"
     />
+
+    <!-- Modal Guardar como plantilla -->
+    <div
+      v-if="templateModalOpen"
+      class="fixed inset-0 z-50 flex items-center justify-center"
+    >
+      <div class="absolute inset-0 bg-black/50" @click="closeTemplateModal"></div>
+      <div
+        class="relative bg-white rounded-lg p-4 w-[90%] max-w-md"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="templateModalTitle"
+      >
+        <form @submit.prevent="saveTemplate">
+          <h2 id="templateModalTitle" class="text-lg font-semibold mb-4">
+            Guardar como plantilla
+          </h2>
+          <div class="template-modal__row">
+            <label for="templateName" class="template-modal__label">Nombre de la plantilla</label>
+            <input
+              id="templateName"
+              ref="templateNameInput"
+              v-model="templateName"
+              class="template-modal__input"
+              type="text"
+              maxlength="80"
+              required
+            />
+            <p v-if="templateError" class="template-modal__error">{{ templateError }}</p>
+          </div>
+          <div class="template-modal__row">
+            <div class="template-modal__summary" id="templateSummary">
+              <div>Tipo: {{ templateSummary.elementType }}</div>
+              <div>
+                Dimensiones: {{ templateSummary.width }}×{{ templateSummary.depth }}×{{
+                  templateSummary.height
+                }}
+              </div>
+              <div>Hijos: {{ templateSummary.childrenCount }}</div>
+            </div>
+          </div>
+          <div class="template-modal__row">
+            <label for="templateNotes" class="template-modal__label">Notas</label>
+            <textarea
+              id="templateNotes"
+              v-model="templateNotes"
+              class="template-modal__textarea"
+              rows="3"
+            ></textarea>
+          </div>
+          <div class="template-modal__actions">
+            <button type="button" @click="closeTemplateModal">Cancelar</button>
+            <button type="submit" :disabled="!templateName.trim()">Guardar</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
   <!-- Información de zoom, vista y dimensiones -->
   <div ref="canvasInfoRef" class="canvas-info" :style="canvasInfoStyle">
@@ -773,6 +831,7 @@ import { useContextMenu } from '@/inventory-smart/composables/useContextMenu'
 import { useDeleteElement } from '@/inventory-smart/composables/useDeleteElement'
 import { useConfirmDialog } from '@/inventory-smart/composables/useConfirmDialog'
 import { useWeightValidation } from '@/inventory-smart/composables/useWeightValidation'
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import { applyEdgeConstraint } from '@/inventory-smart/utils/edgeConstraint'
 import { resetEdgeState } from '@/inventory-smart/composables/useEdgeState'
 import { finalizePlacement } from '@/inventory-smart/utils/finalizeDrag'
@@ -909,6 +968,85 @@ const { visible: ctxVisible, x: ctxX, y: ctxY, isLocked: ctxIsLocked, elementId:
 const { deleteSelected } = useDeleteElement()
 const confirmDialog = useConfirmDialog()
 const weightValidation = useWeightValidation()
+const catalogStore = useCatalogStore()
+
+const templateModalOpen = ref(false)
+const templateName = ref('')
+const templateNotes = ref('')
+const templateError = ref('')
+const templateSummary = ref({ elementType: '', width: 0, height: 0, depth: 0, childrenCount: 0 })
+const templatePayload = ref(null)
+const templateNameInput = ref(null)
+
+const openTemplateModal = (elementId) => {
+  const el = canvasStore.elementoPorId(elementId)
+  if (!el) return
+  const serialized = buffer.serializeElementForTemplate(elementId)
+  if (!serialized) return
+  const elementsArr = Array.from(serialized.allElements.values())
+  templatePayload.value = {
+    rootId: serialized.rootElement.id,
+    elements: elementsArr,
+  }
+  templateSummary.value = {
+    elementType: serialized.rootElement.tipo || '',
+    width: serialized.rootElement.dimensiones?.ancho || 0,
+    depth: serialized.rootElement.dimensiones?.largo || 0,
+    height: serialized.rootElement.dimensiones?.alto || 0,
+    childrenCount: elementsArr.length - 1,
+  }
+  templateName.value = el.nombre || ''
+  templateNotes.value = ''
+  templateError.value = ''
+  templateModalOpen.value = true
+  nextTick(() => templateNameInput.value?.focus?.())
+  ctx.close()
+}
+
+const closeTemplateModal = () => {
+  templateModalOpen.value = false
+}
+
+const saveTemplate = () => {
+  const name = templateName.value.trim()
+  if (!name) {
+    templateError.value = 'El nombre es obligatorio'
+    return
+  }
+  if (catalogStore.getTemplateByName(name)) {
+    templateError.value = 'Ya existe una plantilla con ese nombre'
+    return
+  }
+  const now = new Date().toISOString()
+  const template = {
+    id: `tpl_${Date.now().toString(36)}`,
+    name,
+    createdAt: now,
+    updatedAt: now,
+    meta: {
+      elementType: templateSummary.value.elementType,
+      width: templateSummary.value.width,
+      height: templateSummary.value.height,
+      depth: templateSummary.value.depth,
+      childrenCount: templateSummary.value.childrenCount,
+    },
+    payload: templatePayload.value,
+    notes: templateNotes.value.trim() || undefined,
+    tags: [],
+  }
+  catalogStore.addTemplate(template)
+  showToast('Plantilla guardada', 'success')
+  templateModalOpen.value = false
+}
+
+const onTemplateKeydown = (e) => {
+  if (e.key === 'Escape') closeTemplateModal()
+}
+
+watch(templateModalOpen, (val) => {
+  if (val) window.addEventListener('keydown', onTemplateKeydown)
+  else window.removeEventListener('keydown', onTemplateKeydown)
+})
 
 // Object snapping
 const {
@@ -1832,6 +1970,8 @@ const handleDrop = (e) => {
       createElementFromDrop(data, e)
     } else if (data.tipo === 'buffer-element') {
       createElementFromBuffer(data, e)
+    } else if (data.tipo === 'plantilla-catalogo') {
+      createElementFromTemplate(data, e)
     }
   } catch (error) {
     console.error('Error procesando drop:', error)
@@ -2520,6 +2660,14 @@ const createElementFromBuffer = (data, dropEvent) => {
     )
     // Seleccionar el elemento recién pegado
     canvasStore.seleccionarElemento(newElementId)
+  }
+}
+
+const createElementFromTemplate = (data, dropEvent) => {
+  const pos = getWorldCoordinatesFromPointer(dropEvent)
+  const newId = buffer.pasteFromSerialized(data.payload, pos)
+  if (!newId) {
+    showToast('No se pudo insertar la plantilla', 'error')
   }
 }
 

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -1022,6 +1022,10 @@ const saveTemplate = () => {
   }
   isSaving.value = true
   const now = new Date().toISOString()
+  const root =
+    templatePayload.value?.elements?.find(
+      (e) => e.id === templatePayload.value?.rootId,
+    ) || {}
   const template = {
     id: `tpl_${Date.now().toString(36)}`,
     name,
@@ -1033,6 +1037,8 @@ const saveTemplate = () => {
       height: templateSummary.value.height,
       depth: templateSummary.value.depth,
       childrenCount: templateSummary.value.childrenCount,
+      weight: root.pesoMaximo,
+      location: root.ubicacion,
     },
     payload: templatePayload.value,
     notes: templateNotes.value.trim() || undefined,

--- a/src/inventory-smart/components/ElementosCatalogo.vue
+++ b/src/inventory-smart/components/ElementosCatalogo.vue
@@ -260,7 +260,7 @@ const nuevoElemento = ref({
 // Computed: título dinámico según el contexto
 const tituloContextual = computed(() => {
   if (catalogContext.value.mode === 'root') {
-    return 'Catálogo de Elementos'
+    return ''
   } else if (catalogContext.value.mode === 'detail-element') {
     return 'Catálogo de Contenedores'
   } else if (catalogContext.value.mode === 'detail-container') {

--- a/src/inventory-smart/components/ElementosCatalogo.vue
+++ b/src/inventory-smart/components/ElementosCatalogo.vue
@@ -389,7 +389,11 @@ onMounted(() => {
   const elementosGuardados = localStorage.getItem('elementos-personalizados')
   if (elementosGuardados) {
     try {
-      JSON.parse(elementosGuardados).forEach((el) => items.value.push(el))
+      JSON.parse(elementosGuardados).forEach((el) => {
+        if (!items.value.some((existing) => existing.id === el.id)) {
+          items.value.push(el)
+        }
+      })
     } catch (error) {
       console.error('Error cargando elementos personalizados:', error)
     }

--- a/src/inventory-smart/components/ElementosCatalogo.vue
+++ b/src/inventory-smart/components/ElementosCatalogo.vue
@@ -220,6 +220,7 @@ import {
   TODAS_LAS_CATEGORIAS,
   TIPOS_ENTIDAD,
   getColorPorTipo,
+  getColorCategoria,
   FORMAS_DISPONIBLES,
   UBICACIONES_DISPONIBLES,
 } from '@/inventory-smart/utils/constants'

--- a/src/inventory-smart/components/SpeedDialContext.vue
+++ b/src/inventory-smart/components/SpeedDialContext.vue
@@ -8,7 +8,7 @@
     role="menu"
     aria-label="Menú contextual"
     @keydown.stop.prevent="onKeydown"
-    @contextmenu.prevent
+  @contextmenu.prevent
   >
     <button
       ref="itemRefs[0]"
@@ -21,6 +21,15 @@
     </button>
     <button
       ref="itemRefs[1]"
+      class="sdx-item"
+      role="menuitem"
+      aria-label="Guardar como plantilla"
+      @click="emitSaveTemplate"
+    >
+      Guardar como plantilla
+    </button>
+    <button
+      ref="itemRefs[2]"
       class="sdx-item sdx-danger"
       role="menuitem"
       aria-label="Eliminar"
@@ -42,10 +51,10 @@ const props = defineProps({
   y: { type: Number, default: 0 },
   isLocked: { type: Boolean, default: false },
 })
-const emit = defineEmits(['lockToggle', 'delete', 'close'])
+const emit = defineEmits(['lockToggle', 'delete', 'saveTemplate', 'close'])
 
 const menuRef = ref(null)
-const itemRefs = [ref(null), ref(null)]
+const itemRefs = [ref(null), ref(null), ref(null)]
 const focusedIndex = ref(0)
 
 const pos = ref({ left: 0, top: 0 })
@@ -111,6 +120,7 @@ const onKeydown = (e) => {
     itemRefs[focusedIndex.value].value?.focus?.()
   } else if (e.key === 'Enter' || e.key === ' ') {
     if (focusedIndex.value === 0) emitLock()
+    else if (focusedIndex.value === 1) emitSaveTemplate()
     else emitDelete()
   } else if (e.key === 'Escape') {
     emit('close')
@@ -119,6 +129,9 @@ const onKeydown = (e) => {
 
 const emitLock = () => {
   emit('lockToggle')
+}
+const emitSaveTemplate = () => {
+  emit('saveTemplate')
 }
 const emitDelete = () => {
   emit('delete')

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -72,23 +72,48 @@
     </div>
     <div
       v-else
-      class="flex-1 overflow-hidden"
+      class="flex-1 overflow-hidden flex flex-col"
     >
-      <div class="h-full flex items-center justify-center text-slate-500 text-sm">
-        No hay plantillas aún
+      <div class="p-4 border-b">
+        <input
+          v-model="searchText"
+          type="text"
+          placeholder="Buscar plantillas..."
+          class="w-full pl-3 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-100"
+        />
+      </div>
+      <div class="flex-1 overflow-y-auto p-4">
+        <div
+          v-if="filteredTemplates.length === 0"
+          class="h-full flex items-center justify-center text-slate-500 text-sm"
+        >
+          No hay plantillas aún
+        </div>
+        <ul v-else class="grid grid-cols-1 gap-3">
+          <li
+            v-for="tpl in filteredTemplates"
+            :key="tpl.id"
+            class="border border-gray-200 rounded-lg p-3 cursor-grab hover:shadow-md transition-all duration-200"
+            draggable="true"
+            @dragstart="onTemplateDragStart(tpl, $event)"
+            @dragend="onTemplateDragEnd"
+          >
+            {{ tpl.name }}
+          </li>
+        </ul>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, watch, computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
 
 const catalogStore = useCatalogStore()
-const { selectedCatalog } = storeToRefs(catalogStore)
+const { selectedCatalog, searchText, templates } = storeToRefs(catalogStore)
 
 const focusedTab = ref(null)
 const tabElementos = ref(null)
@@ -120,11 +145,33 @@ onMounted(() => {
     catalogStore.setSelectedCatalog(saved)
   }
   localStorage.setItem('inventory.selectedCatalog', selectedCatalog.value)
+  catalogStore.loadTemplatesFromLocalStorage()
 })
 
 watch(selectedCatalog, (val) => {
   localStorage.setItem('inventory.selectedCatalog', val)
 })
+
+const filteredTemplates = computed(() =>
+  catalogStore.searchTemplates(searchText.value)
+)
+
+const onTemplateDragStart = (tpl, event) => {
+  const dragData = {
+    tipo: 'plantilla-catalogo',
+    plantillaId: tpl.id,
+    payload: tpl.payload,
+  }
+  event.dataTransfer.setData('application/json', JSON.stringify(dragData))
+  event.dataTransfer.effectAllowed = 'copy'
+  const card = event.currentTarget
+  if (card && card.classList) card.classList.add('opacity-50', 'scale-95')
+}
+
+const onTemplateDragEnd = (event) => {
+  const card = event.currentTarget
+  if (card && card.classList) card.classList.remove('opacity-50', 'scale-95')
+}
 </script>
 
 <style scoped>

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -106,7 +106,7 @@
             @dragstart="onTemplateDragStart(tpl, $event)"
             @dragend="onTemplateDragEnd"
             class="group relative bg-white border border-gray-200 rounded-lg p-3 cursor-grab mb-3 hover:shadow-md transition-all duration-200 border-l-4 hover:scale-[1.02]"
-            :style="{ borderLeftColor: '#3b82f6' }"
+            :style="{ borderLeftColor: getTemplateColor(tpl) }"
           >
             <div class="elemento-preview flex items-center justify-center mb-3">
               <div
@@ -114,7 +114,7 @@
                   'preview-shape rounded-sm flex items-center justify-center relative shadow-sm border border-white/20',
                   'w-12 h-8',
                 ]"
-                style="background-color: #3b82f6"
+                :style="{ backgroundColor: getTemplateColor(tpl) }"
               >
                 <component :is="getIconComponent('box')" class="w-4 h-4 text-white" />
               </div>
@@ -133,18 +133,18 @@
                 </div>
                 <div class="spec-item flex justify-between text-xs">
                   <span class="spec-label text-gray-500 font-medium">Peso:</span>
-                  <span class="spec-value text-gray-700">—</span>
+                  <span class="spec-value text-gray-700">{{ formatTemplateWeight(tpl) }}</span>
                 </div>
                 <div class="spec-item flex justify-between text-xs">
                   <span class="spec-label text-gray-500 font-medium">Ubic:</span>
-                  <span class="spec-value text-gray-700">—</span>
+                  <span class="spec-value text-gray-700 capitalize">{{ formatTemplateLocation(tpl) }}</span>
                 </div>
               </div>
 
               <div class="mt-2 flex gap-1">
                 <span
                   class="inline-block px-2 py-1 text-xs rounded-full text-white"
-                  style="background-color: #3b82f6"
+                  :style="{ backgroundColor: getTemplateColor(tpl) }"
                 >
                   Plantillas
                 </span>
@@ -207,6 +207,7 @@ import { ref, onMounted, watch, computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
+import { getColorCategoria } from '@/inventory-smart/utils/constants'
 
 const catalogStore = useCatalogStore()
 const { selectedCatalog, searchText } = storeToRefs(catalogStore)
@@ -270,6 +271,38 @@ const getTemplateDims = (tpl) => ({
 })
 
 const getIconComponent = () => 'svg'
+
+const getTemplateRoot = (tpl) => {
+  const elems = tpl.payload?.elements || []
+  return elems.find((e) => e.id === tpl.payload?.rootId) || elems[0] || {}
+}
+
+const getTemplateColor = (tpl) => {
+  const root = getTemplateRoot(tpl)
+  return root.color || root.colorBase || getColorCategoria(root.categoria)
+}
+
+const getTemplateWeightVal = (tpl) => {
+  if (tpl.meta?.weight != null) return tpl.meta.weight
+  const root = getTemplateRoot(tpl)
+  return root.pesoMaximo
+}
+
+const getTemplateLocationVal = (tpl) => {
+  if (tpl.meta?.location) return tpl.meta.location
+  const root = getTemplateRoot(tpl)
+  return root.ubicacion
+}
+
+const formatTemplateWeight = (tpl) => {
+  const w = getTemplateWeightVal(tpl)
+  return w != null ? `${w}kg` : '—'
+}
+
+const formatTemplateLocation = (tpl) => {
+  const loc = getTemplateLocationVal(tpl)
+  return loc || '—'
+}
 
 const onTemplateDragStart = (tpl, event) => {
   const dragData = {

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -74,33 +74,129 @@
       v-else
       class="flex-1 overflow-hidden flex flex-col"
     >
-      <div class="p-4 border-b">
-        <input
-          v-model="searchText"
-          type="text"
-          placeholder="Buscar plantillas..."
-          class="w-full pl-3 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-100"
-        />
-      </div>
-      <div class="flex-1 overflow-y-auto p-4">
-        <div
-          v-if="filteredTemplates.length === 0"
-          class="h-full flex items-center justify-center text-slate-500 text-sm"
-        >
-          No hay plantillas aún
+      <div class="catalogo-header p-4 border-b border-gray-200">
+        <div class="relative">
+          <input
+            v-model="searchText"
+            type="text"
+            placeholder="Buscar plantillas..."
+            class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-100"
+          />
+          <svg
+            class="absolute left-3 top-2.5 h-5 w-5 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
         </div>
-        <ul v-else class="grid grid-cols-1 gap-3">
-          <li
+      </div>
+      <div class="elementos-lista flex-1 overflow-y-auto p-4">
+        <div class="grid grid-cols-1 gap-3">
+          <div
             v-for="tpl in filteredTemplates"
             :key="tpl.id"
-            class="border border-gray-200 rounded-lg p-3 cursor-grab hover:shadow-md transition-all duration-200"
-            draggable="true"
+            :draggable="true"
             @dragstart="onTemplateDragStart(tpl, $event)"
             @dragend="onTemplateDragEnd"
+            class="group relative bg-white border border-gray-200 rounded-lg p-3 cursor-grab mb-3 hover:shadow-md transition-all duration-200 border-l-4 hover:scale-[1.02]"
+            :style="{ borderLeftColor: '#3b82f6' }"
           >
-            {{ tpl.name }}
-          </li>
-        </ul>
+            <div class="elemento-preview flex items-center justify-center mb-3">
+              <div
+                :class="[
+                  'preview-shape rounded-sm flex items-center justify-center relative shadow-sm border border-white/20',
+                  'w-12 h-8',
+                ]"
+                style="background-color: #3b82f6"
+              >
+                <component :is="getIconComponent('box')" class="w-4 h-4 text-white" />
+              </div>
+            </div>
+
+            <div class="elemento-info space-y-1">
+              <h3 class="font-semibold text-sm text-gray-800 mb-1">{{ tpl.name }}</h3>
+              <p class="text-xs text-gray-500 mb-2">{{ templateDescription(tpl) }}</p>
+
+              <div class="elemento-specs space-y-1">
+                <div class="spec-item flex justify-between text-xs">
+                  <span class="spec-label text-gray-500 font-medium">Dim:</span>
+                  <span class="spec-value text-gray-700">
+                    {{ getTemplateDims(tpl).ancho }}x{{ getTemplateDims(tpl).largo }}x{{ getTemplateDims(tpl).alto }}
+                  </span>
+                </div>
+                <div class="spec-item flex justify-between text-xs">
+                  <span class="spec-label text-gray-500 font-medium">Peso:</span>
+                  <span class="spec-value text-gray-700">—</span>
+                </div>
+                <div class="spec-item flex justify-between text-xs">
+                  <span class="spec-label text-gray-500 font-medium">Ubic:</span>
+                  <span class="spec-value text-gray-700">—</span>
+                </div>
+              </div>
+
+              <div class="mt-2 flex gap-1">
+                <span
+                  class="inline-block px-2 py-1 text-xs rounded-full text-white"
+                  style="background-color: #3b82f6"
+                >
+                  Plantillas
+                </span>
+                <span
+                  v-for="tag in tpl.tags"
+                  :key="tag"
+                  class="inline-block px-2 py-1 text-xs rounded-full bg-gray-100 text-gray-700"
+                >
+                  {{ tag }}
+                </span>
+              </div>
+            </div>
+
+            <div
+              class="drag-indicator absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100"
+            >
+              <svg
+                class="w-4 h-4 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="filteredTemplates.length === 0" class="text-center py-12">
+          <svg
+            class="w-12 h-12 text-gray-300 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2M4 13h2m0 0v5m0-5v-5"
+            />
+          </svg>
+          <p class="text-gray-500 text-center">Aún no hay plantillas</p>
+          <p class="text-gray-400 text-sm text-center mt-1">
+            Crea una desde un elemento
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -113,7 +209,7 @@ import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
 
 const catalogStore = useCatalogStore()
-const { selectedCatalog, searchText, templates } = storeToRefs(catalogStore)
+const { selectedCatalog, searchText } = storeToRefs(catalogStore)
 
 const focusedTab = ref(null)
 const tabElementos = ref(null)
@@ -155,6 +251,25 @@ watch(selectedCatalog, (val) => {
 const filteredTemplates = computed(() =>
   catalogStore.searchTemplates(searchText.value)
 )
+
+const formatDate = (iso) => {
+  try {
+    return new Date(iso).toLocaleDateString()
+  } catch {
+    return ''
+  }
+}
+
+const templateDescription = (tpl) =>
+  tpl.notes || `Plantilla guardada • ${formatDate(tpl.updatedAt)}`
+
+const getTemplateDims = (tpl) => ({
+  ancho: tpl.meta?.width || 0,
+  largo: tpl.meta?.depth || 0,
+  alto: tpl.meta?.height || 0,
+})
+
+const getIconComponent = () => 'svg'
 
 const onTemplateDragStart = (tpl, event) => {
   const dragData = {

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -6,15 +6,125 @@
 
 <template>
   <div class="h-full flex flex-col">
-    <!-- Contenido del catálogo -->
-    <div class="flex-1 overflow-hidden">
+    <div class="p-2">
+      <!-- Conmutador Catálogo de Elementos | Catálogo de Plantillas -->
+      <div
+        class="catalog-switch"
+        role="tablist"
+        aria-label="Cambiar catálogo"
+      >
+        <button
+          ref="tabElementos"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'elementos',
+            'kb-focus': focusedTab === 'elementos',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'elementos'"
+          :tabindex="selectedCatalog === 'elementos' ? 0 : -1"
+          @click="selectCatalog('elementos')"
+          @keydown="onTabKeydown($event, 'elementos')"
+          @focus="focusedTab = 'elementos'"
+          @blur="focusedTab = null"
+        >
+          📦 Catálogo de Elementos
+        </button>
+        <button
+          ref="tabPlantillas"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'plantillas',
+            'kb-focus': focusedTab === 'plantillas',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'plantillas'"
+          :tabindex="selectedCatalog === 'plantillas' ? 0 : -1"
+          @click="selectCatalog('plantillas')"
+          @keydown="onTabKeydown($event, 'plantillas')"
+          @focus="focusedTab = 'plantillas'"
+          @blur="focusedTab = null"
+        >
+          📝 Catálogo de Plantillas
+        </button>
+      </div>
+
+      <!-- Fallback móvil: dropdown -->
+      <div class="catalog-switch catalog-switch--compact">
+        <label for="catalogSelect" class="sr-only">Catálogo</label>
+        <select
+          id="catalogSelect"
+          v-model="selectedCatalog"
+          aria-label="Catálogo"
+        >
+          <option value="elementos">📦 Catálogo de Elementos</option>
+          <option value="plantillas">📝 Catálogo de Plantillas</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Contenido dinámico según catálogo -->
+    <div
+      v-if="selectedCatalog === 'elementos'"
+      class="flex-1 overflow-hidden"
+    >
       <ElementosCatalogo />
+    </div>
+    <div
+      v-else
+      class="flex-1 overflow-hidden"
+    >
+      <div class="h-full flex items-center justify-center text-slate-500 text-sm">
+        No hay plantillas aún
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
+
+const catalogStore = useCatalogStore()
+const { selectedCatalog } = storeToRefs(catalogStore)
+
+const focusedTab = ref(null)
+const tabElementos = ref(null)
+const tabPlantillas = ref(null)
+
+const selectCatalog = (value) => {
+  catalogStore.setSelectedCatalog(value)
+}
+
+const onTabKeydown = (e, current) => {
+  const order = ['elementos', 'plantillas']
+  const idx = order.indexOf(current)
+  if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+    e.preventDefault()
+    const dir = e.key === 'ArrowRight' ? 1 : -1
+    const next = order[(idx + dir + order.length) % order.length]
+    selectCatalog(next)
+    const refMap = { elementos: tabElementos, plantillas: tabPlantillas }
+    refMap[next].value?.focus()
+  } else if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    selectCatalog(current)
+  }
+}
+
+onMounted(() => {
+  const saved = localStorage.getItem('inventory.selectedCatalog')
+  if (saved === 'plantillas' || saved === 'elementos') {
+    catalogStore.setSelectedCatalog(saved)
+  }
+  localStorage.setItem('inventory.selectedCatalog', selectedCatalog.value)
+})
+
+watch(selectedCatalog, (val) => {
+  localStorage.setItem('inventory.selectedCatalog', val)
+})
 </script>
 
 <style scoped>

--- a/src/inventory-smart/composables/useCanvasBuffer.js
+++ b/src/inventory-smart/composables/useCanvasBuffer.js
@@ -58,11 +58,11 @@ export const useCanvasBuffer = () => {
   }
 
   /**
-   * Clonar elemento con todos sus hijos recursivamente
-   * Genera nuevos IDs únicos para evitar conflictos
-   * Retorna un objeto con el elemento principal y todos los elementos de la estructura
+   * Serializar un elemento con todos sus hijos recursivamente.
+   * Genera copias profundas y nuevos IDs únicos para evitar conflictos.
+   * Retorna un objeto con el elemento raíz y un mapa de todos los elementos.
    */
-  const cloneElementWithChildren = (elementoId, offsetX = 0, offsetY = 0) => {
+  const serializeElementForTemplate = (elementoId, offsetX = 0, offsetY = 0) => {
     const elemento = canvasStore.elementoPorId(elementoId)
     if (!elemento) {
       console.warn('⚠️ Elemento no encontrado para clonar:', elementoId)
@@ -186,7 +186,7 @@ export const useCanvasBuffer = () => {
     }
 
     // Clonar la estructura completa
-    const clonedStructure = cloneElementWithChildren(elementoId)
+    const clonedStructure = serializeElementForTemplate(elementoId)
     if (!clonedStructure) {
       console.error('⚠️ Error al clonar la estructura del elemento')
       return false
@@ -539,6 +539,28 @@ export const useCanvasBuffer = () => {
   }
 
   /**
+   * Pegar estructura desde un payload serializado (plantillas)
+   */
+  const pasteFromSerialized = (payload, position = { x: 100, y: 100 }) => {
+    if (!payload || !payload.rootId || !Array.isArray(payload.elements)) {
+      console.warn('⚠️ Payload de plantilla inválido')
+      return false
+    }
+
+    const allElementsMap = new Map()
+    for (const el of payload.elements) {
+      allElementsMap.set(el.id, { ...JSON.parse(JSON.stringify(el)) })
+    }
+
+    const { newElementsMap, newIdMapping } = regenerateUniqueIds(allElementsMap)
+    const newRootId = newIdMapping.get(payload.rootId)
+    const newRootElement = newElementsMap.get(newRootId)
+    if (!newRootElement) return false
+
+    return pasteStructureRecursive(newRootElement, position, newElementsMap)
+  }
+
+  /**
    * Remover elemento del buffer
    */
   const removeFromBuffer = (bufferItemId) => {
@@ -613,6 +635,7 @@ export const useCanvasBuffer = () => {
     addToBuffer,
     copyToBuffer,
     pasteFromBuffer,
+    pasteFromSerialized,
     removeFromBuffer,
     clearBuffer,
 
@@ -621,5 +644,8 @@ export const useCanvasBuffer = () => {
     getBufferItems,
     isInBuffer,
     getBufferInfo,
+
+    // Utilidades
+    serializeElementForTemplate,
   }
 }

--- a/src/inventory-smart/stores/catalog.js
+++ b/src/inventory-smart/stores/catalog.js
@@ -6,6 +6,7 @@ export const useCatalogStore = defineStore('catalog', () => {
   const items = ref(ELEMENTOS_PREDEFINIDOS)
   const searchText = ref('')
   const selectedCategory = ref(null)
+  const selectedCatalog = ref('elementos')
 
   const catalogContext = ref({ mode: 'root', currentId: undefined, currentType: undefined })
 
@@ -50,12 +51,18 @@ export const useCatalogStore = defineStore('catalog', () => {
     catalogContext.value = ctx
   }
 
+  const setSelectedCatalog = (val) => {
+    selectedCatalog.value = val
+  }
+
   return {
     items,
     searchText,
     selectedCategory,
+    selectedCatalog,
     catalogContext,
     setCatalogContext,
+    setSelectedCatalog,
     allowedTypesForContext,
     baseSystemGuard,
     filteredCatalogItems,

--- a/src/inventory-smart/stores/catalog.js
+++ b/src/inventory-smart/stores/catalog.js
@@ -93,7 +93,14 @@ export const useCatalogStore = defineStore('catalog', () => {
 
   const searchTemplates = (query) => {
     const q = query?.toLowerCase?.() || ''
-    return templates.value.filter((t) => t.name?.toLowerCase?.().includes(q))
+    return templates.value
+      .slice()
+      .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt))
+      .filter(
+        (t) =>
+          t.name?.toLowerCase?.().includes(q) ||
+          t.notes?.toLowerCase?.().includes(q)
+      )
   }
 
   return {

--- a/src/inventory-smart/stores/catalog.js
+++ b/src/inventory-smart/stores/catalog.js
@@ -7,6 +7,7 @@ export const useCatalogStore = defineStore('catalog', () => {
   const searchText = ref('')
   const selectedCategory = ref(null)
   const selectedCatalog = ref('elementos')
+  const templates = ref([])
 
   const catalogContext = ref({ mode: 'root', currentId: undefined, currentType: undefined })
 
@@ -55,14 +56,61 @@ export const useCatalogStore = defineStore('catalog', () => {
     selectedCatalog.value = val
   }
 
+  const addTemplate = (template) => {
+    templates.value.push(template)
+    saveTemplatesToLocalStorage()
+  }
+
+  const removeTemplate = (id) => {
+    const idx = templates.value.findIndex((t) => t.id === id)
+    if (idx !== -1) {
+      templates.value.splice(idx, 1)
+      saveTemplatesToLocalStorage()
+    }
+  }
+
+  const loadTemplatesFromLocalStorage = () => {
+    try {
+      const raw = localStorage.getItem('inventory.templates')
+      templates.value = raw ? JSON.parse(raw) : []
+    } catch {
+      templates.value = []
+    }
+  }
+
+  const saveTemplatesToLocalStorage = () => {
+    try {
+      localStorage.setItem('inventory.templates', JSON.stringify(templates.value))
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const getTemplateByName = (name) => {
+    const n = name?.toLowerCase?.() || ''
+    return templates.value.find((t) => t.name?.toLowerCase?.() === n)
+  }
+
+  const searchTemplates = (query) => {
+    const q = query?.toLowerCase?.() || ''
+    return templates.value.filter((t) => t.name?.toLowerCase?.().includes(q))
+  }
+
   return {
     items,
     searchText,
     selectedCategory,
     selectedCatalog,
+    templates,
     catalogContext,
     setCatalogContext,
     setSelectedCatalog,
+    addTemplate,
+    removeTemplate,
+    loadTemplatesFromLocalStorage,
+    saveTemplatesToLocalStorage,
+    getTemplateByName,
+    searchTemplates,
     allowedTypesForContext,
     baseSystemGuard,
     filteredCatalogItems,

--- a/src/inventory-smart/utils/constants.js
+++ b/src/inventory-smart/utils/constants.js
@@ -204,6 +204,14 @@ export const getIconoPorTipo = (tipo) => {
   return tipoInfo?.icono || '📦'
 }
 
+/**
+ * Obtiene el color asociado a una categoría del catálogo
+ */
+export const getColorCategoria = (categoriaId) => {
+  const cat = TODAS_LAS_CATEGORIAS.find((c) => c.id === categoriaId)
+  return cat?.color || '#3b82f6'
+}
+
 export const COLORES_DISPONIBLES = [
   '#3b82f6',
   '#10b981',


### PR DESCRIPTION
## Summary
- add store state for selected catalog
- implement responsive accessible catalog switch with query param persistence
- style catalog switch tabs
- remove URL parameter dependency, persist catalog choice in store/localStorage
- prevent duplicate custom elements when re-entering Elementos catalog

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint' imported from /workspace/canvas-editor/eslint.config.js)*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8485cc88321b321576d4280dac8