### PR TITLE
feat: include template catalog in canvas export

### DIFF
--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -1136,7 +1136,8 @@ export const useCanvasStore = defineStore('canvas', () => {
   const serialize = () => {
     const state = {
       plantas: plantas.value,
-      elementos: elementos.value
+      elementos: elementos.value,
+      plantillasCatalogo: catalogStore.templates.value
     }
     return _serialize(state)
   }

--- a/src/inventory-smart/composables/useStatePersistence.js
+++ b/src/inventory-smart/composables/useStatePersistence.js
@@ -11,6 +11,16 @@
  * - Manejo de errores en operaciones de persistencia
  */
 
+import { EXPORT_FORMAT_VERSION } from '@/inventory-smart/utils/constants'
+import {
+  exportTemplatesToDTO,
+  importTemplatesFromDTO,
+} from '@/inventory-smart/modules/templates/templates.serializer'
+import {
+  assertValidTemplatesDTO,
+  validateMetaVersion,
+} from '@/inventory-smart/modules/templates/templates.validator'
+
 export const useStatePersistence = () => {
   /**
    * Serializa el estado completo del canvas a JSON
@@ -36,7 +46,7 @@ export const useStatePersistence = () => {
     const serializedState = {
       // Información básica del canvas
       meta: {
-        version: '1.0.0',
+        version: EXPORT_FORMAT_VERSION,
         timestamp: new Date().toISOString(),
         app: 'inventory-smart',
         ...(includeMetrics && {
@@ -133,6 +143,9 @@ export const useStatePersistence = () => {
           propiedadesPersonalizadas: elemento.propiedadesPersonalizadas || {},
         }
       }),
+
+      // Catálogo de plantillas
+      plantillasCatalogo: exportTemplatesToDTO(state.plantillasCatalogo || [])
     }
 
     return JSON.stringify(serializedState, null, 2)
@@ -230,7 +243,8 @@ export const useStatePersistence = () => {
       elementosHuerfanos: 0,
       relacionesPadreHijo: 0,
       plantasConElementos: 0,
-      promedioElementosPorPlanta: 0
+      promedioElementosPorPlanta: 0,
+      totalPlantillas: state.plantillasCatalogo?.length || 0
     }
 
     // Analizar elementos
@@ -304,6 +318,15 @@ export const useStatePersistence = () => {
       }
 
       const state = validation.data || JSON.parse(jsonString)
+
+      if (Array.isArray(state.plantillasCatalogo)) {
+        try {
+          assertValidTemplatesDTO(state.plantillasCatalogo)
+          importTemplatesFromDTO(state.plantillasCatalogo)
+        } catch (e) {
+          console.warn('⚠️ Error al importar plantillasCatalogo:', e.message)
+        }
+      }
 
       // === LIMPIEZA Y PREPARACIÓN ===
       storeActions.clearState()
@@ -567,6 +590,10 @@ export const useStatePersistence = () => {
         validationResult.errors.push('Falta la propiedad "elementos"')
       }
 
+      if (data.plantillasCatalogo && !Array.isArray(data.plantillasCatalogo)) {
+        validationResult.errors.push('"plantillasCatalogo" debe ser un array')
+      }
+
       if (validationResult.errors.length > 0) {
         return {
           valid: false,
@@ -757,7 +784,10 @@ export const useStatePersistence = () => {
         app: data.meta?.app || 'desconocida',
         elementosPorTipo: {},
         elementosConHijos: 0,
-        elementosHuerfanos: 0
+        elementosHuerfanos: 0,
+        totalPlantillas: Array.isArray(data.plantillasCatalogo)
+          ? data.plantillasCatalogo.length
+          : 0
       }
 
       // Estadísticas de elementos
@@ -779,6 +809,9 @@ export const useStatePersistence = () => {
           }
         })
       }
+
+      // Validar versión meta
+      validateMetaVersion(data.meta?.version, validationResult.warnings)
 
       // Determinar si es válido
       validationResult.valid = validationResult.errors.length === 0

--- a/src/inventory-smart/modules/templates/templates.serializer.ts
+++ b/src/inventory-smart/modules/templates/templates.serializer.ts
@@ -1,0 +1,185 @@
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
+
+export type TemplateNodeDTO = {
+  id: string
+  tipo: 'elementos' | 'contenedores'
+  categoria: string
+  nombre: string
+  dimensiones: { ancho: number; largo: number; alto: number }
+  offsets?: { dx: number; dy: number }
+  x?: number
+  y?: number
+  canvas?: { width: number; height: number }
+  color?: string
+  colorBase?: string
+  forma?: string
+  ubicacion?: string
+  alturaRespectoAlSuelo?: number
+  pesoMaximo?: number
+  volumenMaximo?: number
+  dimensionLock?: boolean
+  systemTypeKey?: string
+  uso?: { volumen: number; peso: number }
+  descripcion?: string
+  contenedores?: string[]
+  hijos: string[]
+  padre: string | null
+  etiquetas: string[]
+}
+
+export type TemplateDTO = {
+  id: string
+  nombre: string
+  descripcion: string | null
+  categoria: string | null
+  tags: string[]
+  version: '1.0.0'
+  meta: any
+  preview: { bbox: { width: number; height: number } }
+  payload: {
+    root: string
+    layout: { mode: 'relative' | 'absoluteSnapshot'; origin: 'rootTopLeft' }
+    nodos: TemplateNodeDTO[]
+  }
+  auditoria: { createdAt: string; updatedAt: string }
+}
+
+export function exportTemplatesToDTO(stateTemplates: any[]): TemplateDTO[] {
+  if (!Array.isArray(stateTemplates)) return []
+  return stateTemplates.map((raw) => {
+    const tpl = JSON.parse(JSON.stringify(raw))
+    const elements = tpl.payload?.elements || []
+    const rootId = tpl.payload?.rootId
+    return {
+      id: tpl.id,
+      nombre: tpl.name,
+      descripcion: tpl.notes ?? null,
+      categoria: elements[0]?.categoria ?? null,
+      tags: tpl.tags || [],
+      version: '1.0.0',
+      meta: tpl.meta || {},
+      preview: { bbox: guessPreviewBBox(elements, rootId) },
+      payload: {
+        root: rootId,
+        layout: { mode: 'relative', origin: 'rootTopLeft' },
+        nodos: toRelativeLayout(elements, rootId),
+      },
+      auditoria: { createdAt: tpl.createdAt, updatedAt: tpl.updatedAt },
+    }
+  })
+}
+
+export function importTemplatesFromDTO(dtos: TemplateDTO[] | undefined): void {
+  if (!Array.isArray(dtos)) return
+  const catalog = useCatalogStore()
+  dtos.forEach((dto) => {
+    const layoutMode = dto.payload?.layout?.mode || 'relative'
+    const elements = dto.payload.nodos.map((n) => {
+      const x =
+        layoutMode === 'relative' ? n.offsets?.dx ?? 0 : n.x ?? 0
+      const y =
+        layoutMode === 'relative' ? n.offsets?.dy ?? 0 : n.y ?? 0
+      return {
+        id: n.id,
+        nombre: n.nombre,
+        tipo: n.tipo,
+        categoria: n.categoria,
+        dimensiones: n.dimensiones,
+        x,
+        y,
+        canvas: n.canvas,
+        color: n.color,
+        colorBase: n.colorBase,
+        forma: n.forma,
+        ubicacion: n.ubicacion,
+        alturaRespectoAlSuelo: n.alturaRespectoAlSuelo,
+        pesoMaximo: n.pesoMaximo,
+        volumenMaximo: n.volumenMaximo,
+        dimensionLock: n.dimensionLock,
+        systemTypeKey: n.systemTypeKey,
+        uso: n.uso,
+        descripcion: n.descripcion,
+        contenedores: n.contenedores,
+        hijos: n.hijos || [],
+        padre: n.padre ?? null,
+        etiquetas: n.etiquetas || [],
+      }
+    })
+    const template = {
+      id: dto.id,
+      name: dto.nombre,
+      createdAt: dto.auditoria?.createdAt,
+      updatedAt: dto.auditoria?.updatedAt,
+      meta: dto.meta,
+      payload: { rootId: dto.payload.root, elements },
+      notes: dto.descripcion ?? undefined,
+      tags: dto.tags || [],
+    }
+    const idx = catalog.templates.findIndex((t) => t.id === template.id)
+    if (idx !== -1) {
+      catalog.templates[idx] = template
+    } else {
+      catalog.templates.push(template)
+    }
+  })
+  catalog.saveTemplatesToLocalStorage()
+}
+
+export function toRelativeLayout(
+  elements: any[],
+  rootId: string,
+): TemplateNodeDTO[] {
+  const root = elements.find((e) => e.id === rootId) || { x: 0, y: 0 }
+  return elements.map((el) => {
+    const node: TemplateNodeDTO = {
+      id: el.id,
+      tipo: el.tipo || 'elementos',
+      categoria: el.categoria || '',
+      nombre: el.nombre || '',
+      dimensiones: {
+        ancho: el.dimensiones?.ancho || 0,
+        largo: el.dimensiones?.largo || 0,
+        alto: el.dimensiones?.alto || 0,
+      },
+      offsets: {
+        dx: (el.x || 0) - (root.x || 0),
+        dy: (el.y || 0) - (root.y || 0),
+      },
+      canvas: el.width || el.height ? { width: el.width, height: el.height } : undefined,
+      color: el.color,
+      colorBase: el.colorBase,
+      forma: el.forma,
+      ubicacion: el.ubicacion,
+      alturaRespectoAlSuelo: el.alturaRespectoAlSuelo,
+      pesoMaximo: el.pesoMaximo,
+      volumenMaximo: el.volumenMaximo,
+      dimensionLock: el.dimensionLock,
+      systemTypeKey: el.systemTypeKey,
+      uso: el.uso,
+      descripcion: el.descripcion,
+      contenedores: el.contenedores,
+      hijos: el.hijos || [],
+      padre: el.padre ?? null,
+      etiquetas: el.etiquetas || [],
+    }
+    return node
+  })
+}
+
+export function guessPreviewBBox(
+  elements: any[],
+  rootId: string,
+): { width: number; height: number } {
+  const root = elements.find((e) => e.id === rootId)
+  if (root && root.width && root.height) {
+    return { width: root.width, height: root.height }
+  }
+  if (elements.length > 0) {
+    return {
+      width: elements[0].width || 100,
+      height: elements[0].height || 100,
+    }
+  }
+  return { width: 100, height: 100 }
+}
+

--- a/src/inventory-smart/modules/templates/templates.validator.ts
+++ b/src/inventory-smart/modules/templates/templates.validator.ts
@@ -1,0 +1,67 @@
+import { EXPORT_FORMAT_VERSION } from '@/inventory-smart/utils/constants'
+import type { TemplateDTO, TemplateNodeDTO } from './templates.serializer'
+
+const SEMVER_RE = /^\d+\.\d+\.\d+$/
+
+export function assertValidTemplatesDTO(dtos: TemplateDTO[] | undefined): void {
+  if (dtos === undefined) return
+  if (!Array.isArray(dtos)) throw new Error('plantillasCatalogo debe ser un array')
+  dtos.forEach((tpl, index) => {
+    if (!tpl || typeof tpl !== 'object') throw new Error(`Plantilla ${index} inválida`)
+    if (!tpl.id || typeof tpl.id !== 'string') throw new Error(`Plantilla ${index} sin id`)
+    if (!tpl.nombre || typeof tpl.nombre !== 'string') throw new Error(`Plantilla ${tpl.id} sin nombre`)
+    if (!tpl.payload || typeof tpl.payload !== 'object') throw new Error(`Plantilla ${tpl.id} sin payload`)
+    if (!tpl.payload.root || typeof tpl.payload.root !== 'string') throw new Error(`Plantilla ${tpl.id} payload.root inválido`)
+    if (!Array.isArray(tpl.payload.nodos)) throw new Error(`Plantilla ${tpl.id} nodos debe ser array`)
+    const ids = new Set(tpl.payload.nodos.map((n) => n.id))
+    if (!ids.has(tpl.payload.root)) throw new Error(`Plantilla ${tpl.id} root no está en nodos`)
+    const mode = tpl.payload.layout?.mode || 'relative'
+    tpl.payload.nodos.forEach((n: TemplateNodeDTO, idx: number) => {
+      if (!['elementos', 'contenedores'].includes(n.tipo)) {
+        throw new Error(`Nodo ${idx} de plantilla ${tpl.id} tiene tipo inválido`)
+      }
+      if (!n.dimensiones || typeof n.dimensiones.ancho !== 'number' || n.dimensiones.ancho <= 0) {
+        throw new Error(`Nodo ${n.id} dimensiones.ancho inválido`)
+      }
+      if (typeof n.dimensiones.largo !== 'number' || n.dimensiones.largo <= 0) {
+        throw new Error(`Nodo ${n.id} dimensiones.largo inválido`)
+      }
+      if (typeof n.dimensiones.alto !== 'number' || n.dimensiones.alto <= 0) {
+        throw new Error(`Nodo ${n.id} dimensiones.alto inválido`)
+      }
+      if (mode === 'relative') {
+        if (typeof n.offsets?.dx !== 'number' || typeof n.offsets?.dy !== 'number') {
+          throw new Error(`Nodo ${n.id} offsets inválidos`)
+        }
+      }
+      if (mode === 'absoluteSnapshot') {
+        if (typeof n.x !== 'number' || typeof n.y !== 'number') {
+          throw new Error(`Nodo ${n.id} coordenadas absolutas inválidas`)
+        }
+      }
+    })
+  })
+}
+
+export function validateMetaVersion(version: string | undefined, warnings: string[]): void {
+  if (!version) return
+  if (!SEMVER_RE.test(version)) {
+    warnings.push('meta.version no es semver válido')
+    return
+  }
+  const cmp = compareSemver(version, EXPORT_FORMAT_VERSION)
+  if (cmp > 0) {
+    warnings.push(`meta.version ${version} es mayor que soportada ${EXPORT_FORMAT_VERSION}`)
+  }
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1
+  }
+  return 0
+}
+

--- a/src/inventory-smart/utils/constants.js
+++ b/src/inventory-smart/utils/constants.js
@@ -4,6 +4,9 @@
  * Constantes y elementos predefinidos para el catálogo del editor.
  */
 
+export const EXPORT_FORMAT_VERSION = '1.1.0'
+export const SCHEMA_VERSION_PLANTILLAS = 1
+
 export const TIPOS_ENTIDAD = [
   { id: 'plantas', nombre: 'Plantas', color: '#10b981', icono: '🏢' },
   { id: 'elementos', nombre: 'Elementos', color: '#3b82f6', icono: '📦' },


### PR DESCRIPTION
## Summary
- support exporting/importing catalog templates alongside canvas state
- bump export format version and metrics
- add validation for template DTOs

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1913b098832195ab5bb1bf4da2f5