### PR TITLE
feat: add elastic floor configuration and tests

### DIFF
--- a/server/migrations/1726531200000-AddElasticFlagToFloors.ts
+++ b/server/migrations/1726531200000-AddElasticFlagToFloors.ts
@@ -1,0 +1,39 @@
+const FLOOR_TABLE = 'floors'
+const DIMENSION_CONSTRAINT = 'CHK_floors_dimensions_positive'
+
+type QueryRunnerLike = {
+  query: (sql: string) => Promise<unknown>
+}
+
+type TableIdentifier = string | { schema?: string; tableName: string }
+
+function tableName(input: TableIdentifier): string {
+  if (typeof input === 'string') {
+    return `"${input}"`
+  }
+  const schema = input.schema ? `"${input.schema}".` : ''
+  return `${schema}"${input.tableName}"`
+}
+
+export class AddElasticFlagToFloors1726531200000 {
+  readonly name = 'AddElasticFlagToFloors1726531200000'
+
+  async up(queryRunner: QueryRunnerLike, table: TableIdentifier = FLOOR_TABLE): Promise<void> {
+    const tableRef = tableName(table)
+    await queryRunner.query(`ALTER TABLE ${tableRef} ADD COLUMN IF NOT EXISTS "isElastic" boolean NOT NULL DEFAULT false`)
+    await queryRunner.query(`ALTER TABLE ${tableRef} DROP CONSTRAINT IF EXISTS ${DIMENSION_CONSTRAINT}`)
+    await queryRunner.query(`ALTER TABLE ${tableRef}
+      ADD CONSTRAINT ${DIMENSION_CONSTRAINT}
+      CHECK (
+        ("isElastic" = true AND "width" >= 0 AND "length" >= 0 AND "height" >= 0)
+        OR
+        ("isElastic" = false AND "width" > 0 AND "length" > 0 AND "height" > 0)
+      )`)
+  }
+
+  async down(queryRunner: QueryRunnerLike, table: TableIdentifier = FLOOR_TABLE): Promise<void> {
+    const tableRef = tableName(table)
+    await queryRunner.query(`ALTER TABLE ${tableRef} DROP CONSTRAINT IF EXISTS ${DIMENSION_CONSTRAINT}`)
+    await queryRunner.query(`ALTER TABLE ${tableRef} DROP COLUMN IF EXISTS "isElastic"`)
+  }
+}

