### PR TITLE
feat: allow saving elements as templates

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -230,6 +230,99 @@ onUnmounted(() => {
   background: var(--ui-bg-dark);
   border: 1px solid var(--ui-border-dark);
 }
+
+/* ====== INVENTORY: Estilos para el conmutador de Catálogo (Elementos | Plantillas) ======
+   Contexto: pestaña Elementos — controla catálogo visible.
+   NOTA: no mover ni duplicar en otros archivos. Mantener aquí.
+======================================================================================== */
+.catalog-switch {
+  display: flex;
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+}
+
+.catalog-switch--compact {
+  display: none;
+}
+
+.catalog-tab {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--ui-border);
+  border-radius: 9999px;
+  background: var(--ui-bg);
+  color: #334155;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.catalog-tab:hover {
+  background: #f1f5f9;
+}
+
+.catalog-tab.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.catalog-tab.kb-focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+@media (max-width: 479px) {
+  .catalog-switch {
+    display: none;
+  }
+
+  .catalog-switch.catalog-switch--compact {
+    display: block;
+  }
+
+  .catalog-switch--compact select {
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--ui-border);
+    border-radius: 0.375rem;
+  }
+}
+
+/* ====== INVENTORY: Ajustes visuales para equiparar modal 'Guardar como plantilla' con 'Eliminar' ======
+   NOTA: Reusar las mismas clases de botones y layout. Solo correcciones menores aquí.
+======================================================================================================= */
+.modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:1100}
+.modal{width:420px;max-width:92vw;background:#fff;border-radius:10px;box-shadow:0 10px 30px rgba(0,0,0,.25);overflow:hidden}
+.modal-header{display:flex;justify-content:space-between;align-items:center;padding:12px 16px;border-bottom:1px solid #e5e7eb}
+.modal-header .title{font-size:16px;font-weight:600;color:#111827}
+.modal-header .close{background:transparent;border:none;font-size:20px;cursor:pointer;color:#6b7280}
+.modal-body{padding:16px;color:#374151}
+.modal-footer{display:flex;gap:8px;justify-content:flex-end;padding:12px 16px;border-top:1px solid #e5e7eb}
+.btn{border:1px solid #e5e7eb;background:#fff;border-radius:6px;padding:8px 12px;font-size:14px;cursor:pointer}
+.btn-primary{background:#2563eb;color:#fff;border-color:#2563eb}
+.btn-primary:hover{background:#1d4ed8}
+.btn:disabled{opacity:.6;cursor:not-allowed}
+.btn:focus-visible{outline:2px solid #2563eb;outline-offset:2px}
+.template-modal__row { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
+.template-modal__label { font-weight: 600; font-size: 0.95rem; }
+.template-modal__input,
+.template-modal__textarea {
+  width: 100%; border: 1px solid var(--border-color, #e3e6eb); border-radius: 8px;
+  padding: 8px 10px; background: #fff; font: inherit;
+}
+.template-modal__input:focus,
+.template-modal__textarea:focus {
+  outline: none; box-shadow: 0 0 0 3px rgba(38,132,255,.25);
+}
+.template-modal__summary {
+  font-size: 0.9rem; color: var(--text-muted, #5b6473);
+  background: var(--bg-muted, #f7f8fa); border: 1px solid var(--border-color, #e3e6eb);
+  border-radius: 8px; padding: 10px;
+}
+
+/* ====== INVENTORY: Ajustes visuales para Catálogo de Plantillas (alineado a Elementos) =========
+   NOTA: Reusar EXACTAS clases de tarjetas/inputs ya usadas por Elementos. Solo shims menores aquí.
+=============================================================================================== */
+.template-modal__error { color: #c62828; font-size: 0.85rem; }
 </style>
 
 <style scoped>

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -627,8 +627,67 @@
       :isLocked="ctxIsLocked"
       @lockToggle="() => toggleLock(ctxElementId)"
       @delete="() => onDelete(ctxElementId)"
+      @saveTemplate="() => openTemplateModal(ctxElementId)"
       @close="ctx.close()"
     />
+
+    <!-- Modal Guardar como plantilla -->
+    <div
+      v-if="templateModalOpen"
+      class="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="templateModalTitle"
+      @click.self="closeTemplateModal"
+    >
+      <form class="modal" @submit.prevent="saveTemplate">
+        <header class="modal-header">
+          <h3 id="templateModalTitle" class="title">Guardar como plantilla</h3>
+          <button type="button" class="close" @click="closeTemplateModal" aria-label="Cerrar">×</button>
+        </header>
+        <section class="modal-body">
+          <div class="template-modal__row">
+            <label for="templateName" class="template-modal__label">Nombre de la plantilla</label>
+            <input
+              id="templateName"
+              ref="templateNameInput"
+              v-model="templateName"
+              class="template-modal__input"
+              type="text"
+              maxlength="80"
+              required
+            />
+            <p v-if="templateError" class="template-modal__error">{{ templateError }}</p>
+          </div>
+          <div class="template-modal__row">
+            <div class="template-modal__summary" id="templateSummary">
+              <div>Tipo: {{ templateSummary.elementType }}</div>
+              <div>
+                Dimensiones: {{ templateSummary.width }}×{{ templateSummary.depth }}×{{
+                  templateSummary.height
+                }}
+              </div>
+              <div>Hijos: {{ templateSummary.childrenCount }}</div>
+            </div>
+          </div>
+          <div class="template-modal__row">
+            <label for="templateNotes" class="template-modal__label">Notas</label>
+            <textarea
+              id="templateNotes"
+              v-model="templateNotes"
+              class="template-modal__textarea"
+              rows="3"
+            ></textarea>
+          </div>
+        </section>
+        <footer class="modal-footer">
+          <button type="button" class="btn" @click="closeTemplateModal">Cancelar</button>
+          <button type="submit" class="btn btn-primary" :disabled="!templateName.trim() || isSaving">
+            Guardar
+          </button>
+        </footer>
+      </form>
+    </div>
 
   <!-- Información de zoom, vista y dimensiones -->
   <div ref="canvasInfoRef" class="canvas-info" :style="canvasInfoStyle">
@@ -773,6 +832,7 @@ import { useContextMenu } from '@/inventory-smart/composables/useContextMenu'
 import { useDeleteElement } from '@/inventory-smart/composables/useDeleteElement'
 import { useConfirmDialog } from '@/inventory-smart/composables/useConfirmDialog'
 import { useWeightValidation } from '@/inventory-smart/composables/useWeightValidation'
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import { applyEdgeConstraint } from '@/inventory-smart/utils/edgeConstraint'
 import { resetEdgeState } from '@/inventory-smart/composables/useEdgeState'
 import { finalizePlacement } from '@/inventory-smart/utils/finalizeDrag'
@@ -909,6 +969,89 @@ const { visible: ctxVisible, x: ctxX, y: ctxY, isLocked: ctxIsLocked, elementId:
 const { deleteSelected } = useDeleteElement()
 const confirmDialog = useConfirmDialog()
 const weightValidation = useWeightValidation()
+const catalogStore = useCatalogStore()
+
+const templateModalOpen = ref(false)
+const templateName = ref('')
+const templateNotes = ref('')
+const templateError = ref('')
+const templateSummary = ref({ elementType: '', width: 0, height: 0, depth: 0, childrenCount: 0 })
+const templatePayload = ref(null)
+const templateNameInput = ref(null)
+const isSaving = ref(false)
+
+const openTemplateModal = (elementId) => {
+  const el = canvasStore.elementoPorId(elementId)
+  if (!el) return
+  const serialized = buffer.serializeElementForTemplate(elementId)
+  if (!serialized) return
+  const elementsArr = Array.from(serialized.allElements.values())
+  templatePayload.value = {
+    rootId: serialized.rootElement.id,
+    elements: elementsArr,
+  }
+  templateSummary.value = {
+    elementType: serialized.rootElement.tipo || '',
+    width: serialized.rootElement.dimensiones?.ancho || 0,
+    depth: serialized.rootElement.dimensiones?.largo || 0,
+    height: serialized.rootElement.dimensiones?.alto || 0,
+    childrenCount: elementsArr.length - 1,
+  }
+  templateName.value = el.nombre || ''
+  templateNotes.value = ''
+  templateError.value = ''
+  templateModalOpen.value = true
+  nextTick(() => templateNameInput.value?.focus?.())
+  ctx.close()
+}
+
+const closeTemplateModal = () => {
+  templateModalOpen.value = false
+}
+
+const saveTemplate = () => {
+  if (isSaving.value) return
+  const name = templateName.value.trim()
+  if (!name) {
+    templateError.value = 'El nombre es obligatorio'
+    return
+  }
+  if (catalogStore.getTemplateByName(name)) {
+    templateError.value = 'Ya existe una plantilla con ese nombre'
+    return
+  }
+  isSaving.value = true
+  const now = new Date().toISOString()
+  const template = {
+    id: `tpl_${Date.now().toString(36)}`,
+    name,
+    createdAt: now,
+    updatedAt: now,
+    meta: {
+      elementType: templateSummary.value.elementType,
+      width: templateSummary.value.width,
+      height: templateSummary.value.height,
+      depth: templateSummary.value.depth,
+      childrenCount: templateSummary.value.childrenCount,
+    },
+    payload: templatePayload.value,
+    notes: templateNotes.value.trim() || undefined,
+    tags: [],
+  }
+  catalogStore.addTemplate(template)
+  showToast('Plantilla guardada', 'success')
+  templateModalOpen.value = false
+  isSaving.value = false
+}
+
+const onTemplateKeydown = (e) => {
+  if (e.key === 'Escape') closeTemplateModal()
+}
+
+watch(templateModalOpen, (val) => {
+  if (val) window.addEventListener('keydown', onTemplateKeydown)
+  else window.removeEventListener('keydown', onTemplateKeydown)
+})
 
 // Object snapping
 const {
@@ -1832,6 +1975,8 @@ const handleDrop = (e) => {
       createElementFromDrop(data, e)
     } else if (data.tipo === 'buffer-element') {
       createElementFromBuffer(data, e)
+    } else if (data.tipo === 'plantilla-catalogo') {
+      createElementFromTemplate(data, e)
     }
   } catch (error) {
     console.error('Error procesando drop:', error)
@@ -2520,6 +2665,14 @@ const createElementFromBuffer = (data, dropEvent) => {
     )
     // Seleccionar el elemento recién pegado
     canvasStore.seleccionarElemento(newElementId)
+  }
+}
+
+const createElementFromTemplate = (data, dropEvent) => {
+  const pos = getWorldCoordinatesFromPointer(dropEvent)
+  const newId = buffer.pasteFromSerialized(data.payload, pos)
+  if (!newId) {
+    showToast('No se pudo insertar la plantilla', 'error')
   }
 }
 

--- a/src/inventory-smart/components/ElementosCatalogo.vue
+++ b/src/inventory-smart/components/ElementosCatalogo.vue
@@ -389,7 +389,11 @@ onMounted(() => {
   const elementosGuardados = localStorage.getItem('elementos-personalizados')
   if (elementosGuardados) {
     try {
-      JSON.parse(elementosGuardados).forEach((el) => items.value.push(el))
+      JSON.parse(elementosGuardados).forEach((el) => {
+        if (!items.value.some((existing) => existing.id === el.id)) {
+          items.value.push(el)
+        }
+      })
     } catch (error) {
       console.error('Error cargando elementos personalizados:', error)
     }

--- a/src/inventory-smart/components/SpeedDialContext.vue
+++ b/src/inventory-smart/components/SpeedDialContext.vue
@@ -11,28 +11,22 @@
     @contextmenu.prevent
   >
     <button
-      ref="itemRefs[0]"
+      v-for="(item, i) in visibleItems"
+      :key="i"
+      :ref="el => (itemRefs[i] = el)"
       class="sdx-item"
+      :class="item.class"
       role="menuitem"
-      :aria-label="isLocked ? 'Desbloquear' : 'Bloquear'"
-      @click="emitLock"
+      :aria-label="item.aria"
+      @click="item.action"
     >
-      {{ isLocked ? 'Desbloquear' : 'Bloquear' }}
-    </button>
-    <button
-      ref="itemRefs[1]"
-      class="sdx-item sdx-danger"
-      role="menuitem"
-      aria-label="Eliminar"
-      @click="emitDelete"
-    >
-      Eliminar
+      {{ item.label }}
     </button>
   </div>
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onBeforeUnmount, nextTick, defineOptions } from 'vue'
+import { ref, watch, onMounted, onBeforeUnmount, nextTick, defineOptions, computed } from 'vue'
 
 defineOptions({ name: 'SpeedDialContext' })
 
@@ -41,11 +35,13 @@ const props = defineProps({
   x: { type: Number, default: 0 },
   y: { type: Number, default: 0 },
   isLocked: { type: Boolean, default: false },
+  showLock: { type: Boolean, default: true },
+  showSaveTemplate: { type: Boolean, default: true },
 })
-const emit = defineEmits(['lockToggle', 'delete', 'close'])
+const emit = defineEmits(['lockToggle', 'delete', 'saveTemplate', 'close'])
 
 const menuRef = ref(null)
-const itemRefs = [ref(null), ref(null)]
+const itemRefs = []
 const focusedIndex = ref(0)
 
 const pos = ref({ left: 0, top: 0 })
@@ -62,16 +58,48 @@ const clampToViewport = () => {
   pos.value = { left, top }
 }
 
-watch(() => [props.visible, props.x, props.y], async () => {
-  await nextTick()
-  clampToViewport()
-  if (props.visible) {
-    focusedIndex.value = 0
-    openedAt.value = (typeof performance !== 'undefined' ? performance.now() : Date.now())
-    await nextTick()
-    itemRefs[0].value?.focus?.()
+const visibleItems = computed(() => {
+  const items = []
+  if (props.showLock) {
+    items.push({
+      label: props.isLocked ? 'Desbloquear' : 'Bloquear',
+      action: emitLock,
+      aria: props.isLocked ? 'Desbloquear' : 'Bloquear',
+      class: '',
+    })
   }
-}, { immediate: true })
+  if (props.showSaveTemplate) {
+    items.push({
+      label: 'Guardar como plantilla',
+      action: emitSaveTemplate,
+      aria: 'Guardar como plantilla',
+      class: '',
+    })
+  }
+  items.push({
+    label: 'Eliminar',
+    action: emitDelete,
+    aria: 'Eliminar',
+    class: 'sdx-danger',
+  })
+  return items
+})
+
+watch(
+  () => [props.visible, props.x, props.y, visibleItems.value.length],
+  async () => {
+    await nextTick()
+    clampToViewport()
+    if (props.visible) {
+      focusedIndex.value = 0
+      openedAt.value =
+        typeof performance !== 'undefined' ? performance.now() : Date.now()
+      await nextTick()
+      itemRefs[0]?.focus?.()
+    }
+  },
+  { immediate: true }
+)
 
 const onGlobalClick = (e) => {
   if (!props.visible) return
@@ -105,13 +133,12 @@ onBeforeUnmount(() => {
 const onKeydown = (e) => {
   if (e.key === 'ArrowDown') {
     focusedIndex.value = (focusedIndex.value + 1) % itemRefs.length
-    itemRefs[focusedIndex.value].value?.focus?.()
+    itemRefs[focusedIndex.value]?.focus?.()
   } else if (e.key === 'ArrowUp') {
     focusedIndex.value = (focusedIndex.value - 1 + itemRefs.length) % itemRefs.length
-    itemRefs[focusedIndex.value].value?.focus?.()
+    itemRefs[focusedIndex.value]?.focus?.()
   } else if (e.key === 'Enter' || e.key === ' ') {
-    if (focusedIndex.value === 0) emitLock()
-    else emitDelete()
+    visibleItems.value[focusedIndex.value]?.action()
   } else if (e.key === 'Escape') {
     emit('close')
   }
@@ -119,6 +146,9 @@ const onKeydown = (e) => {
 
 const emitLock = () => {
   emit('lockToggle')
+}
+const emitSaveTemplate = () => {
+  emit('saveTemplate')
 }
 const emitDelete = () => {
   emit('delete')

--- a/src/inventory-smart/components/tabs/ElementosTab.vue
+++ b/src/inventory-smart/components/tabs/ElementosTab.vue
@@ -6,15 +6,274 @@
 
 <template>
   <div class="h-full flex flex-col">
-    <!-- Contenido del catálogo -->
-    <div class="flex-1 overflow-hidden">
+    <div class="p-2">
+      <!-- Conmutador Catálogo de Elementos | Catálogo de Plantillas -->
+      <div
+        class="catalog-switch"
+        role="tablist"
+        aria-label="Cambiar catálogo"
+      >
+        <button
+          ref="tabElementos"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'elementos',
+            'kb-focus': focusedTab === 'elementos',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'elementos'"
+          :tabindex="selectedCatalog === 'elementos' ? 0 : -1"
+          @click="selectCatalog('elementos')"
+          @keydown="onTabKeydown($event, 'elementos')"
+          @focus="focusedTab = 'elementos'"
+          @blur="focusedTab = null"
+        >
+          📦 Catálogo de Elementos
+        </button>
+        <button
+          ref="tabPlantillas"
+          class="catalog-tab"
+          :class="{
+            'is-active': selectedCatalog === 'plantillas',
+            'kb-focus': focusedTab === 'plantillas',
+          }"
+          role="tab"
+          :aria-selected="selectedCatalog === 'plantillas'"
+          :tabindex="selectedCatalog === 'plantillas' ? 0 : -1"
+          @click="selectCatalog('plantillas')"
+          @keydown="onTabKeydown($event, 'plantillas')"
+          @focus="focusedTab = 'plantillas'"
+          @blur="focusedTab = null"
+        >
+          📝 Catálogo de Plantillas
+        </button>
+      </div>
+
+      <!-- Fallback móvil: dropdown -->
+      <div class="catalog-switch catalog-switch--compact">
+        <label for="catalogSelect" class="sr-only">Catálogo</label>
+        <select
+          id="catalogSelect"
+          v-model="selectedCatalog"
+          aria-label="Catálogo"
+        >
+          <option value="elementos">📦 Catálogo de Elementos</option>
+          <option value="plantillas">📝 Catálogo de Plantillas</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Contenido dinámico según catálogo -->
+    <div
+      v-if="selectedCatalog === 'elementos'"
+      class="flex-1 overflow-hidden"
+    >
       <ElementosCatalogo />
+    </div>
+    <div
+      v-else
+      class="flex-1 overflow-hidden flex flex-col"
+    >
+      <div class="p-4 border-b">
+        <div class="relative">
+          <input
+            v-model="searchText"
+            type="text"
+            placeholder="Buscar plantillas..."
+            class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-100"
+          />
+          <svg
+            class="absolute left-3 top-2.5 h-5 w-5 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+      </div>
+      <div class="flex-1 overflow-y-auto p-4">
+        <div
+          v-if="filteredTemplates.length === 0"
+          class="h-full flex items-center justify-center text-slate-500 text-sm"
+        >
+          No hay plantillas aún
+        </div>
+        <div v-else class="grid grid-cols-1 gap-3">
+          <div
+            v-for="tpl in filteredTemplates"
+            :key="tpl.id"
+            :draggable="true"
+            @dragstart="onTemplateDragStart(tpl, $event)"
+            @dragend="onTemplateDragEnd"
+            @contextmenu.prevent="openTplContext(tpl, $event)"
+            tabindex="0"
+            class="group relative bg-white border border-gray-200 rounded-lg p-3 cursor-grab mb-3 hover:shadow-md transition-all duration-200 border-l-4 hover:scale-[1.02]"
+            :style="{ borderLeftColor: '#3b82f6' }"
+          >
+            <div class="elemento-preview flex items-center justify-center mb-3">
+              <div
+                class="preview-shape rounded flex items-center justify-center relative shadow-sm border border-white/20 w-12 h-8"
+                :style="{ backgroundColor: '#3b82f6' }"
+              >
+                <svg class="w-4 h-4 text-white" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M4 4h16v16H4z" />
+                </svg>
+              </div>
+            </div>
+            <div class="elemento-info space-y-1">
+              <h3 class="font-semibold text-sm text-gray-800 mb-1">{{ tpl.name }}</h3>
+              <p class="text-xs text-gray-500 mb-2">
+                {{ tpl.notes || `Plantilla guardada • ${formatDate(tpl.createdAt)}` }}
+              </p>
+              <div class="elemento-specs space-y-1">
+                <div class="spec-item flex justify-between text-xs">
+                  <span class="spec-label text-gray-500 font-medium">Dim:</span>
+                  <span class="spec-value text-gray-700">
+                    {{ formatDims(tpl.meta) }}
+                  </span>
+                </div>
+                <div class="spec-item flex justify-between text-xs">
+                  <span class="spec-label text-gray-500 font-medium">Peso:</span>
+                  <span class="spec-value text-gray-700">{{ tpl.meta?.weight || '—' }}</span>
+                </div>
+                <div class="spec-item flex justify-between text-xs">
+                  <span class="spec-label text-gray-500 font-medium">Ubic:</span>
+                  <span class="spec-value text-gray-700">{{ tpl.meta?.location || '—' }}</span>
+                </div>
+              </div>
+              <div class="mt-2 flex gap-1">
+                <span class="inline-block px-2 py-1 text-xs rounded-full bg-gray-100 text-gray-700">Plantillas</span>
+                <span
+                  v-for="tag in tpl.tags"
+                  :key="tag"
+                  class="inline-block px-2 py-1 text-xs rounded-full bg-gray-100 text-gray-700"
+                >
+                  {{ tag }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <SpeedDialContext
+        :visible="tplContext.visible"
+        :x="tplContext.x"
+        :y="tplContext.y"
+        :isLocked="false"
+        :showLock="false"
+        :showSaveTemplate="false"
+        @delete="onTemplateDelete"
+        @close="tplContext.visible = false"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted, watch, computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import ElementosCatalogo from '@/inventory-smart/components/ElementosCatalogo.vue'
+import SpeedDialContext from '@/inventory-smart/components/SpeedDialContext.vue'
+
+const catalogStore = useCatalogStore()
+const { selectedCatalog, searchText, templates } = storeToRefs(catalogStore)
+
+const focusedTab = ref(null)
+const tabElementos = ref(null)
+const tabPlantillas = ref(null)
+
+const selectCatalog = (value) => {
+  catalogStore.setSelectedCatalog(value)
+}
+
+const onTabKeydown = (e, current) => {
+  const order = ['elementos', 'plantillas']
+  const idx = order.indexOf(current)
+  if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+    e.preventDefault()
+    const dir = e.key === 'ArrowRight' ? 1 : -1
+    const next = order[(idx + dir + order.length) % order.length]
+    selectCatalog(next)
+    const refMap = { elementos: tabElementos, plantillas: tabPlantillas }
+    refMap[next].value?.focus()
+  } else if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    selectCatalog(current)
+  }
+}
+
+onMounted(() => {
+  const saved = localStorage.getItem('inventory.selectedCatalog')
+  if (saved === 'plantillas' || saved === 'elementos') {
+    catalogStore.setSelectedCatalog(saved)
+  }
+  localStorage.setItem('inventory.selectedCatalog', selectedCatalog.value)
+  catalogStore.loadTemplatesFromLocalStorage()
+})
+
+watch(selectedCatalog, (val) => {
+  localStorage.setItem('inventory.selectedCatalog', val)
+})
+
+const filteredTemplates = computed(() =>
+  catalogStore.searchTemplates(searchText.value)
+)
+
+const onTemplateDragStart = (tpl, event) => {
+  const dragData = {
+    tipo: 'plantilla-catalogo',
+    plantillaId: tpl.id,
+    payload: tpl.payload,
+  }
+  event.dataTransfer.setData('application/json', JSON.stringify(dragData))
+  event.dataTransfer.effectAllowed = 'copy'
+  const card = event.currentTarget
+  if (card && card.classList) card.classList.add('opacity-50', 'scale-95')
+}
+
+const onTemplateDragEnd = (event) => {
+  const card = event.currentTarget
+  if (card && card.classList) card.classList.remove('opacity-50', 'scale-95')
+}
+
+const tplContext = ref({ visible: false, x: 0, y: 0, tpl: null })
+
+const openTplContext = (tpl, event) => {
+  tplContext.value = {
+    visible: true,
+    x: event.clientX,
+    y: event.clientY,
+    tpl,
+  }
+}
+
+const onTemplateDelete = () => {
+  const tpl = tplContext.value.tpl
+  if (tpl) catalogStore.removeTemplate(tpl.id)
+  tplContext.value.visible = false
+}
+
+const formatDims = (meta) => {
+  const w = meta?.width || 0
+  const h = meta?.height || 0
+  const d = meta?.depth || 0
+  return `${w}x${h}${d ? `x${d}` : ''}`
+}
+
+const formatDate = (iso) => {
+  try {
+    return new Date(iso).toLocaleDateString()
+  } catch {
+    return ''
+  }
+}
 </script>
 
 <style scoped>

--- a/src/inventory-smart/composables/useCanvasBuffer.js
+++ b/src/inventory-smart/composables/useCanvasBuffer.js
@@ -58,11 +58,11 @@ export const useCanvasBuffer = () => {
   }
 
   /**
-   * Clonar elemento con todos sus hijos recursivamente
-   * Genera nuevos IDs únicos para evitar conflictos
-   * Retorna un objeto con el elemento principal y todos los elementos de la estructura
+   * Serializar un elemento con todos sus hijos recursivamente.
+   * Genera copias profundas y nuevos IDs únicos para evitar conflictos.
+   * Retorna un objeto con el elemento raíz y un mapa de todos los elementos.
    */
-  const cloneElementWithChildren = (elementoId, offsetX = 0, offsetY = 0) => {
+  const serializeElementForTemplate = (elementoId, offsetX = 0, offsetY = 0) => {
     const elemento = canvasStore.elementoPorId(elementoId)
     if (!elemento) {
       console.warn('⚠️ Elemento no encontrado para clonar:', elementoId)
@@ -186,7 +186,7 @@ export const useCanvasBuffer = () => {
     }
 
     // Clonar la estructura completa
-    const clonedStructure = cloneElementWithChildren(elementoId)
+    const clonedStructure = serializeElementForTemplate(elementoId)
     if (!clonedStructure) {
       console.error('⚠️ Error al clonar la estructura del elemento')
       return false
@@ -539,6 +539,28 @@ export const useCanvasBuffer = () => {
   }
 
   /**
+   * Pegar estructura desde un payload serializado (plantillas)
+   */
+  const pasteFromSerialized = (payload, position = { x: 100, y: 100 }) => {
+    if (!payload || !payload.rootId || !Array.isArray(payload.elements)) {
+      console.warn('⚠️ Payload de plantilla inválido')
+      return false
+    }
+
+    const allElementsMap = new Map()
+    for (const el of payload.elements) {
+      allElementsMap.set(el.id, { ...JSON.parse(JSON.stringify(el)) })
+    }
+
+    const { newElementsMap, newIdMapping } = regenerateUniqueIds(allElementsMap)
+    const newRootId = newIdMapping.get(payload.rootId)
+    const newRootElement = newElementsMap.get(newRootId)
+    if (!newRootElement) return false
+
+    return pasteStructureRecursive(newRootElement, position, newElementsMap)
+  }
+
+  /**
    * Remover elemento del buffer
    */
   const removeFromBuffer = (bufferItemId) => {
@@ -613,6 +635,7 @@ export const useCanvasBuffer = () => {
     addToBuffer,
     copyToBuffer,
     pasteFromBuffer,
+    pasteFromSerialized,
     removeFromBuffer,
     clearBuffer,
 
@@ -621,5 +644,8 @@ export const useCanvasBuffer = () => {
     getBufferItems,
     isInBuffer,
     getBufferInfo,
+
+    // Utilidades
+    serializeElementForTemplate,
   }
 }

--- a/src/inventory-smart/stores/catalog.js
+++ b/src/inventory-smart/stores/catalog.js
@@ -6,6 +6,8 @@ export const useCatalogStore = defineStore('catalog', () => {
   const items = ref(ELEMENTOS_PREDEFINIDOS)
   const searchText = ref('')
   const selectedCategory = ref(null)
+  const selectedCatalog = ref('elementos')
+  const templates = ref([])
 
   const catalogContext = ref({ mode: 'root', currentId: undefined, currentType: undefined })
 
@@ -50,12 +52,72 @@ export const useCatalogStore = defineStore('catalog', () => {
     catalogContext.value = ctx
   }
 
+  const setSelectedCatalog = (val) => {
+    selectedCatalog.value = val
+  }
+
+  const addTemplate = (template) => {
+    templates.value.push(template)
+    saveTemplatesToLocalStorage()
+  }
+
+  const removeTemplate = (id) => {
+    const idx = templates.value.findIndex((t) => t.id === id)
+    if (idx !== -1) {
+      templates.value.splice(idx, 1)
+      saveTemplatesToLocalStorage()
+    }
+  }
+
+  const loadTemplatesFromLocalStorage = () => {
+    try {
+      const raw = localStorage.getItem('inventory.templates')
+      templates.value = raw ? JSON.parse(raw) : []
+    } catch {
+      templates.value = []
+    }
+  }
+
+  const saveTemplatesToLocalStorage = () => {
+    try {
+      localStorage.setItem('inventory.templates', JSON.stringify(templates.value))
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const getTemplateByName = (name) => {
+    const n = name?.toLowerCase?.() || ''
+    return templates.value.find((t) => t.name?.toLowerCase?.() === n)
+  }
+
+  const searchTemplates = (query) => {
+    const q = query?.toLowerCase?.() || ''
+    return templates.value
+      .slice()
+      .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt))
+      .filter(
+        (t) =>
+          t.name?.toLowerCase?.().includes(q) ||
+          t.notes?.toLowerCase?.().includes(q)
+      )
+  }
+
   return {
     items,
     searchText,
     selectedCategory,
+    selectedCatalog,
+    templates,
     catalogContext,
     setCatalogContext,
+    setSelectedCatalog,
+    addTemplate,
+    removeTemplate,
+    loadTemplatesFromLocalStorage,
+    saveTemplatesToLocalStorage,
+    getTemplateByName,
+    searchTemplates,
     allowedTypesForContext,
     baseSystemGuard,
     filteredCatalogItems,


### PR DESCRIPTION
## Summary
- add persistent template storage in catalog store
- save elements as templates via context menu with modal input
- list and drag templates in catalog with search
- align "Guardar como plantilla" modal with the existing delete-element modal styles
- match template catalog visuals and context menu behavior with elements catalog

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint' imported from /workspace/canvas-editor/eslint.config.js)*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8485cc88321b321576d4280dac8