### PR TITLE
Add elastic floor support to form and canvas components

### DIFF
--- a/src/components/FloorCanvas.tsx
+++ b/src/components/FloorCanvas.tsx
@@ -1,0 +1,167 @@
+import { computed, defineComponent, h, ref, watch } from 'vue'
+import type { PropType } from 'vue'
+
+import {
+  DEFAULT_ELASTIC_AREA,
+  DEFAULT_ELASTIC_PADDING,
+  type FloorDimensions,
+} from '../constants/floor'
+
+export type FloorCanvasItem = {
+  id: string
+  x: number
+  y: number
+  z?: number
+  width: number
+  length: number
+  height: number
+}
+
+type Bounds = {
+  width: number
+  length: number
+  height: number
+}
+
+const clamp = (value: number): number => {
+  if (!Number.isFinite(value)) return 0
+  return value < 0 ? 0 : value
+}
+
+const toBaseBounds = (floor: FloorDimensions): Bounds => {
+  const base = {
+    width: clamp(floor.width ?? 0),
+    length: clamp(floor.length ?? 0),
+    height: clamp(floor.height ?? 0),
+  }
+
+  if (!floor.isElastic) {
+    return base
+  }
+
+  return {
+    width: Math.max(DEFAULT_ELASTIC_AREA.width, base.width),
+    length: Math.max(DEFAULT_ELASTIC_AREA.length, base.length),
+    height: Math.max(DEFAULT_ELASTIC_AREA.height, base.height),
+  }
+}
+
+const expandBoundsWithItem = (bounds: Bounds, item: FloorCanvasItem): Bounds => {
+  const paddingFactor = 1 + DEFAULT_ELASTIC_PADDING
+  const maxX = clamp(item.x) + clamp(item.width)
+  const maxY = clamp(item.y) + clamp(item.length)
+  const maxZ = clamp(item.z ?? 0) + clamp(item.height)
+
+  return {
+    width: Math.max(bounds.width, Math.ceil(maxX * paddingFactor)),
+    length: Math.max(bounds.length, Math.ceil(maxY * paddingFactor)),
+    height: Math.max(bounds.height, Math.ceil(maxZ * paddingFactor)),
+  }
+}
+
+const cloneItems = (items: FloorCanvasItem[]): FloorCanvasItem[] =>
+  items.map((item) => ({ ...item }))
+
+export default defineComponent({
+  name: 'FloorCanvas',
+  props: {
+    floor: {
+      type: Object as PropType<FloorDimensions>,
+      required: true,
+    },
+    items: {
+      type: Array as PropType<FloorCanvasItem[]>,
+      default: () => [] as FloorCanvasItem[],
+    },
+  },
+  emits: ['update:items'],
+  setup(props, { emit, expose }) {
+    const localItems = ref<FloorCanvasItem[]>(cloneItems(props.items))
+
+    watch(
+      () => props.items,
+      (next) => {
+        localItems.value = cloneItems(next)
+      },
+      { deep: true },
+    )
+
+    const updateItems = (updater: (items: FloorCanvasItem[]) => FloorCanvasItem[]) => {
+      const draft = updater(cloneItems(localItems.value))
+      localItems.value = cloneItems(draft)
+      emit('update:items', cloneItems(localItems.value))
+    }
+
+    const moveItem = (id: string, partial: Partial<FloorCanvasItem>) => {
+      updateItems((items) =>
+        items.map((item) => (item.id === id ? { ...item, ...partial } : item)),
+      )
+    }
+
+    const areaBounds = computed<Bounds>(() => {
+      const base = toBaseBounds(props.floor)
+      if (!props.floor.isElastic) {
+        return base
+      }
+      return localItems.value.reduce(expandBoundsWithItem, base)
+    })
+
+    const handleDragEnd = (event: DragEvent, itemId: string) => {
+      event.preventDefault()
+      const nextX = clamp(event.clientX)
+      const nextY = clamp(event.clientY)
+      moveItem(itemId, { x: nextX, y: nextY })
+    }
+
+    const placeItem = (item: FloorCanvasItem) => {
+      updateItems((items) => [...items, { ...item }])
+    }
+
+    expose({ placeItem })
+
+    return () =>
+      h(
+        'div',
+        {
+          class: 'floor-canvas',
+          'data-testid': 'floor-canvas',
+          'data-area-width': String(areaBounds.value.width),
+          'data-area-length': String(areaBounds.value.length),
+          'data-area-height': String(areaBounds.value.height),
+          style: {
+            position: 'relative',
+            width: `${areaBounds.value.width}px`,
+            height: `${areaBounds.value.length}px`,
+          },
+        },
+        [
+          props.floor.isElastic
+            ? h('div', {
+                class: 'elastic-outline',
+                'data-testid': 'elastic-outline',
+                style: {
+                  width: `${areaBounds.value.width}px`,
+                  height: `${areaBounds.value.length}px`,
+                },
+              })
+            : null,
+          ...localItems.value.map((item) =>
+            h('div', {
+              key: item.id,
+              class: 'floor-item',
+              'data-testid': `floor-item-${item.id}`,
+              draggable: true,
+              style: {
+                position: 'absolute',
+                left: `${clamp(item.x)}px`,
+                top: `${clamp(item.y)}px`,
+                width: `${clamp(item.width)}px`,
+                height: `${clamp(item.length)}px`,
+              },
+              onDragend: (event: DragEvent) => handleDragEnd(event, item.id),
+            }),
+          ),
+        ],
+      )
+  },
+})

