### PR TITLE
feat: include template catalog in canvas import/export

### DIFF
--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -1136,7 +1136,8 @@ export const useCanvasStore = defineStore('canvas', () => {
   const serialize = () => {
     const state = {
       plantas: plantas.value,
-      elementos: elementos.value
+      elementos: elementos.value,
+      plantillasCatalogo: catalogStore.templates.value
     }
     return _serialize(state)
   }

--- a/src/inventory-smart/composables/useStatePersistence.js
+++ b/src/inventory-smart/composables/useStatePersistence.js
@@ -11,6 +11,13 @@
  * - Manejo de errores en operaciones de persistencia
  */
 
+import { EXPORT_FORMAT_VERSION } from '@/inventory-smart/utils/constants'
+import {
+  exportTemplatesToDTO,
+  importTemplatesFromDTO,
+} from '@/inventory-smart/modules/templates/templates.serializer'
+import { assertValidTemplatesDTO } from '@/inventory-smart/modules/templates/templates.validator'
+
 export const useStatePersistence = () => {
   /**
    * Serializa el estado completo del canvas a JSON
@@ -33,14 +40,20 @@ export const useStatePersistence = () => {
       }
     }
 
+    const templatesDTO = exportTemplatesToDTO(state.plantillasCatalogo || [])
+    const metrics = includeMetrics ? calculateStateMetrics(state) : null
+    if (metrics) {
+      metrics.totalPlantillas = templatesDTO.length
+    }
+
     const serializedState = {
       // Información básica del canvas
       meta: {
-        version: '1.0.0',
+        version: EXPORT_FORMAT_VERSION,
         timestamp: new Date().toISOString(),
         app: 'inventory-smart',
-        ...(includeMetrics && {
-          metrics: calculateStateMetrics(state)
+        ...(metrics && {
+          metrics
         })
       },
 
@@ -230,23 +243,21 @@ export const useStatePersistence = () => {
       elementosHuerfanos: 0,
       relacionesPadreHijo: 0,
       plantasConElementos: 0,
-      promedioElementosPorPlanta: 0
+      promedioElementosPorPlanta: 0,
+      totalPlantillas: state.plantillasCatalogo?.length || 0,
     }
 
     // Analizar elementos
     if (Array.isArray(state.elementos)) {
-      state.elementos.forEach(elemento => {
-        // Contar por tipo
+      state.elementos.forEach((elemento) => {
         const tipo = elemento.tipo || 'sin_tipo'
         metrics.elementosPorTipo[tipo] = (metrics.elementosPorTipo[tipo] || 0) + 1
 
-        // Contar elementos con hijos
         if (elemento.hijos && elemento.hijos.length > 0) {
           metrics.elementosConHijos++
           metrics.relacionesPadreHijo += elemento.hijos.length
         }
 
-        // Contar elementos huérfanos
         if (!elemento.padre) {
           metrics.elementosHuerfanos++
         }
@@ -255,16 +266,15 @@ export const useStatePersistence = () => {
 
     // Analizar plantas
     if (Array.isArray(state.plantas)) {
-      state.plantas.forEach(planta => {
+      state.plantas.forEach((planta) => {
         if (planta.elementos && planta.elementos.length > 0) {
           metrics.plantasConElementos++
         }
       })
 
       if (metrics.totalPlantas > 0) {
-        metrics.promedioElementosPorPlanta = Math.round(
-          metrics.totalElementos / metrics.totalPlantas * 100
-        ) / 100
+        metrics.promedioElementosPorPlanta =
+          Math.round((metrics.totalElementos / metrics.totalPlantas) * 100) / 100
       }
     }
 
@@ -304,6 +314,27 @@ export const useStatePersistence = () => {
       }
 
       const state = validation.data || JSON.parse(jsonString)
+
+      // Validar versión de esquema
+      const version = state.meta?.version
+      if (version) {
+        const [a1, a2, a3] = String(version).split('.').map(Number)
+        const [b1, b2, b3] = EXPORT_FORMAT_VERSION.split('.').map(Number)
+        if (a1 > b1 || (a1 === b1 && (a2 > b2 || (a2 === b2 && a3 > b3)))) {
+          console.warn(
+            `⚠️ Archivo con versión ${version} mayor a soportada ${EXPORT_FORMAT_VERSION}`
+          )
+        }
+      }
+
+      if (state.plantillasCatalogo) {
+        try {
+          const tpl = assertValidTemplatesDTO(state.plantillasCatalogo)
+          importTemplatesFromDTO(tpl)
+        } catch (err) {
+          console.warn('Plantillas inválidas omitidas:', err?.message || err)
+        }
+      }
 
       // === LIMPIEZA Y PREPARACIÓN ===
       storeActions.clearState()

--- a/src/inventory-smart/modules/templates/templates.serializer.ts
+++ b/src/inventory-smart/modules/templates/templates.serializer.ts
@@ -1,0 +1,160 @@
+import { useCatalogStore } from '@/inventory-smart/stores/catalog'
+import type { TemplateDTO, TemplateNodeDTO } from './templates.validator'
+
+/**
+ * Exporta las plantillas del estado a su representación DTO
+ */
+export function exportTemplatesToDTO(stateTemplates: any[]): TemplateDTO[] {
+  if (!Array.isArray(stateTemplates)) return []
+
+  return stateTemplates.map((raw) => {
+    const tpl = raw?._custom?.value ?? raw
+    const elements: any[] = Array.isArray(tpl.payload?.elements)
+      ? tpl.payload.elements
+      : []
+    const rootId: string = tpl.payload?.rootId || elements[0]?.id || ''
+    const nodos = toRelativeLayout(elements, rootId)
+    const preview = guessPreviewBBox(elements, rootId)
+    const categoria = elements[0]?.categoria ?? null
+
+    return {
+      id: tpl.id,
+      nombre: tpl.name,
+      descripcion: tpl.descripcion ?? null,
+      categoria,
+      tags: tpl.tags || [],
+      version: '1.0.0',
+      meta: tpl.meta,
+      preview: { bbox: preview },
+      payload: {
+        root: rootId,
+        layout: { mode: 'relative', origin: 'rootTopLeft' },
+        nodos,
+      },
+      auditoria: { createdAt: tpl.createdAt, updatedAt: tpl.updatedAt },
+    }
+  })
+}
+
+/**
+ * Importa plantillas desde DTO y hace upsert en el store
+ */
+export function importTemplatesFromDTO(dtos: TemplateDTO[] | undefined): void {
+  if (!Array.isArray(dtos) || dtos.length === 0) return
+  const catalog = useCatalogStore()
+  dtos.forEach((dto) => {
+    const layoutMode = dto.payload.layout.mode
+    const elements = dto.payload.nodos.map((n) => {
+      const baseX = layoutMode === 'relative' ? n.offsets?.dx || 0 : n.x || 0
+      const baseY = layoutMode === 'relative' ? n.offsets?.dy || 0 : n.y || 0
+      return {
+        id: n.id,
+        tipo: n.tipo,
+        categoria: n.categoria,
+        nombre: n.nombre,
+        dimensiones: n.dimensiones,
+        x: baseX,
+        y: baseY,
+        width: n.canvas?.width ?? n.dimensiones.ancho,
+        height: n.canvas?.height ?? n.dimensiones.alto,
+        color: n.color,
+        colorBase: n.colorBase,
+        forma: n.forma,
+        ubicacion: n.ubicacion,
+        alturaRespectoAlSuelo: n.alturaRespectoAlSuelo,
+        pesoMaximo: n.pesoMaximo,
+        volumenMaximo: n.volumenMaximo,
+        dimensionLock: n.dimensionLock,
+        systemTypeKey: n.systemTypeKey,
+        uso: n.uso,
+        descripcion: n.descripcion,
+        contenedores: n.contenedores,
+        hijos: n.hijos,
+        padre: n.padre,
+        etiquetas: n.etiquetas,
+      }
+    })
+
+    const normalized = {
+      id: dto.id,
+      name: dto.nombre,
+      createdAt: dto.auditoria.createdAt,
+      updatedAt: dto.auditoria.updatedAt,
+      meta: dto.meta,
+      payload: { rootId: dto.payload.root, elements },
+      tags: dto.tags,
+    }
+
+    const idx = catalog.templates.value.findIndex((t) => t.id === dto.id)
+    if (idx !== -1) {
+      catalog.templates.value[idx] = normalized
+    } else {
+      catalog.templates.value.push(normalized)
+    }
+  })
+  catalog.saveTemplatesToLocalStorage?.()
+}
+
+/**
+ * Convierte un conjunto de nodos a layout relativo respecto al root
+ */
+export function toRelativeLayout(elements: any[], rootId: string): TemplateNodeDTO[] {
+  const root = elements.find((e) => e.id === rootId) || { x: 0, y: 0 }
+  return elements.map((e) => {
+    const node: TemplateNodeDTO = {
+      id: e.id,
+      tipo: e.tipo,
+      categoria: e.categoria,
+      nombre: e.nombre,
+      dimensiones: e.dimensiones,
+      offsets: { dx: (e.x || 0) - (root.x || 0), dy: (e.y || 0) - (root.y || 0) },
+      canvas: { width: e.width || e.dimensiones?.ancho || 0, height: e.height || e.dimensiones?.alto || 0 },
+      color: e.color,
+      colorBase: e.colorBase,
+      forma: e.forma,
+      ubicacion: e.ubicacion,
+      alturaRespectoAlSuelo: e.alturaRespectoAlSuelo,
+      pesoMaximo: e.pesoMaximo,
+      volumenMaximo: e.volumenMaximo,
+      dimensionLock: e.dimensionLock,
+      systemTypeKey: e.systemTypeKey,
+      uso: e.uso,
+      descripcion: e.descripcion,
+      contenedores: e.contenedores,
+      hijos: e.hijos || [],
+      padre: e.padre ?? null,
+      etiquetas: e.etiquetas || [],
+    }
+    return node
+  })
+}
+
+/**
+ * Intenta obtener un bbox de previsualización
+ */
+export function guessPreviewBBox(
+  elements: any[],
+  rootId: string
+): { width: number; height: number } {
+  const root = elements.find((e) => e.id === rootId)
+  if (root && typeof root.width === 'number' && typeof root.height === 'number') {
+    return { width: root.width, height: root.height }
+  }
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  elements.forEach((e) => {
+    const x = e.x || 0
+    const y = e.y || 0
+    const w = e.width || 0
+    const h = e.height || 0
+    minX = Math.min(minX, x)
+    minY = Math.min(minY, y)
+    maxX = Math.max(maxX, x + w)
+    maxY = Math.max(maxY, y + h)
+  })
+  if (minX === Infinity) return { width: 0, height: 0 }
+  return { width: maxX - minX, height: maxY - minY }
+}

--- a/src/inventory-smart/modules/templates/templates.validator.ts
+++ b/src/inventory-smart/modules/templates/templates.validator.ts
@@ -1,0 +1,105 @@
+export type TemplateNodeDTO = {
+  id: string
+  tipo: 'elementos' | 'contenedores'
+  categoria: string
+  nombre?: string
+  dimensiones: { ancho: number; largo: number; alto: number }
+  offsets?: { dx: number; dy: number }
+  x?: number
+  y?: number
+  canvas?: { width: number; height: number }
+  color?: string
+  colorBase?: string
+  forma?: string
+  ubicacion?: string
+  alturaRespectoAlSuelo?: number
+  pesoMaximo?: number
+  volumenMaximo?: number
+  dimensionLock?: boolean
+  systemTypeKey?: string
+  uso?: { volumen: number; peso: number }
+  descripcion?: string
+  contenedores?: string[]
+  hijos: string[]
+  padre: string | null
+  etiquetas: string[]
+}
+
+export type TemplateDTO = {
+  id: string
+  nombre: string
+  descripcion: string | null
+  categoria: string | null
+  tags: string[]
+  version: '1.0.0'
+  meta: {
+    elementType: string
+    width: number
+    height: number
+    depth: number
+    childrenCount: number
+    weight: number
+    location: string
+  }
+  preview: { bbox: { width: number; height: number } }
+  payload: {
+    root: string
+    layout: { mode: 'relative' | 'absoluteSnapshot'; origin?: string }
+    nodos: TemplateNodeDTO[]
+  }
+  auditoria: { createdAt: string; updatedAt: string }
+}
+
+/**
+ * Valida el array de plantillas y lanza error descriptivo si es inválido
+ */
+export function assertValidTemplatesDTO(data: any): TemplateDTO[] {
+  if (!Array.isArray(data)) {
+    throw new Error('plantillasCatalogo debe ser un array')
+  }
+
+  data.forEach((tpl, index) => {
+    if (!tpl || typeof tpl !== 'object') {
+      throw new Error(`Template ${index + 1} inválido`)
+    }
+    if (!tpl.id || typeof tpl.id !== 'string') {
+      throw new Error(`Template ${index + 1}: id requerido`)
+    }
+    if (!tpl.nombre || typeof tpl.nombre !== 'string') {
+      throw new Error(`Template ${tpl.id}: nombre requerido`)
+    }
+    if (!tpl.payload || typeof tpl.payload !== 'object') {
+      throw new Error(`Template ${tpl.id}: payload requerido`)
+    }
+    if (!Array.isArray(tpl.payload.nodos)) {
+      throw new Error(`Template ${tpl.id}: payload.nodos debe ser un array`)
+    }
+    if (!tpl.payload.nodos.find((n: any) => n.id === tpl.payload.root)) {
+      throw new Error(`Template ${tpl.id}: payload.root no encontrado en nodos`)
+    }
+    const mode = tpl.payload.layout?.mode
+    tpl.payload.nodos.forEach((n: any) => {
+      if (!n.id || typeof n.id !== 'string') {
+        throw new Error(`Template ${tpl.id}: nodo sin id`)
+      }
+      if (!['elementos', 'contenedores'].includes(n.tipo)) {
+        throw new Error(`Template ${tpl.id}: nodo ${n.id} tipo inválido`)
+      }
+      const dims = n.dimensiones
+      if (!dims || typeof dims.ancho !== 'number' || dims.ancho <= 0 || typeof dims.largo !== 'number' || dims.largo <= 0 || typeof dims.alto !== 'number' || dims.alto <= 0) {
+        throw new Error(`Template ${tpl.id}: nodo ${n.id} dimensiones inválidas`)
+      }
+      if (mode === 'relative') {
+        if (!n.offsets || typeof n.offsets.dx !== 'number' || typeof n.offsets.dy !== 'number') {
+          throw new Error(`Template ${tpl.id}: nodo ${n.id} requiere offsets`)
+        }
+      } else if (mode === 'absoluteSnapshot') {
+        if (typeof n.x !== 'number' || typeof n.y !== 'number') {
+          throw new Error(`Template ${tpl.id}: nodo ${n.id} requiere x,y`)
+        }
+      }
+    })
+  })
+
+  return data as TemplateDTO[]
+}

--- a/src/inventory-smart/utils/constants.js
+++ b/src/inventory-smart/utils/constants.js
@@ -4,6 +4,10 @@
  * Constantes y elementos predefinidos para el catálogo del editor.
  */
 
+// Versionado de formato de exportación e importación
+export const EXPORT_FORMAT_VERSION = '1.1.0'
+export const SCHEMA_VERSION_PLANTILLAS = 1
+
 export const TIPOS_ENTIDAD = [
   { id: 'plantas', nombre: 'Plantas', color: '#10b981', icono: '🏢' },
   { id: 'elementos', nombre: 'Elementos', color: '#3b82f6', icono: '📦' },


### PR DESCRIPTION
## Summary
- support template catalog in export/import with version 1.1.0
- add template serializer, validator and metrics
- upsert templates into catalog store when importing

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1913b098832195ab5bb1bf4da2f5