--- a/src/__tests__/FloorCanvas.test.tsx
+++ b/src/__tests__/FloorCanvas.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_ELASTIC_AREA, DEFAULT_ELASTIC_PADDING } from '@/constants/floor'
+import {
+  FloorCanvas,
+  createElasticBoundsController,
+  type AreaBounds,
+  type FloorShape,
+  type ItemBounds,
+} from '@/canvas/FloorCanvas'
+import { findElement } from './mini-react-helpers'
+
+function createFloor(overrides: Partial<FloorShape> = {}): FloorShape {
+  return {
+    width: 120,
+    length: 120,
+    height: 40,
+    isElastic: true,
+    ...overrides,
+  }
+}
+
+function createItem(overrides: Partial<ItemBounds> = {}): ItemBounds {
+  return {
+    id: 'rack',
+    x: 40,
+    y: 40,
+    width: 20,
+    length: 20,
+    height: 10,
+    z: 0,
+    ...overrides,
+  }
+}
+
+describe('FloorCanvas elastic bounds', () => {
+  it('initializes elastic bounds from defaults', () => {
+    const floor = createFloor({ isElastic: true })
+    const controller = createElasticBoundsController(floor, DEFAULT_ELASTIC_PADDING)
+    const tree = FloorCanvas({ floor, items: [], controller })
+
+    const outline = findElement(tree, (element) => element.props.className === 'elastic-outline')
+    expect(outline).not.toBeNull()
+
+    expect(outline!.props.style.width).toBe(DEFAULT_ELASTIC_AREA.width)
+    expect(outline!.props.style.height).toBe(DEFAULT_ELASTIC_AREA.length)
+
+    const canvas = findElement(tree, (element) => element.props.className === 'floor-canvas')
+    expect(canvas?.props['data-width']).toBe(DEFAULT_ELASTIC_AREA.width)
+    expect(canvas?.props['data-length']).toBe(DEFAULT_ELASTIC_AREA.length)
+  })
+
+  it('expands bounds with padding when an item moves close to the edge', () => {
+    const floor = createFloor({ isElastic: true })
+    const controller = createElasticBoundsController(floor, DEFAULT_ELASTIC_PADDING)
+    const onBoundsChange: AreaBounds[] = []
+
+    const item = createItem({ x: 80, y: 90, width: 18, length: 15, height: 12, z: 95 })
+    const initialTree = FloorCanvas({ floor, items: [item], controller, onBoundsChange: (next) => onBoundsChange.push(next) })
+
+    const draggable = findElement(initialTree, (element) => element.props.className === 'canvas-item')
+    expect(draggable).not.toBeNull()
+
+    const nextItemState: ItemBounds = { ...item, x: 120, y: 125, z: 102 }
+    draggable!.props.onMove(nextItemState)
+
+    const rerender = FloorCanvas({ floor, items: [], controller })
+    const outline = findElement(rerender, (element) => element.props.className === 'elastic-outline')
+    expect(outline).not.toBeNull()
+
+    const expectedWidth = Math.max(
+      DEFAULT_ELASTIC_AREA.width,
+      nextItemState.x + nextItemState.width + nextItemState.width * DEFAULT_ELASTIC_PADDING,
+    )
+    const expectedLength = Math.max(
+      DEFAULT_ELASTIC_AREA.length,
+      nextItemState.y + nextItemState.length + nextItemState.length * DEFAULT_ELASTIC_PADDING,
+    )
+    const expectedHeight = Math.max(
+      DEFAULT_ELASTIC_AREA.height,
+      (nextItemState.z ?? 0) + (nextItemState.height ?? 0) + (nextItemState.height ?? 0) * DEFAULT_ELASTIC_PADDING,
+    )
+
+    expect(outline!.props.style.width).toBeCloseTo(expectedWidth)
+    expect(outline!.props.style.height).toBeCloseTo(expectedLength)
+
+    const canvas = findElement(rerender, (element) => element.props.className === 'floor-canvas')
+    expect(canvas?.props['data-width']).toBeCloseTo(expectedWidth)
+    expect(canvas?.props['data-length']).toBeCloseTo(expectedLength)
+    expect(canvas?.props['data-height']).toBeCloseTo(expectedHeight)
+
+    const reported = onBoundsChange.at(-1)
+    expect(reported?.width).toBeCloseTo(expectedWidth)
+    expect(reported?.length).toBeCloseTo(expectedLength)
+    expect(reported?.height).toBeCloseTo(expectedHeight)
+  })
+})