--- a/src/components/FloorForm.tsx
+++ b/src/components/FloorForm.tsx
@@ -1,0 +1,200 @@
+import { computed, defineComponent, h, reactive, watch } from 'vue'
+import type { PropType } from 'vue'
+
+export type FloorFormValues = {
+  width: number
+  length: number
+  height: number
+  isElastic: boolean
+}
+
+type ErrorBag = {
+  width: string
+  length: string
+  height: string
+}
+
+const createInitialState = (values?: Partial<FloorFormValues>): FloorFormValues => ({
+  width: Number(values?.width ?? 0),
+  length: Number(values?.length ?? 0),
+  height: Number(values?.height ?? 0),
+  isElastic: Boolean(values?.isElastic),
+})
+
+const createEmptyErrors = (): ErrorBag => ({ width: '', length: '', height: '' })
+
+export default defineComponent({
+  name: 'FloorForm',
+  props: {
+    initialValues: {
+      type: Object as PropType<Partial<FloorFormValues>>,
+      default: () => ({}) as Partial<FloorFormValues>,
+    },
+  },
+  emits: ['submit'],
+  setup(props, { emit }) {
+    const state = reactive(createInitialState(props.initialValues))
+    const errors = reactive(createEmptyErrors())
+
+    const disableDimensions = computed(() => state.isElastic)
+
+    const syncFromProps = (values?: Partial<FloorFormValues>) => {
+      const next = createInitialState(values)
+      state.width = next.width
+      state.length = next.length
+      state.height = next.height
+      state.isElastic = next.isElastic
+    }
+
+    watch(
+      () => props.initialValues,
+      (next) => {
+        syncFromProps(next)
+        Object.assign(errors, createEmptyErrors())
+      },
+      { deep: true },
+    )
+
+    const clearErrors = () => {
+      Object.assign(errors, createEmptyErrors())
+    }
+
+    const parseNumber = (value: string): number => {
+      const parsed = Number(value)
+      return Number.isFinite(parsed) ? parsed : 0
+    }
+
+    const validate = (): ErrorBag => {
+      const result = createEmptyErrors()
+      const checks: Array<[keyof ErrorBag, number]> = [
+        ['width', state.width],
+        ['length', state.length],
+        ['height', state.height],
+      ]
+
+      for (const [field, value] of checks) {
+        if (state.isElastic) {
+          if (value < 0) {
+            result[field] = 'No puede ser negativo'
+          }
+        } else if (value <= 0) {
+          result[field] = 'Debe ser mayor a 0'
+        }
+      }
+
+      return result
+    }
+
+    const handleSubmit = (event: Event) => {
+      event.preventDefault()
+      const validation = validate()
+      Object.assign(errors, validation)
+
+      const hasErrors = Object.values(validation).some((message) => message)
+      if (!hasErrors) {
+        emit('submit', { ...state })
+      }
+    }
+
+    const handleInput = (field: keyof FloorFormValues, event: Event) => {
+      const target = event.target as HTMLInputElement | null
+      if (!target) return
+      const value = parseNumber(target.value)
+      state[field] = value
+    }
+
+    const handleElasticToggle = (event: Event) => {
+      const target = event.target as HTMLInputElement | null
+      if (!target) return
+      state.isElastic = target.checked
+      if (state.isElastic) {
+        clearErrors()
+      }
+    }
+
+    return () =>
+      h(
+        'form',
+        {
+          class: 'floor-form',
+          onSubmit: handleSubmit,
+        },
+        [
+          h('div', { class: 'field' }, [
+            h('label', { for: 'floor-width' }, 'Ancho (cm)'),
+            h('input', {
+              id: 'floor-width',
+              name: 'width',
+              type: 'number',
+              min: '0',
+              value: state.width,
+              disabled: disableDimensions.value,
+              onInput: (event: Event) => handleInput('width', event),
+            }),
+            errors.width
+              ? h(
+                  'p',
+                  { class: 'error', 'data-error': 'width', role: 'alert' },
+                  errors.width,
+                )
+              : null,
+          ]),
+          h('div', { class: 'field' }, [
+            h('label', { for: 'floor-length' }, 'Largo (cm)'),
+            h('input', {
+              id: 'floor-length',
+              name: 'length',
+              type: 'number',
+              min: '0',
+              value: state.length,
+              disabled: disableDimensions.value,
+              onInput: (event: Event) => handleInput('length', event),
+            }),
+            errors.length
+              ? h(
+                  'p',
+                  { class: 'error', 'data-error': 'length', role: 'alert' },
+                  errors.length,
+                )
+              : null,
+          ]),
+          h('div', { class: 'field' }, [
+            h('label', { for: 'floor-height' }, 'Alto (cm)'),
+            h('input', {
+              id: 'floor-height',
+              name: 'height',
+              type: 'number',
+              min: '0',
+              value: state.height,
+              disabled: disableDimensions.value,
+              onInput: (event: Event) => handleInput('height', event),
+            }),
+            errors.height
+              ? h(
+                  'p',
+                  { class: 'error', 'data-error': 'height', role: 'alert' },
+                  errors.height,
+                )
+              : null,
+          ]),
+          h('div', { class: 'field' }, [
+            h(
+              'label',
+              { class: 'checkbox', for: 'floor-isElastic' },
+              [
+                h('input', {
+                  id: 'floor-isElastic',
+                  type: 'checkbox',
+                  name: 'isElastic',
+                  checked: state.isElastic,
+                  onChange: handleElasticToggle,
+                }),
+                h('span', null, 'Piso elástico'),
+              ],
+            ),
+          ]),
+          h('button', { type: 'submit' }, 'Guardar piso'),
+        ],
+      )
+  },
+})

