### PR TITLE
feat: add catalog switch tabs

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -230,6 +230,85 @@ onUnmounted(() => {
   background: var(--ui-bg-dark);
   border: 1px solid var(--ui-border-dark);
 }
+
+/* ====== INVENTORY: Estilos para el conmutador de Catálogo (Elementos | Plantillas) ======
+   Contexto: pestaña Elementos — controla catálogo visible.
+   NOTA: no mover ni duplicar en otros archivos. Mantener aquí.
+======================================================================================== */
+.catalog-switch {
+  display: flex;
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+}
+
+.catalog-switch--compact {
+  display: none;
+}
+
+.catalog-tab {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--ui-border);
+  border-radius: 9999px;
+  background: var(--ui-bg);
+  color: #334155;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.catalog-tab:hover {
+  background: #f1f5f9;
+}
+
+.catalog-tab.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.catalog-tab.kb-focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+@media (max-width: 479px) {
+  .catalog-switch {
+    display: none;
+  }
+
+  .catalog-switch.catalog-switch--compact {
+    display: block;
+  }
+
+  .catalog-switch--compact select {
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+  }
+}
+
+/* ====== INVENTORY: Estilos del modal 'Guardar como plantilla' ===========================
+   Contexto: Catálogo de Plantillas — creación desde elemento existente.
+   NOTA: mantener estos estilos aquí; no crear nuevos archivos de estilos.
+======================================================================================== */
+.template-modal__row { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
+.template-modal__label { font-weight: 600; font-size: 0.95rem; }
+.template-modal__input,
+.template-modal__textarea {
+  width: 100%; border: 1px solid var(--border-color, #e3e6eb); border-radius: 8px;
+  padding: 8px 10px; background: #fff; font: inherit;
+}
+.template-modal__input:focus,
+.template-modal__textarea:focus {
+  outline: none; box-shadow: 0 0 0 3px rgba(38,132,255,.25);
+}
+.template-modal__summary {
+  font-size: 0.9rem; color: var(--text-muted, #5b6473);
+  background: var(--bg-muted, #f7f8fa); border: 1px solid var(--border-color, #e3e6eb);
+  border-radius: 8px; padding: 10px;
+}
+.template-modal__actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+.template-modal__error { color: #c62828; font-size: 0.85rem; }
 </style>
 
 <style scoped>

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -626,9 +626,60 @@
       :y="ctxY"
       :isLocked="ctxIsLocked"
       @lockToggle="() => toggleLock(ctxElementId)"
+      @save-template="onSaveTemplate(ctxElementId)"
       @delete="() => onDelete(ctxElementId)"
       @close="ctx.close()"
     />
+
+    <!-- Modal Guardar como plantilla -->
+    <div
+      v-if="showTemplateModal"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-[1100]"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="templateModalTitle"
+      aria-describedby="templateSummary"
+      @click.self="closeTemplateModal"
+      @keydown.esc="closeTemplateModal"
+    >
+      <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+        <h3 id="templateModalTitle" class="text-lg font-medium mb-4">Guardar como plantilla</h3>
+        <form @submit.prevent="saveTemplate">
+          <div class="template-modal__row">
+            <label for="templateName" class="template-modal__label">Nombre de la plantilla</label>
+            <input
+              id="templateName"
+              ref="templateNameInput"
+              v-model="templateName"
+              class="template-modal__input"
+              maxlength="80"
+              required
+            />
+            <p v-if="templateError" class="template-modal__error">{{ templateError }}</p>
+          </div>
+          <div class="template-modal__row">
+            <div class="template-modal__summary" id="templateSummary">
+              Tipo: {{ templateSummary.type }}<br />
+              Dimensiones: {{ templateSummary.width }}×{{ templateSummary.height }}<span v-if="templateSummary.depth">×{{ templateSummary.depth }}</span><br />
+              Hijos: {{ templateSummary.children }}
+            </div>
+          </div>
+          <div class="template-modal__row">
+            <label for="templateNotes" class="template-modal__label">Notas</label>
+            <textarea
+              id="templateNotes"
+              v-model="templateNotes"
+              class="template-modal__textarea"
+              rows="3"
+            ></textarea>
+          </div>
+          <div class="template-modal__actions">
+            <button type="button" @click="closeTemplateModal">Cancelar</button>
+            <button type="submit" :disabled="!templateName.trim()">Guardar</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
   <!-- Información de zoom, vista y dimensiones -->
   <div ref="canvasInfoRef" class="canvas-info" :style="canvasInfoStyle">
@@ -745,7 +796,7 @@ import { setupRafDrag } from '@/inventory-smart/composables/useRafDrag'
 import { enablePerfMode } from '@/inventory-smart/composables/usePerfMode'
 import { throttleEveryNFrames } from '@/inventory-smart/utils/dragMath'
 import { useCanvasWithHistory } from '@/inventory-smart/composables/useCanvasWithHistory'
-import { useCanvasBuffer } from '@/inventory-smart/composables/useCanvasBuffer'
+import { useCanvasBuffer, serializeElementForTemplate } from '@/inventory-smart/composables/useCanvasBuffer'
 import { useConflicts } from '@/inventory-smart/composables/useConflicts'
 import RulersOverlay from '@/inventory-smart/components/RulersOverlay.vue'
 import {
@@ -784,6 +835,7 @@ import FloatingToolbar from '@/inventory-smart/components/FloatingToolbar.vue'
 import { getUsoInfo, useProductSimulation } from '@/inventory-smart/utils/simulateProducts'
 import SnapGuides from '@/inventory-smart/components/SnapGuides.vue'
 import { useToast } from '@/inventory-smart/composables/useToast'
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 
 // Nuevo: espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -1839,6 +1891,84 @@ const handleDrop = (e) => {
 }
 
 const { showToast } = useToast()
+const catalogStore = useCatalogStore()
+
+const showTemplateModal = ref(false)
+const templateName = ref('')
+const templateNotes = ref('')
+const templateError = ref('')
+const templateSummary = ref({ type: '', width: 0, height: 0, depth: 0, children: 0 })
+const templatePayload = ref(null)
+const templateNameInput = ref(null)
+
+const openTemplateModal = (elementId) => {
+  const element = canvasStore.elementoPorId(elementId)
+  if (!element) return
+  const serialized = serializeElementForTemplate(elementId)
+  if (!serialized) return
+  templatePayload.value = serialized
+  const childrenCount = serialized.allElements.size - 1
+  const width = element.width || element.dimensiones?.ancho || 0
+  const height = element.height || element.dimensiones?.largo || 0
+  const depth = element.depth || element.dimensiones?.alto || 0
+  templateSummary.value = {
+    type: element.tipo || element.categoria || 'elemento',
+    width,
+    height,
+    depth,
+    children: childrenCount,
+  }
+  showTemplateModal.value = true
+  nextTick(() => {
+    templateNameInput.value?.focus()
+  })
+}
+
+const closeTemplateModal = () => {
+  showTemplateModal.value = false
+  templateName.value = ''
+  templateNotes.value = ''
+  templateError.value = ''
+  templatePayload.value = null
+}
+
+const saveTemplate = () => {
+  templateError.value = ''
+  const name = templateName.value.trim()
+  if (!name) {
+    templateError.value = 'El nombre es obligatorio'
+    return
+  }
+  if (catalogStore.getTemplateByName(name)) {
+    templateError.value = 'Ya existe una plantilla con ese nombre'
+    return
+  }
+  const now = new Date().toISOString()
+  const tpl = {
+    id: Date.now().toString(),
+    name,
+    createdAt: now,
+    updatedAt: now,
+    meta: {
+      elementType: templateSummary.value.type,
+      width: templateSummary.value.width,
+      height: templateSummary.value.height,
+      depth: templateSummary.value.depth,
+      childrenCount: templateSummary.value.children,
+    },
+    payload: templatePayload.value,
+    notes: templateNotes.value || '',
+    tags: [],
+  }
+  catalogStore.addTemplate(tpl)
+  showToast('Plantilla guardada', { type: 'success' })
+  closeTemplateModal()
+}
+
+const onSaveTemplate = (elementId) => {
+  ctx.close()
+  openTemplateModal(elementId)
+}
 
 const { simularLlenadoContenedor} = useProductSimulation({
   canvasStore,

--- a/src/inventory-smart/components/ElementosCatalogo.vue
+++ b/src/inventory-smart/components/ElementosCatalogo.vue
@@ -389,7 +389,11 @@ onMounted(() => {
   const elementosGuardados = localStorage.getItem('elementos-personalizados')
   if (elementosGuardados) {
     try {
-      JSON.parse(elementosGuardados).forEach((el) => items.value.push(el))
+      JSON.parse(elementosGuardados).forEach((el) => {
+        if (!items.value.some((existing) => existing.id === el.id)) {
+          items.value.push(el)
+        }
+      })
     } catch (error) {
       console.error('Error cargando elementos personalizados:', error)
     }

--- a/src/inventory-smart/components/SpeedDialContext.vue
+++ b/src/inventory-smart/components/SpeedDialContext.vue
@@ -21,6 +21,15 @@
     </button>
     <button
       ref="itemRefs[1]"
+      class="sdx-item"
+      role="menuitem"
+      aria-label="Guardar como plantilla"
+      @click="emitSaveTemplate"
+    >
+      Guardar como plantilla
+    </button>
+    <button
+      ref="itemRefs[2]"
       class="sdx-item sdx-danger"
       role="menuitem"
       aria-label="Eliminar"
@@ -42,10 +51,10 @@ const props = defineProps({
   y: { type: Number, default: 0 },
   isLocked: { type: Boolean, default: false },
 })
-const emit = defineEmits(['lockToggle', 'delete', 'close'])
+const emit = defineEmits(['lockToggle', 'save-template', 'delete', 'close'])
 
 const menuRef = ref(null)
-const itemRefs = [ref(null), ref(null)]
+const itemRefs = [ref(null), ref(null), ref(null)]
 const focusedIndex = ref(0)
 
 const pos = ref({ left: 0, top: 0 })
@@ -111,6 +120,7 @@ const onKeydown = (e) => {
     itemRefs[focusedIndex.value].value?.focus?.()
   } else if (e.key === 'Enter' || e.key === ' ') {
     if (focusedIndex.value === 0) emitLock()
+    else if (focusedIndex.value === 1) emitSaveTemplate()
     else emitDelete()
   } else if (e.key === 'Escape') {
     emit('close')
@@ -122,6 +132,9 @@ const emitLock = () => {
 }
 const emitDelete = () => {
   emit('delete')
+}
+const emitSaveTemplate = () => {
+  emit('save-template')
 }
 </script>
 

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -6,15 +6,144 @@
 
 <template>
   <div class="h-full flex flex-col">
-    <!-- Contenido del catálogo -->
-    <div class="flex-1 overflow-hidden">
+    <div class="p-2">
+      <!-- Conmutador Catálogo de Elementos | Catálogo de Plantillas -->
+      <div
+        class="catalog-switch"
+        role="tablist"
+        aria-label="Cambiar catálogo"
+      >
+        <button
+          ref="tabElementos"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'elementos',
+            'kb-focus': focusedTab === 'elementos',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'elementos'"
+          :tabindex="selectedCatalog === 'elementos' ? 0 : -1"
+          @click="selectCatalog('elementos')"
+          @keydown="onTabKeydown($event, 'elementos')"
+          @focus="focusedTab = 'elementos'"
+          @blur="focusedTab = null"
+        >
+          📦 Catálogo de Elementos
+        </button>
+        <button
+          ref="tabPlantillas"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'plantillas',
+            'kb-focus': focusedTab === 'plantillas',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'plantillas'"
+          :tabindex="selectedCatalog === 'plantillas' ? 0 : -1"
+          @click="selectCatalog('plantillas')"
+          @keydown="onTabKeydown($event, 'plantillas')"
+          @focus="focusedTab = 'plantillas'"
+          @blur="focusedTab = null"
+        >
+          📝 Catálogo de Plantillas
+        </button>
+      </div>
+
+      <!-- Fallback móvil: dropdown -->
+      <div class="catalog-switch catalog-switch--compact">
+        <label for="catalogSelect" class="sr-only">Catálogo</label>
+        <select
+          id="catalogSelect"
+          v-model="selectedCatalog"
+          aria-label="Catálogo"
+        >
+          <option value="elementos">📦 Catálogo de Elementos</option>
+          <option value="plantillas">📝 Catálogo de Plantillas</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Contenido dinámico según catálogo -->
+    <div
+      v-if="selectedCatalog === 'elementos'"
+      class="flex-1 overflow-hidden"
+    >
       <ElementosCatalogo />
+    </div>
+    <div v-else class="flex-1 overflow-hidden flex flex-col">
+      <div class="p-2 border-b">
+        <input
+          v-model="searchText"
+          type="text"
+          placeholder="Buscar plantillas..."
+          class="w-full px-2 py-1 border border-gray-300 rounded"
+        />
+      </div>
+      <div class="flex-1 overflow-auto p-2">
+        <div
+          v-if="filteredTemplates.length === 0"
+          class="h-full flex items-center justify-center text-slate-500 text-sm"
+        >
+          No hay plantillas aún
+        </div>
+        <ul v-else class="grid grid-cols-1 gap-2">
+          <li
+            v-for="tpl in filteredTemplates"
+            :key="tpl.id"
+            class="p-2 border border-gray-200 rounded bg-white"
+          >
+            {{ tpl.name }}
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
+
+const catalogStore = useCatalogStore()
+const { selectedCatalog, searchText, filteredTemplates } = storeToRefs(catalogStore)
+
+const focusedTab = ref(null)
+const tabElementos = ref(null)
+const tabPlantillas = ref(null)
+
+const selectCatalog = (value) => {
+  catalogStore.setSelectedCatalog(value)
+}
+
+const onTabKeydown = (e, current) => {
+  const order = ['elementos', 'plantillas']
+  const idx = order.indexOf(current)
+  if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+    e.preventDefault()
+    const dir = e.key === 'ArrowRight' ? 1 : -1
+    const next = order[(idx + dir + order.length) % order.length]
+    selectCatalog(next)
+    const refMap = { elementos: tabElementos, plantillas: tabPlantillas }
+    refMap[next].value?.focus()
+  } else if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    selectCatalog(current)
+  }
+}
+
+onMounted(() => {
+  const saved = localStorage.getItem('inventory.selectedCatalog')
+  if (saved === 'plantillas' || saved === 'elementos') {
+    catalogStore.setSelectedCatalog(saved)
+  }
+  localStorage.setItem('inventory.selectedCatalog', selectedCatalog.value)
+})
+
+watch(selectedCatalog, (val) => {
+  localStorage.setItem('inventory.selectedCatalog', val)
+})
 </script>
 
 <style scoped>

--- a/src/inventory-smart/composables/useCanvasBuffer.js
+++ b/src/inventory-smart/composables/useCanvasBuffer.js
@@ -21,6 +21,89 @@ import { useToast } from './useToast'
 // Estado global del buffer (singleton)
 const bufferItems = ref([])
 
+/**
+ * Serializa un elemento con todos sus hijos generando nuevos IDs únicos.
+ * Se utiliza tanto para copiar al buffer/clipboard como para crear plantillas.
+ */
+export const serializeElementForTemplate = (elementoId, offsetX = 0, offsetY = 0) => {
+  const canvasStore = useCanvasStore()
+  const elemento = canvasStore.elementoPorId(elementoId)
+  if (!elemento) {
+    console.warn('⚠️ Elemento no encontrado para clonar:', elementoId)
+    return null
+  }
+
+  const idMapping = new Map()
+  const allClonedElements = new Map()
+  const baseTimestamp = Date.now()
+  let counter = 0
+
+  const cloneElementRecursive = (elem, parentNewId = null, level = 0) => {
+    const uniqueTimestamp = baseTimestamp + counter
+    const randomSuffix = Math.random().toString(36).substr(2, 9)
+    const newId = `${elem.tipo || elem.categoria || 'elemento'}_${uniqueTimestamp}_${randomSuffix}`
+    idMapping.set(elem.id, newId)
+    counter++
+
+    const clonedElement = {
+      ...JSON.parse(JSON.stringify(elem)),
+      id: newId,
+      x: elem.x + offsetX,
+      y: elem.y + offsetY,
+      padre: parentNewId,
+      hijos: [],
+    }
+
+    if (level === 0) {
+      delete clonedElement.plantaId
+      clonedElement.padre = null
+    }
+
+    allClonedElements.set(newId, clonedElement)
+
+    if (elem.hijos && elem.hijos.length > 0) {
+      console.log(`📋 Clonando ${elem.hijos.length} hijos para ${elem.nombre || elem.tipo}`)
+      for (const hijoId of elem.hijos) {
+        const hijo = canvasStore.elementoPorId(hijoId)
+        if (hijo) {
+          const clonedChild = cloneElementRecursive(hijo, newId, level + 1)
+          if (clonedChild) {
+            clonedElement.hijos.push(clonedChild.id)
+          }
+        }
+      }
+    }
+
+    console.log(`📋 Elemento clonado nivel ${level}:`, {
+      original: elem.id,
+      nuevo: newId,
+      nombre: elem.nombre || elem.tipo,
+      hijos: clonedElement.hijos.length,
+      padre: clonedElement.padre,
+    })
+
+    return clonedElement
+  }
+
+  const rootClonedElement = cloneElementRecursive(elemento, null, 0)
+
+  if (rootClonedElement) {
+    console.log('📋 Estructura clonada completa:', {
+      elementoOriginal: elemento.nombre || elemento.tipo,
+      elementosProcesados: idMapping.size,
+      mapeoIds: Array.from(idMapping.entries()),
+    })
+
+    return {
+      rootElement: rootClonedElement,
+      allElements: allClonedElements,
+      idMapping: idMapping,
+    }
+  }
+
+  return null
+}
+
 export const useCanvasBuffer = () => {
   const canvasStore = useCanvasStore()
   const weightValidation = useWeightValidation()
@@ -49,103 +132,12 @@ export const useCanvasBuffer = () => {
           year: 'numeric',
           hour: '2-digit',
           minute: '2-digit',
-          second: '2-digit'
+          second: '2-digit',
         }),
         ...sourceInfo,
       },
       addedToBuffer: currentTimestamp,
     }
-  }
-
-  /**
-   * Clonar elemento con todos sus hijos recursivamente
-   * Genera nuevos IDs únicos para evitar conflictos
-   * Retorna un objeto con el elemento principal y todos los elementos de la estructura
-   */
-  const cloneElementWithChildren = (elementoId, offsetX = 0, offsetY = 0) => {
-    const elemento = canvasStore.elementoPorId(elementoId)
-    if (!elemento) {
-      console.warn('⚠️ Elemento no encontrado para clonar:', elementoId)
-      return null
-    }
-
-    // Mapeo de IDs originales a nuevos IDs y elementos clonados
-    const idMapping = new Map()
-    const allClonedElements = new Map() // ID clonado -> elemento clonado
-    const baseTimestamp = Date.now()
-    let counter = 0
-
-    // Función recursiva para clonar un elemento y sus hijos
-    const cloneElementRecursive = (elem, parentNewId = null, level = 0) => {
-      // Generar nuevo ID único con timestamp incremental y sufijo aleatorio
-      const uniqueTimestamp = baseTimestamp + counter
-      const randomSuffix = Math.random().toString(36).substr(2, 9)
-      const newId = `${elem.tipo || elem.categoria || 'elemento'}_${uniqueTimestamp}_${randomSuffix}`
-      idMapping.set(elem.id, newId)
-      counter++
-
-      // Clonar el elemento
-      const clonedElement = {
-        ...JSON.parse(JSON.stringify(elem)), // Deep clone
-        id: newId,
-        x: elem.x + offsetX,
-        y: elem.y + offsetY,
-        padre: parentNewId, // Asignar nuevo padre si corresponde
-        hijos: [], // Se llenará después con los nuevos IDs
-      }
-
-      // Limpiar propiedades que se manejarán según el contexto
-      if (level === 0) {
-        // Solo para el elemento raíz, limpiar plantaId y padre
-        delete clonedElement.plantaId
-        clonedElement.padre = null
-      }
-
-      // Guardar elemento clonado usando ID clonado como clave
-      allClonedElements.set(newId, clonedElement)
-
-      // Si el elemento tiene hijos, clonarlos recursivamente
-      if (elem.hijos && elem.hijos.length > 0) {
-        console.log(`📋 Clonando ${elem.hijos.length} hijos para ${elem.nombre || elem.tipo}`)
-
-        for (const hijoId of elem.hijos) {
-          const hijo = canvasStore.elementoPorId(hijoId)
-          if (hijo) {
-            const clonedChild = cloneElementRecursive(hijo, newId, level + 1)
-            if (clonedChild) {
-              clonedElement.hijos.push(clonedChild.id)
-            }
-          }
-        }
-      }
-
-      console.log(`📋 Elemento clonado nivel ${level}:`, {
-        original: elem.id,
-        nuevo: newId,
-        nombre: elem.nombre || elem.tipo,
-        hijos: clonedElement.hijos.length,
-        padre: clonedElement.padre
-      })
-
-      return clonedElement
-    }    // Iniciar clonado recursivo
-    const rootClonedElement = cloneElementRecursive(elemento, null, 0)
-
-    if (rootClonedElement) {
-      console.log('📋 Estructura clonada completa:', {
-        elementoOriginal: elemento.nombre || elemento.tipo,
-        elementosProcesados: idMapping.size,
-        mapeoIds: Array.from(idMapping.entries())
-      })
-
-      return {
-        rootElement: rootClonedElement,
-        allElements: allClonedElements,
-        idMapping: idMapping
-      }
-    }
-
-    return null
   }
 
   /**
@@ -186,7 +178,7 @@ export const useCanvasBuffer = () => {
     }
 
     // Clonar la estructura completa
-    const clonedStructure = cloneElementWithChildren(elementoId)
+    const clonedStructure = serializeElementForTemplate(elementoId)
     if (!clonedStructure) {
       console.error('⚠️ Error al clonar la estructura del elemento')
       return false

--- a/src/inventory-smart/stores/catalog.js
+++ b/src/inventory-smart/stores/catalog.js
@@ -6,6 +6,8 @@ export const useCatalogStore = defineStore('catalog', () => {
   const items = ref(ELEMENTOS_PREDEFINIDOS)
   const searchText = ref('')
   const selectedCategory = ref(null)
+  const selectedCatalog = ref('elementos')
+  const templates = ref([])
 
   const catalogContext = ref({ mode: 'root', currentId: undefined, currentType: undefined })
 
@@ -50,14 +52,76 @@ export const useCatalogStore = defineStore('catalog', () => {
     catalogContext.value = ctx
   }
 
+  const filteredTemplates = computed(() => {
+    const q = searchText.value.toLowerCase()
+    return templates.value
+      .filter((t) => t.name.toLowerCase().includes(q))
+      .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt))
+  })
+
+  const setSelectedCatalog = (val) => {
+    selectedCatalog.value = val
+  }
+
+  const addTemplate = (template) => {
+    templates.value.push(template)
+    saveTemplatesToLocalStorage()
+  }
+
+  const removeTemplate = (id) => {
+    const idx = templates.value.findIndex((t) => t.id === id)
+    if (idx !== -1) {
+      templates.value.splice(idx, 1)
+      saveTemplatesToLocalStorage()
+    }
+  }
+
+  const getTemplateByName = (name) =>
+    templates.value.find((t) => t.name.toLowerCase() === name.toLowerCase())
+
+  const saveTemplatesToLocalStorage = () => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('inventory.templates', JSON.stringify(templates.value))
+    }
+  }
+
+  const loadTemplatesFromLocalStorage = () => {
+    if (typeof localStorage === 'undefined') return
+    try {
+      const raw = localStorage.getItem('inventory.templates')
+      if (raw) {
+        templates.value = JSON.parse(raw)
+      }
+    } catch {
+      templates.value = []
+    }
+  }
+
+  loadTemplatesFromLocalStorage()
+
+  const searchTemplates = (query) => {
+    const q = query.toLowerCase()
+    return templates.value.filter((t) => t.name.toLowerCase().includes(q))
+  }
+
   return {
     items,
     searchText,
     selectedCategory,
+    selectedCatalog,
     catalogContext,
     setCatalogContext,
+    setSelectedCatalog,
     allowedTypesForContext,
     baseSystemGuard,
     filteredCatalogItems,
+    templates,
+    filteredTemplates,
+    addTemplate,
+    removeTemplate,
+    getTemplateByName,
+    loadTemplatesFromLocalStorage,
+    saveTemplatesToLocalStorage,
+    searchTemplates,
   }
 })


### PR DESCRIPTION
## Summary
- add store state for selected catalog
- implement responsive accessible catalog switch with query param persistence
- style catalog switch tabs
- remove URL parameter dependency, persist catalog choice in store/localStorage
- prevent duplicate custom elements when re-entering Elementos catalog
- allow saving configured elements as reusable templates with an accessible modal and localStorage persistence

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint' imported from /workspace/canvas-editor/eslint.config.js)*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8485cc88321b321576d4280dac8