--- a/src/__tests__/FloorForm.test.tsx
+++ b/src/__tests__/FloorForm.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { FloorForm, validateFloorDimensions } from '@/components/FloorForm'
+import type { FloorFormValues } from '@/components/FloorForm'
+import { findElement } from './mini-react-helpers'
+
+function createValues(overrides: Partial<FloorFormValues> = {}): FloorFormValues {
+  return {
+    width: 10,
+    length: 10,
+    height: 10,
+    isElastic: false,
+    ...overrides,
+  }
+}
+
+function findInput(root: ReturnType<typeof FloorForm>, name: string) {
+  const node = findElement(root, (element) => element.type === 'input' && element.props.name === name)
+  if (!node) {
+    throw new Error(`Input with name "${name}" not found`)
+  }
+  return node
+}
+
+describe('FloorForm', () => {
+  it('disables dimension fields when the floor is elastic', () => {
+    const values = createValues({ isElastic: true })
+    const tree = FloorForm({ value: values, onChange: () => {}, showErrors: true })
+
+    const width = findInput(tree, 'width')
+    const length = findInput(tree, 'length')
+    const height = findInput(tree, 'height')
+
+    expect(width.props.disabled).toBe(true)
+    expect(length.props.disabled).toBe(true)
+    expect(height.props.disabled).toBe(true)
+  })
+
+  it('skips greater-than-zero validation when elastic is enabled', () => {
+    const nonElasticValues = createValues({ width: 0, length: 0, height: 0, isElastic: false })
+    const nonElasticTree = FloorForm({ value: nonElasticValues, onChange: () => {}, showErrors: true })
+
+    expect(findInput(nonElasticTree, 'width').props['data-error']).toContain('greater than 0')
+    expect(findInput(nonElasticTree, 'length').props['data-error']).toContain('greater than 0')
+    expect(findInput(nonElasticTree, 'height').props['data-error']).toContain('greater than 0')
+
+    const elasticValues = { ...nonElasticValues, isElastic: true }
+    const elasticTree = FloorForm({ value: elasticValues, onChange: () => {}, showErrors: true })
+
+    expect(findInput(elasticTree, 'width').props['data-error']).toBe('')
+    expect(findInput(elasticTree, 'length').props['data-error']).toBe('')
+    expect(findInput(elasticTree, 'height').props['data-error']).toBe('')
+
+    expect(validateFloorDimensions(elasticValues)).toEqual({})
+  })
+})

--- a/src/__tests__/mini-react-helpers.ts
+++ b/src/__tests__/mini-react-helpers.ts
@@ -1,0 +1,50 @@
+import type { MiniReactChild, MiniReactElement } from '@/lib/mini-react/jsx-runtime'
+
+export function isMiniReactElement(value: MiniReactChild): value is MiniReactElement {
+  return Boolean(value && typeof value === 'object' && 'props' in (value as Record<string, unknown>))
+}
+
+export function getChildren(element: MiniReactElement): MiniReactChild[] {
+  return element.props.children ?? []
+}
+
+export function findElement(
+  node: MiniReactChild,
+  predicate: (element: MiniReactElement) => boolean,
+): MiniReactElement | null {
+  if (!isMiniReactElement(node)) {
+    return null
+  }
+
+  if (predicate(node)) {
+    return node
+  }
+
+  for (const child of getChildren(node)) {
+    const match = findElement(child, predicate)
+    if (match) {
+      return match
+    }
+  }
+  return null
+}
+
+export function collectElements(
+  node: MiniReactChild,
+  predicate: (element: MiniReactElement) => boolean,
+  bucket: MiniReactElement[] = [],
+): MiniReactElement[] {
+  if (!isMiniReactElement(node)) {
+    return bucket
+  }
+
+  if (predicate(node)) {
+    bucket.push(node)
+  }
+
+  for (const child of getChildren(node)) {
+    collectElements(child, predicate, bucket)
+  }
+
+  return bucket
+}