--- a/src/components/__tests__/FloorCanvas.test.tsx
+++ b/src/components/__tests__/FloorCanvas.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+import FloorCanvas, { type FloorCanvasItem } from '../FloorCanvas'
+import { DEFAULT_ELASTIC_AREA, DEFAULT_ELASTIC_PADDING } from '../../constants/floor'
+
+describe('FloorCanvas', () => {
+  it('usa el área elástica por defecto al iniciar', async () => {
+    const wrapper = mount(FloorCanvas, {
+      props: {
+        floor: { width: 20, length: 25, height: 30, isElastic: true },
+        items: [],
+      },
+    })
+
+    await nextTick()
+
+    const canvas = wrapper.get('[data-testid="floor-canvas"]')
+    expect(canvas.attributes('data-area-width')).toBe(String(DEFAULT_ELASTIC_AREA.width))
+    expect(canvas.attributes('data-area-length')).toBe(String(DEFAULT_ELASTIC_AREA.length))
+    expect(canvas.attributes('data-area-height')).toBe(String(DEFAULT_ELASTIC_AREA.height))
+    expect(wrapper.find('[data-testid="elastic-outline"]').exists()).toBe(true)
+  })
+
+  it('expande los límites al arrastrar elementos más allá del área actual', async () => {
+    const initialItem: FloorCanvasItem = {
+      id: 'rack',
+      x: 10,
+      y: 15,
+      width: 40,
+      length: 35,
+      height: 25,
+    }
+
+    const wrapper = mount(FloorCanvas, {
+      props: {
+        floor: { width: 80, length: 80, height: 60, isElastic: true },
+        items: [initialItem],
+      },
+    })
+
+    const node = wrapper.get('[data-testid="floor-item-rack"]')
+    await node.trigger('dragend', { clientX: 220, clientY: 190 })
+    await nextTick()
+
+    const expectedWidth = Math.ceil((220 + initialItem.width) * (1 + DEFAULT_ELASTIC_PADDING))
+    const expectedLength = Math.ceil((190 + initialItem.length) * (1 + DEFAULT_ELASTIC_PADDING))
+
+    const canvas = wrapper.get('[data-testid="floor-canvas"]')
+    expect(Number(canvas.attributes('data-area-width'))).toBe(expectedWidth)
+    expect(Number(canvas.attributes('data-area-length'))).toBe(expectedLength)
+  })
+
+  it('amplía el área cuando se coloca un nuevo elemento', async () => {
+    const wrapper = mount(FloorCanvas, {
+      props: {
+        floor: { width: 50, length: 50, height: 40, isElastic: true },
+        items: [],
+      },
+    })
+
+    const api = wrapper.vm as unknown as { placeItem: (item: FloorCanvasItem) => void }
+    api.placeItem({ id: 'new', x: 260, y: 40, width: 60, length: 45, height: 30 })
+
+    await nextTick()
+
+    const expectedWidth = Math.ceil((260 + 60) * (1 + DEFAULT_ELASTIC_PADDING))
+    const expectedLength = Math.ceil((40 + 45) * (1 + DEFAULT_ELASTIC_PADDING))
+
+    const canvas = wrapper.get('[data-testid="floor-canvas"]')
+    expect(Number(canvas.attributes('data-area-width'))).toBe(expectedWidth)
+    expect(Number(canvas.attributes('data-area-length'))).toBe(expectedLength)
+  })
+})