--- a/src/canvas/FloorCanvas.tsx
+++ b/src/canvas/FloorCanvas.tsx
@@ -1,0 +1,165 @@
+import type { MiniReactElement } from '@/lib/mini-react/jsx-runtime'
+import { DEFAULT_ELASTIC_AREA, DEFAULT_ELASTIC_PADDING } from '@/constants/floor'
+
+export interface FloorShape {
+  width: number
+  length: number
+  height: number
+  isElastic: boolean
+}
+
+export interface ItemBounds {
+  id: string
+  x: number
+  y: number
+  width: number
+  length: number
+  height?: number
+  z?: number
+}
+
+export interface AreaBounds {
+  width: number
+  length: number
+  height: number
+}
+
+export interface ElasticBoundsController {
+  readonly bounds: AreaBounds
+  include: (rect: ItemBounds) => AreaBounds
+  reset: (floor: FloorShape) => AreaBounds
+}
+
+export interface FloorCanvasProps {
+  floor: FloorShape
+  items: ItemBounds[]
+  padding?: number
+  onBoundsChange?: (bounds: AreaBounds) => void
+  controller?: ElasticBoundsController
+}
+
+function cloneBounds(bounds: AreaBounds): AreaBounds {
+  return {
+    width: bounds.width,
+    length: bounds.length,
+    height: bounds.height,
+  }
+}
+
+function baseBoundsFromFloor(floor: FloorShape): AreaBounds {
+  if (floor.isElastic) {
+    return cloneBounds(DEFAULT_ELASTIC_AREA)
+  }
+  return {
+    width: Math.max(0, floor.width),
+    length: Math.max(0, floor.length),
+    height: Math.max(0, floor.height),
+  }
+}
+
+function expandBoundsWithPadding(current: AreaBounds, rect: ItemBounds, padding: number): AreaBounds {
+  const padX = rect.width * padding
+  const padY = rect.length * padding
+  const padZ = (rect.height ?? 0) * padding
+
+  const nextWidth = Math.max(current.width, rect.x + rect.width + padX)
+  const nextLength = Math.max(current.length, rect.y + rect.length + padY)
+  const referenceHeight = rect.height ?? current.height
+  const nextHeight = Math.max(current.height, (rect.z ?? 0) + referenceHeight + padZ)
+
+  if (nextWidth === current.width && nextLength === current.length && nextHeight === current.height) {
+    return current
+  }
+
+  return {
+    width: nextWidth,
+    length: nextLength,
+    height: nextHeight,
+  }
+}
+
+export function createElasticBoundsController(
+  floor: FloorShape,
+  padding: number = DEFAULT_ELASTIC_PADDING,
+): ElasticBoundsController {
+  let currentFloor: FloorShape = { ...floor }
+  let internalBounds: AreaBounds = baseBoundsFromFloor(currentFloor)
+
+  const ensureElasticBounds = (rect: ItemBounds): AreaBounds => {
+    if (!currentFloor.isElastic) {
+      return cloneBounds(internalBounds)
+    }
+    const expanded = expandBoundsWithPadding(internalBounds, rect, padding)
+    if (expanded !== internalBounds) {
+      internalBounds = expanded
+    }
+    return cloneBounds(internalBounds)
+  }
+
+  return {
+    get bounds() {
+      return cloneBounds(internalBounds)
+    },
+    include(rect: ItemBounds) {
+      return ensureElasticBounds(rect)
+    },
+    reset(nextFloor: FloorShape) {
+      currentFloor = { ...nextFloor }
+      internalBounds = baseBoundsFromFloor(currentFloor)
+      return cloneBounds(internalBounds)
+    },
+  }
+}
+
+export function FloorCanvas({
+  floor,
+  items,
+  padding = DEFAULT_ELASTIC_PADDING,
+  onBoundsChange,
+  controller,
+}: FloorCanvasProps): MiniReactElement {
+  const boundsController = controller ?? createElasticBoundsController(floor, padding)
+  if (!controller) {
+    boundsController.reset(floor)
+  }
+  const snapshot = boundsController.bounds
+
+  const outline = floor.isElastic ? (
+    <div
+      className="elastic-outline"
+      data-role="elastic-outline"
+      style={{ width: snapshot.width, height: snapshot.length }}
+    />
+  ) : null
+
+  const itemNodes = items.map((item) => (
+    <div
+      key={item.id}
+      className="canvas-item"
+      data-id={item.id}
+      data-x={item.x}
+      data-y={item.y}
+      data-width={item.width}
+      data-length={item.length}
+      data-height={item.height ?? ''}
+      onMove={(nextBounds: ItemBounds) => {
+        const updated = boundsController.include(nextBounds)
+        if (floor.isElastic) {
+          onBoundsChange?.(updated)
+        }
+      }}
+    />
+  ))
+
+  return (
+    <div
+      className="floor-canvas"
+      data-width={snapshot.width}
+      data-length={snapshot.length}
+      data-height={snapshot.height}
+    >
+      {outline}
+      {itemNodes}
+    </div>
+  )
+}