--- a/src/components/__tests__/FloorForm.test.tsx
+++ b/src/components/__tests__/FloorForm.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import FloorForm from '../FloorForm'
+
+describe('FloorForm', () => {
+  it('deshabilita dimensiones cuando el piso es elástico', async () => {
+    const wrapper = mount(FloorForm, {
+      props: {
+        initialValues: { width: 120, length: 140, height: 60, isElastic: false },
+      },
+    })
+
+    const widthInput = wrapper.get('#floor-width')
+    const lengthInput = wrapper.get('#floor-length')
+    const heightInput = wrapper.get('#floor-height')
+
+    expect(widthInput.element.hasAttribute('disabled')).toBe(false)
+    expect(lengthInput.element.hasAttribute('disabled')).toBe(false)
+    expect(heightInput.element.hasAttribute('disabled')).toBe(false)
+
+    const checkbox = wrapper.get('#floor-isElastic')
+    await checkbox.setValue(true)
+
+    expect(widthInput.element.hasAttribute('disabled')).toBe(true)
+    expect(lengthInput.element.hasAttribute('disabled')).toBe(true)
+    expect(heightInput.element.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('omite la validación de > 0 cuando el piso es elástico', async () => {
+    const wrapper = mount(FloorForm, {
+      props: {
+        initialValues: { width: 0, length: 80, height: 70, isElastic: false },
+      },
+    })
+
+    const form = wrapper.get('form')
+    await form.trigger('submit.prevent')
+
+    const widthError = wrapper.get('[data-error="width"]')
+    expect(widthError.text()).toContain('Debe ser mayor a 0')
+    expect(wrapper.emitted('submit')).toBeUndefined()
+
+    const checkbox = wrapper.get('#floor-isElastic')
+    await checkbox.setValue(true)
+
+    await form.trigger('submit.prevent')
+
+    expect(wrapper.find('[data-error="width"]').exists()).toBe(false)
+    const submissions = wrapper.emitted('submit')
+    expect(submissions).toBeTruthy()
+    const payload = submissions?.[submissions.length - 1]?.[0] as { isElastic: boolean; width: number }
+    expect(payload.isElastic).toBe(true)
+    expect(payload.width).toBe(0)
+  })
+})

--- a/src/constants/floor.ts
+++ b/src/constants/floor.ts
@@ -1,0 +1,20 @@
+export interface FloorDimensions {
+  width: number
+  length: number
+  height: number
+  isElastic?: boolean
+}
+
+export interface ElasticBounds {
+  width: number
+  length: number
+  height: number
+}
+
+export const DEFAULT_ELASTIC_AREA: ElasticBounds = {
+  width: 100,
+  length: 100,
+  height: 100,
+}
+
+export const DEFAULT_ELASTIC_PADDING = 0.25

--- a/src/server/migrations/1710000000000-add-elastic-floor.ts
+++ b/src/server/migrations/1710000000000-add-elastic-floor.ts
@@ -1,0 +1,48 @@
+/*
+ * Migration to introduce the elastic floor flag and relaxed dimension checks.
+ * The implementation mirrors a TypeORM MigrationInterface without importing the
+ * full dependency (kept lightweight for the snippet catalog).
+ */
+
+export type QueryRunnerLike = { query: (sql: string) => Promise<unknown> }
+
+export class AddElasticToFloor1710000000000 /* implements MigrationInterface */ {
+  public async up(queryRunner: QueryRunnerLike): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "floors" ADD COLUMN IF NOT EXISTS "isElastic" boolean NOT NULL DEFAULT false',
+    )
+
+    await queryRunner.query(
+      'ALTER TABLE "floors" DROP CONSTRAINT IF EXISTS "CHK_floors_positive_dimensions"',
+    )
+
+    await queryRunner.query(
+      [
+        'ALTER TABLE "floors" ADD CONSTRAINT "CHK_floors_positive_dimensions"',
+        'CHECK (',
+        '  CASE',
+        '    WHEN "isElastic" THEN',
+        '      "width" >= 0 AND "length" >= 0 AND "height" >= 0',
+        '    ELSE',
+        '      "width" > 0 AND "length" > 0 AND "height" > 0',
+        '  END',
+        ')',
+      ].join(' '),
+    )
+  }
+
+  public async down(queryRunner: QueryRunnerLike): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "floors" DROP CONSTRAINT IF EXISTS "CHK_floors_positive_dimensions"',
+    )
+
+    await queryRunner.query('ALTER TABLE "floors" DROP COLUMN IF EXISTS "isElastic"')
+
+    await queryRunner.query(
+      [
+        'ALTER TABLE "floors" ADD CONSTRAINT "CHK_floors_positive_dimensions"',
+        'CHECK ("width" > 0 AND "length" > 0 AND "height" > 0)',
+      ].join(' '),
+    )
+  }
+}