--- a/src/components/FloorForm.tsx
+++ b/src/components/FloorForm.tsx
@@ -1,0 +1,120 @@
+import type { MiniReactElement } from '@/lib/mini-react/jsx-runtime'
+
+type DimensionKey = 'width' | 'length' | 'height'
+
+export interface FloorFormValues {
+  width: number
+  length: number
+  height: number
+  isElastic: boolean
+}
+
+export type FloorFieldErrors = Partial<Record<DimensionKey, string>>
+
+export interface FloorFormProps {
+  value: FloorFormValues
+  onChange: (next: FloorFormValues) => void
+  showErrors?: boolean
+}
+
+type NumericInputChangeEvent = {
+  currentTarget: {
+    value: string
+  }
+}
+
+type CheckboxChangeEvent = {
+  currentTarget: {
+    checked: boolean
+  }
+}
+
+const DIMENSION_LABELS: Record<DimensionKey, string> = {
+  width: 'Width',
+  length: 'Length',
+  height: 'Height',
+}
+
+export function validateFloorDimensions(values: FloorFormValues): FloorFieldErrors {
+  if (values.isElastic) {
+    return {}
+  }
+
+  const errors: FloorFieldErrors = {}
+  for (const dimension of ['width', 'length', 'height'] as DimensionKey[]) {
+    if (values[dimension] <= 0) {
+      errors[dimension] = `${DIMENSION_LABELS[dimension]} must be greater than 0`
+    }
+  }
+  return errors
+}
+
+function parseNumericValue(input: string): number {
+  const numeric = Number.parseFloat(input)
+  if (!Number.isFinite(numeric)) {
+    return 0
+  }
+  return numeric
+}
+
+export function FloorForm({ value, onChange, showErrors = false }: FloorFormProps): MiniReactElement {
+  const errors = validateFloorDimensions(value)
+
+  const handleDimensionChange = (dimension: DimensionKey) => (event: NumericInputChangeEvent) => {
+    const nextValue = parseNumericValue(event.currentTarget.value)
+    onChange({ ...value, [dimension]: nextValue })
+  }
+
+  const handleElasticToggle = (event: CheckboxChangeEvent) => {
+    const nextElastic = event.currentTarget.checked
+    const nextValues: FloorFormValues = {
+      ...value,
+      isElastic: nextElastic,
+    }
+
+    if (nextElastic) {
+      nextValues.width = Math.max(0, value.width)
+      nextValues.length = Math.max(0, value.length)
+      nextValues.height = Math.max(0, value.height)
+    }
+
+    onChange(nextValues)
+  }
+
+  const renderDimensionInput = (dimension: DimensionKey): MiniReactElement => {
+    const dimensionError = errors[dimension]
+    const invalid = showErrors && Boolean(dimensionError)
+
+    return (
+      <label className={`floor-dimension field-${dimension}`}>
+        <span>{DIMENSION_LABELS[dimension]}</span>
+        <input
+          type="number"
+          name={dimension}
+          value={value[dimension]}
+          disabled={value.isElastic}
+          min={value.isElastic ? undefined : 0}
+          aria-invalid={invalid ? 'true' : undefined}
+          data-error={dimensionError ?? ''}
+          onChange={handleDimensionChange(dimension)}
+        />
+      </label>
+    )
+  }
+
+  return (
+    <>
+      <label className="floor-flag field-elastic">
+        <input type="checkbox" name="isElastic" checked={value.isElastic} onChange={handleElasticToggle} />
+        <span>isElastic</span>
+      </label>
+      <div className="floor-dimensions" data-elastic={value.isElastic ? 'true' : 'false'}>
+        {(['width', 'length', 'height'] as DimensionKey[]).map((dimension) => (
+          <div className="dimension-field" data-dimension={dimension} key={dimension}>
+            {renderDimensionInput(dimension)}
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/src/constants/floor.ts
+++ b/src/constants/floor.ts
@@ -1,0 +1,13 @@
+export interface ElasticAreaDimensions {
+  width: number
+  length: number
+  height: number
+}
+
+export const DEFAULT_ELASTIC_AREA: ElasticAreaDimensions = {
+  width: 100,
+  length: 100,
+  height: 100,
+}
+
+export const DEFAULT_ELASTIC_PADDING = 0.25

--- a/src/lib/mini-react/jsx-dev-runtime.ts
+++ b/src/lib/mini-react/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export { Fragment, jsxDEV, jsx, jsxs } from './jsx-runtime'

--- a/src/lib/mini-react/jsx-runtime.ts
+++ b/src/lib/mini-react/jsx-runtime.ts
@@ -1,0 +1,79 @@
+export type MiniReactChild = MiniReactElement | MiniReactPrimitive
+
+export type MiniReactPrimitive = string | number | boolean | null | undefined
+
+export interface MiniReactElement<P = Record<string, unknown>> {
+  readonly type: MiniReactComponent<P> | string | typeof Fragment
+  readonly key: string | number | null
+  readonly props: P & {
+    children?: MiniReactChild[]
+  }
+}
+
+export type MiniReactComponent<P = Record<string, unknown>> = (props: P) => MiniReactChild | MiniReactChild[]
+
+export const Fragment = Symbol('MiniReact.Fragment')
+
+type JSXRuntimeProps = Record<string, unknown> & {
+  children?: MiniReactChild[] | MiniReactChild
+}
+
+type JSXKey = string | number | undefined
+
+function normalizeChildren(children: JSXRuntimeProps['children']): MiniReactChild[] | undefined {
+  if (children === undefined || children === null) {
+    return undefined
+  }
+  const asArray = Array.isArray(children) ? children : [children]
+  const filtered: MiniReactChild[] = []
+  const pushChild = (child: JSXRuntimeProps['children']) => {
+    if (Array.isArray(child)) {
+      child.forEach(pushChild)
+      return
+    }
+    if (child === false || child === undefined || child === null) {
+      return
+    }
+    filtered.push(child as MiniReactChild)
+  }
+  asArray.forEach(pushChild)
+  return filtered.length > 0 ? filtered : undefined
+}
+
+function createElement<P extends JSXRuntimeProps>(
+  type: MiniReactElement<P>['type'],
+  props: P | null,
+  key?: JSXKey,
+): MiniReactElement<P> {
+  const normalized = props ? { ...props } : ({} as P)
+  if ('children' in (normalized as JSXRuntimeProps)) {
+    const normalizedChildren = normalizeChildren((normalized as JSXRuntimeProps).children)
+    if (normalizedChildren === undefined) {
+      delete (normalized as JSXRuntimeProps).children
+    } else {
+      ;(normalized as JSXRuntimeProps).children = normalizedChildren
+    }
+  }
+
+  return {
+    type,
+    key: key ?? null,
+    props: normalized as MiniReactElement<P>['props'],
+  }
+}
+
+export function jsx<P extends JSXRuntimeProps>(type: MiniReactElement<P>['type'], props: P | null, key?: JSXKey) {
+  return createElement(type, props, key)
+}
+
+export function jsxs<P extends JSXRuntimeProps>(type: MiniReactElement<P>['type'], props: P | null, key?: JSXKey) {
+  return createElement(type, props, key)
+}
+
+export function jsxDEV<P extends JSXRuntimeProps>(
+  type: MiniReactElement<P>['type'],
+  props: P | null,
+  key?: JSXKey,
+) {
+  return createElement(type, props, key)
+}

--- a/src/styles/floors.scss
+++ b/src/styles/floors.scss
@@ -1,0 +1,6 @@
+.elastic-outline {
+  border: 2px dashed #888;
+  position: absolute;
+  transition: width 0.3s, height 0.3s;
+  pointer-events: none;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@/lib/mini-react",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*", "vite.config.js", "vitest.config.js"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a migration helper to introduce the `isElastic` flag and relaxed dimension constraint for elastic floors
- expose reusable floor constants plus new form and canvas TSX fragments that toggle elastic behavior and expand bounds with padding
- provide a lightweight JSX runtime, elastic outline styles, and focused tests covering the new form and canvas logic

## Testing
- `npx vitest run src/__tests__/FloorForm.test.tsx src/__tests__/FloorCanvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ca3fe910c0832198130fd9037d01eb