--- a/src/server/mongoose/floor.schema.ts
+++ b/src/server/mongoose/floor.schema.ts
@@ -1,0 +1,79 @@
+type SchemaDefinitionInput = Record<string, unknown>
+type SchemaOptionsInput = Record<string, unknown>
+
+type SchemaPathValidator = {
+  validator(this: FloorSchemaThis, value: number): boolean
+  message: string
+}
+
+type SchemaPathLike = {
+  validate(config: SchemaPathValidator): void
+}
+
+type SchemaInstanceLike = {
+  path(path: string): SchemaPathLike
+}
+
+type SchemaConstructorLike = new (
+  definition: SchemaDefinitionInput,
+  options?: SchemaOptionsInput,
+) => SchemaInstanceLike
+
+type FloorSchemaThis = {
+  get(path: 'isElastic'): boolean
+}
+
+const widthMessage = 'La anchura debe ser mayor a 0 salvo en pisos elásticos.'
+const lengthMessage = 'La longitud debe ser mayor a 0 salvo en pisos elásticos.'
+const heightMessage = 'La altura debe ser mayor a 0 salvo en pisos elásticos.'
+
+const buildDefinition = (): SchemaDefinitionInput => ({
+  width: {
+    type: Number,
+    min: [0, 'La anchura no puede ser negativa'],
+    required: true,
+  },
+  length: {
+    type: Number,
+    min: [0, 'La longitud no puede ser negativa'],
+    required: true,
+  },
+  height: {
+    type: Number,
+    min: [0, 'La altura no puede ser negativa'],
+    required: true,
+  },
+  isElastic: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const buildValidation = (schema: SchemaInstanceLike): void => {
+  const isElastic = function (this: FloorSchemaThis) {
+    return Boolean(this.get('isElastic'))
+  }
+
+  const validatorFactory = (message: string) => ({
+    validator(this: FloorSchemaThis, value: number) {
+      return isElastic.call(this) ? value >= 0 : value > 0
+    },
+    message,
+  })
+
+  schema.path('width').validate(validatorFactory(widthMessage))
+  schema.path('length').validate(validatorFactory(lengthMessage))
+  schema.path('height').validate(validatorFactory(heightMessage))
+}
+
+export const createFloorSchema = (
+  SchemaCtor: SchemaConstructorLike,
+  options: SchemaOptionsInput = { timestamps: true },
+): SchemaInstanceLike => {
+  const schema = new SchemaCtor(buildDefinition(), options)
+  buildValidation(schema)
+  return schema
+}
+
+type CreateFloorSchema = typeof createFloorSchema
+export type FloorSchema = ReturnType<CreateFloorSchema>

--- a/src/styles/floors.scss
+++ b/src/styles/floors.scss
@@ -1,0 +1,6 @@
+.elastic-outline {
+  border: 2px dashed #888;
+  position: absolute;
+  transition: width 0.3s, height 0.3s;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add a lightweight migration stub to register the `isElastic` flag and relaxed dimension checks for floors
- provide reusable floor constants and Vue form/canvas components that honour elastic floors while disabling validations when needed
- back the new behaviour with focused unit tests and styling for the elastic outline

## Testing
- npx vitest run src/components/__tests__/FloorForm.test.tsx src/components/__tests__/FloorCanvas.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca3fe910c0832198130fd9037d01eb