### PR TITLE
Fix infinite plant dragging visibility

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -14,7 +14,10 @@
 
       <!-- Canvas principal -->
       <div class="app-canvas">
-        <CanvasView :safeRight="canvasStore.mostrarPropiedades ? 320 : 20" />
+        <CanvasView
+          ref="canvasViewRef"
+          :safeRight="canvasStore.mostrarPropiedades ? 320 : 20"
+        />
       </div>
 
       <!-- Panel de propiedades (superpuesto para no empujar el canvas) -->
@@ -86,8 +89,10 @@ const { exportarCanvas, importarCanvas, validarJSON } = useCanvasImportExport()
 const { undo, redo, store: canvasStore } = useCanvasWithHistory()
 const buffer = useCanvasBuffer()
 const { deleteSelected } = useDeleteElement()
-const { handlePaste } = useAutoPaste()
+const { handlePaste: autoPaste } = useAutoPaste()
 const { showToast } = useToast()
+
+const canvasViewRef = ref(null)
 
 // Estado del modal de aviso de reemplazo por servidor
 const showReplaceNotice = ref(false)
@@ -190,7 +195,7 @@ const handleKeydown = (e) => {
       handleCopyToBuffer()
     } else if (e.key === 'v') {
       e.preventDefault()
-      handlePaste()
+      triggerPaste()
     }
   } else if (e.key === 'Delete' || e.key === 'Backspace') {
     // Supr o Retroceso -> eliminar seleccionado
@@ -209,6 +214,56 @@ const handleCopyToBuffer = () => {
   if (elementoSeleccionado) {
     buffer.copyToBuffer(elementoSeleccionado)
     console.log('📋 Estructura copiada al buffer')
+  }
+}
+
+const triggerPaste = () => {
+  try {
+    const stage = canvasViewRef.value?.getStage?.()
+    const viewportSize = canvasViewRef.value?.getStageSize?.() || null
+    const viewportWorld = canvasViewRef.value?.getViewportWorldRect?.() || null
+
+    let startPosition = null
+
+    if (stage && typeof stage.getPointerPosition === 'function') {
+      const pointer = stage.getPointerPosition()
+      const scale = typeof stage.scaleX === 'function' ? stage.scaleX() || 1 : 1
+      const stageX = typeof stage.x === 'function' ? stage.x() || 0 : 0
+      const stageY = typeof stage.y === 'function' ? stage.y() || 0 : 0
+
+      if (pointer) {
+        startPosition = {
+          x: (pointer.x - stageX) / (scale || 1),
+          y: (pointer.y - stageY) / (scale || 1),
+        }
+      }
+
+      if (!startPosition && viewportSize) {
+        startPosition = {
+          x: (viewportSize.width / 2 - stageX) / (scale || 1),
+          y: (viewportSize.height / 2 - stageY) / (scale || 1),
+        }
+      }
+    }
+
+    if (!startPosition && viewportSize) {
+      const scale = canvasStore.zoom || 1
+      const stageX = canvasStore.panX || 0
+      const stageY = canvasStore.panY || 0
+      startPosition = {
+        x: (viewportSize.width / 2 - stageX) / (scale || 1),
+        y: (viewportSize.height / 2 - stageY) / (scale || 1),
+      }
+    }
+
+    void autoPaste({
+      startPosition: startPosition || null,
+      viewportSize,
+      viewportWorld,
+    })
+  } catch (error) {
+    console.warn('No se pudo calcular el punto inicial para pegar:', error)
+    void autoPaste()
   }
 }
 

--- a/src/inventory-smart/components/CanvasInfo.vue
+++ b/src/inventory-smart/components/CanvasInfo.vue
@@ -8,7 +8,7 @@
         position="bottom"
         :delay="300"
       >
-        <span class="elastic-badge">Elástico</span>
+        <span class="elastic-badge">Infinito</span>
       </UiTooltip>
     </template>
     <!-- <span v-if="store.estaEnPlanta && store.plantaActivaData">

--- a/src/inventory-smart/components/CanvasInfo.vue
+++ b/src/inventory-smart/components/CanvasInfo.vue
@@ -78,5 +78,11 @@ onUnmounted(() => {
   }
 })
 
-watch(() => [store.zoom, store.vistaActiva, store.contextoActual.id], () => nextTick(recompute))
+watch(
+  () => {
+    const ctx = store.contextoActual || {}
+    return [store.zoom, store.vistaActiva, ctx?.id]
+  },
+  () => nextTick(recompute),
+)
 </script>

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -2189,6 +2189,34 @@ const onDelete = async (id) => {
   await deleteSelected({ withConfirm: true })
   ctx.close()
 }
+
+const getStageInstance = () => stageRef.value?.getNode?.() || null
+
+const getStageSizeSnapshot = () => ({
+  width: stageSize.value.width,
+  height: stageSize.value.height,
+})
+
+const getViewportWorldRect = () => {
+  const stage = getStageInstance()
+  if (!stage) return null
+  const scale = typeof stage.scaleX === 'function' ? stage.scaleX() || 1 : 1
+  if (!Number.isFinite(scale) || scale === 0) return null
+  const stageX = typeof stage.x === 'function' ? stage.x() || 0 : 0
+  const stageY = typeof stage.y === 'function' ? stage.y() || 0 : 0
+  return {
+    minX: (0 - stageX) / scale,
+    minY: (0 - stageY) / scale,
+    maxX: (stageSize.value.width - stageX) / scale,
+    maxY: (stageSize.value.height - stageY) / scale,
+  }
+}
+
+defineExpose({
+  getStage: getStageInstance,
+  getStageSize: getStageSizeSnapshot,
+  getViewportWorldRect,
+})
 </script>
 
 <style scoped>

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -606,7 +606,7 @@
       @close="closeTemplateModal"
     />
 
-    <CanvasInfo />
+    <CanvasInfo v-if="!isInfinitePlant" />
 
     <FloatingControls
       :safe-right="safeRight"

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -1887,7 +1887,9 @@ const updateStageSize = () => {
   centrarPlantaEnCanvas()
 }
 
-function centrarPlantaEnCanvas() {
+function centrarPlantaEnCanvas(options = {}) {
+  const { force = false } = options
+  if (isInfinitePlant.value && !force) return
   try {
     const stage = stageRef.value?.getNode?.()
     if (!stage) return
@@ -1957,13 +1959,15 @@ onUnmounted(() => {
   window.removeEventListener('keydown', handleKeyDown)
 })
 
-function recomputeBoundsAndIndex() {
+function recomputeBoundsAndIndex({ skipCenter = false } = {}) {
   try {
     conflictsApi.clear()
     dragLastValidPositions.value.clear()
     isElementDragging.value = false
     stageDragEnabled.value = true
-    nextTick(() => centrarPlantaEnCanvas())
+    if (!skipCenter) {
+      nextTick(() => centrarPlantaEnCanvas())
+    }
   } catch {
     console.error('Error recomputando bounds e índice de elementos')
   }
@@ -2002,7 +2006,7 @@ watch(
   () => [layerConfig.value.width, layerConfig.value.height],
   async () => {
     await nextTick()
-    recomputeBoundsAndIndex()
+    recomputeBoundsAndIndex({ skipCenter: isInfinitePlant.value })
     await nextTick()
     forceRedraw()
   },
@@ -2037,7 +2041,8 @@ const fitToPlanta = () => {
 
     // Sincronizar llamada explícita para compatibilidad con pruebas:
     // intentar usar el bbox del polígono crudo (sin interpretar unidades)
-    let z = getDynamicMinZoom()
+    const dynamicMinZoom = getDynamicMinZoom()
+    let z = dynamicMinZoom
     try {
       const poly = canvasStore.plantaActivaData?.poligono
       if (Array.isArray(poly) && poly.length >= 3) {
@@ -2059,7 +2064,11 @@ const fitToPlanta = () => {
       }
     } catch { /* ignore */ }
 
-    canvasStore.configurarZoom(z, z)
+    if (isInfinitePlant.value) {
+      canvasStore.configurarZoom(canvasStore.zoom, dynamicMinZoom)
+    } else {
+      canvasStore.configurarZoom(z, z)
+    }
   } catch (e) {
     console.error('fitToPlanta error', e)
     try {

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -609,7 +609,7 @@
       @close="closeTemplateModal"
     />
 
-    <CanvasInfo v-if="!isInfinitePlant" />
+    <CanvasInfo />
 
     <FloatingControls
       :safe-right="safeRight"

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -15,7 +15,11 @@
   <div
     ref="containerRef"
     class="canvas-container"
-    :class="{ 'drag-over': isDragOverCanvas, 'cursor-grab': !dragModeGlobal }"
+    :class="{
+      'drag-over': isDragOverCanvas,
+      'cursor-grab': !dragModeGlobal,
+      'infinite-floor': isInfinitePlant,
+    }"
     @drop="handleDrop"
     @dragover="handleDragOver"
     @dragenter="handleDragEnter"
@@ -836,6 +840,7 @@ const stageConfig = computed(() => {
 })
 
 const activeBounds = computed(() => getActiveBounds(canvasStore))
+const isInfinitePlant = computed(() => canvasStore.plantaActivaData?.isInfinite === true)
 
 const plantPolygon = computed(() => activeBounds.value.polygonPx)
 
@@ -843,16 +848,34 @@ const insetPoly = computed(() => polygonInset(plantPolygon.value, 1))
 
 const plantPolygonFlat = computed(() => plantPolygon.value.flatMap((p) => [p.x, p.y]))
 
-const floorBoundary = computed(() => activeBounds.value.boundsPx)
+const floorBoundary = computed(() => {
+  const bounds = activeBounds.value.boundsPx || { width: 0, height: 0 }
+  if (!isInfinitePlant.value) {
+    return bounds
+  }
+  const zoom = canvasStore.zoom || 1
+  const viewWidth = stageSize.value.width / (zoom || 1)
+  const viewHeight = stageSize.value.height / (zoom || 1)
+  return {
+    width: Math.max(bounds.width || 0, viewWidth || 0),
+    height: Math.max(bounds.height || 0, viewHeight || 0),
+  }
+})
 
 // Configuración del layer - SIEMPRE USA CANVAS ADAPTATIVO
 const layerConfig = computed(() => {
-  // Usar siempre canvasAdaptativo como fuente única de verdad
-  const config = {
-    width: canvasStore.canvasAdaptativo.width,
-    height: canvasStore.canvasAdaptativo.height,
+  const baseWidth = canvasStore.canvasAdaptativo?.width || 0
+  const baseHeight = canvasStore.canvasAdaptativo?.height || 0
+  if (!isInfinitePlant.value) {
+    return { width: baseWidth, height: baseHeight }
   }
-  return config
+  const zoom = canvasStore.zoom || 1
+  const viewWidth = stageSize.value.width / (zoom || 1)
+  const viewHeight = stageSize.value.height / (zoom || 1)
+  return {
+    width: Math.max(baseWidth, viewWidth || 0),
+    height: Math.max(baseHeight, viewHeight || 0),
+  }
 })
 
 // Composable para zoom
@@ -865,7 +888,51 @@ const {
 // Elementos visibles en el canvas (excluye elementos ocultos)
 const elementosVisiblesEnCanvas = computed(() => {
   const visibles = canvasStore.elementosVisibles.filter((elemento) => elemento.visible !== false)
-  return visibles
+  if (!isInfinitePlant.value) {
+    return visibles
+  }
+
+  const zoom = canvasStore.zoom || 1
+  const stageWidth = stageSize.value.width || 0
+  const stageHeight = stageSize.value.height || 0
+
+  if (!stageWidth || !stageHeight || !Number.isFinite(zoom) || zoom <= 0) {
+    return visibles
+  }
+
+  const viewX = -canvasStore.panX / zoom
+  const viewY = -canvasStore.panY / zoom
+  const viewW = stageWidth / zoom
+  const viewH = stageHeight / zoom
+  const padding = 200 / zoom
+
+  const minX = viewX - padding
+  const maxX = viewX + viewW + padding
+  const minY = viewY - padding
+  const maxY = viewY + viewH + padding
+
+  const stage = stageRef.value?.getNode?.()
+
+  return visibles.filter((elemento) => {
+    const width = getDrawWidth(elemento) || 0
+    const height = getDrawHeight(elemento) || 0
+    const x = elemento.x ?? 0
+    const y = elemento.y ?? 0
+
+    const intersects = x + width >= minX && x <= maxX && y + height >= minY && y <= maxY
+    if (intersects) {
+      return true
+    }
+
+    if (stage) {
+      const node = stage.findOne?.(`#${elemento.id}`)
+      if (node && typeof node.isDragging === 'function' && node.isDragging()) {
+        return true
+      }
+    }
+
+    return false
+  })
 })
 
 // Detectar si existen pasillos visibles y toggle para su borde punteado
@@ -901,19 +968,33 @@ const gridLines = computed(() => {
 })
 
 watch(
-  plantPolygon,
-  (poly) => {
+  [plantPolygon, isInfinitePlant],
+  ([poly, infinite]) => {
     const layer = layerRef.value?.getNode?.()
-    if (layer && poly?.length) {
-      layer.clipFunc((ctx) => {
-        ctx.beginPath()
-        poly.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)))
-        ctx.closePath()
-      })
+    if (!layer) return
+
+    if (infinite || !poly?.length) {
+      try {
+        layer.clipFunc(null)
+        if (typeof layer.clipWidth === 'function') layer.clipWidth(null)
+        if (typeof layer.clipHeight === 'function') layer.clipHeight(null)
+        if (typeof layer.clipX === 'function') layer.clipX(0)
+        if (typeof layer.clipY === 'function') layer.clipY(0)
+      } catch {
+        /* ignore */
+      }
       layer.batchDraw?.()
+      return
     }
+
+    layer.clipFunc((ctx) => {
+      ctx.beginPath()
+      poly.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)))
+      ctx.closePath()
+    })
+    layer.batchDraw?.()
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 )
 
 // Contorno activo siempre expresado como polígono
@@ -1096,6 +1177,9 @@ const toStageCoords = (pos) => {
 // Drag bound para cada elemento y forma (clamp mínimo al contorno)
 const dragBoundForElement = (pos, elemento) => {
   try {
+    if (isInfinitePlant.value) {
+      return pos
+    }
     const lp = toLayerCoords(pos)
     const boundary = computeBoundary()
     const { w_cm, h_cm } = dimsCmFor(elemento, canvasStore.vistaActiva)
@@ -1237,7 +1321,7 @@ const getWorldCoordinatesFromPointer = (dropEvent) => {
 const runPreDropValidations = (elemento, dropEvent) => {
   if (!elemento) return { ok: false, reason: 'invalid' }
 
-  const contextoActual = canvasStore.contextoActual.tipo
+  const contextoActual = canvasStore.contextoActual?.tipo || 'plantas'
   const tipoElemento = elemento.tipo
 
   // Reglas de jerarquía actualizadas
@@ -1989,8 +2073,13 @@ const fitToPlanta = () => {
 
 // Auto-ajustar siempre que cambia el contexto (planta / elemento / contenedor)
 watch(
-  () => [canvasStore.contextoActual.tipo, canvasStore.contextoActual.id],
+  () => {
+    const ctx = canvasStore.contextoActual || {}
+    return [ctx?.tipo, ctx?.id]
+  },
   async () => {
+    const ctx = canvasStore.contextoActual
+    if (!ctx || !ctx.tipo) return
     // Esperar a que el store recalcule canvasAdaptativo y layerConfig
     await nextTick()
     await nextTick()
@@ -2102,6 +2191,10 @@ const onDelete = async (id) => {
   background: #f8fafc;
   border: 1px solid #e2e8f0;
   transition: all 0.2s ease;
+}
+
+.canvas-container.infinite-floor {
+  overflow: visible;
 }
 
 .canvas-container.drag-over {

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -449,6 +449,7 @@
       <v-layer ref="uiLayerRef" :config="{ listening: false }">
         <!-- Debug: mostrar información según el contexto -->
         <v-text
+          v-if="!canvasStore.estaEnPlanta || canvasStore.plantaActivaData?.isInfinite !== true"
           :config="{
             x: 10,
             y: -(39 / canvasStore.zoom),
@@ -459,10 +460,11 @@
             fontFamily: 'Arial',
             fill: '#3b82f6',
             listening: false,
+            name: 'floor-info-label',
           }"
         />
         <v-text
-          v-if="canvasStore.estaEnPlanta"
+          v-if="canvasStore.estaEnPlanta && canvasStore.plantaActivaData?.isInfinite !== true"
           :config="{
             x: 10,
             y: -(11 / canvasStore.zoom) - 8 / canvasStore.zoom,
@@ -471,6 +473,7 @@
             fontFamily: 'Arial',
             fill: '#6b7280',
             listening: false,
+            name: 'floor-info-label',
           }"
         />
 

--- a/src/inventory-smart/composables/useAutoPaste.js
+++ b/src/inventory-smart/composables/useAutoPaste.js
@@ -38,6 +38,11 @@ export function useAutoPaste() {
   const { showToast } = useToast()
   const { startLoading, stopLoading, isOperationInProgress } = useLoader()
 
+  const pasteOffsetStep = { x: 16, y: 16 }
+  let lastPasteContextKey = null
+  let lastPasteAnchor = null
+  let lastOffsetApplied = 0
+
   /**
    * Calcula el centroide de un polígono
    */
@@ -162,13 +167,102 @@ export function useAutoPaste() {
    * Obtiene las dimensiones del área disponible en el contexto actual
    * considerando la vista activa (XY o XZ), las dimensiones apropiadas y el polígono de la planta
    */
-  const getAreaBounds = () => {
+  const getAreaBounds = (options = {}) => {
     const contexto = canvasStore.contextoActual
     const vistaActiva = canvasStore.vistaActiva
     const canvasAdaptativo = canvasStore.canvasAdaptativo
+    const { startPosition = null, viewportSize = null, viewportWorld = null } = options || {}
     let bounds = { minX: 0, minY: 0, maxX: 0, maxY: 0 }
     let polygonPoints = null
     let insetPolygon = null
+
+    const isInfiniteFloor =
+      contexto?.tipo === 'plantas' && canvasStore.plantaActivaData?.isInfinite === true
+
+    if (isInfiniteFloor) {
+      const zoom = canvasStore.zoom || 1
+      const panX = canvasStore.panX || 0
+      const panY = canvasStore.panY || 0
+
+      const baseRect =
+        viewportWorld &&
+        Number.isFinite(viewportWorld.minX) &&
+        Number.isFinite(viewportWorld.minY) &&
+        Number.isFinite(viewportWorld.maxX) &&
+        Number.isFinite(viewportWorld.maxY)
+          ? viewportWorld
+          : (() => {
+              const widthScreen = viewportSize?.width ?? canvasAdaptativo?.width ?? 2000
+              const heightScreen = viewportSize?.height ?? canvasAdaptativo?.height ?? 2000
+              const safeZoom = zoom || 1
+              const minX = (-panX) / safeZoom
+              const minY = (-panY) / safeZoom
+              const widthWorld = (widthScreen || 0) / safeZoom
+              const heightWorld = (heightScreen || 0) / safeZoom
+              return {
+                minX,
+                minY,
+                maxX: minX + Math.max(1, widthWorld || 0),
+                maxY: minY + Math.max(1, heightWorld || 0),
+              }
+            })()
+
+      let { minX, minY, maxX, maxY } = baseRect
+
+      const spanX = Math.max(1, maxX - minX)
+      const spanY = Math.max(1, maxY - minY)
+      const padX = Math.max(200, spanX * 0.25)
+      const padY = Math.max(200, spanY * 0.25)
+
+      minX -= padX
+      maxX += padX
+      minY -= padY
+      maxY += padY
+
+      if (startPosition) {
+        const ensurePadX = Math.max(padX, spanX * 0.5)
+        const ensurePadY = Math.max(padY, spanY * 0.5)
+        minX = Math.min(minX, startPosition.x - ensurePadX)
+        maxX = Math.max(maxX, startPosition.x + ensurePadX)
+        minY = Math.min(minY, startPosition.y - ensurePadY)
+        maxY = Math.max(maxY, startPosition.y + ensurePadY)
+      }
+
+      if (!Number.isFinite(minX) || !Number.isFinite(maxX)) {
+        minX = -1000
+        maxX = 1000
+      }
+
+      if (!Number.isFinite(minY) || !Number.isFinite(maxY)) {
+        minY = -1000
+        maxY = 1000
+      }
+
+      if (maxX <= minX) {
+        const centerX = startPosition?.x ?? (minX + maxX) / 2
+        const width = Math.max(spanX, 400)
+        minX = centerX - width / 2
+        maxX = centerX + width / 2
+      }
+
+      if (maxY <= minY) {
+        const centerY = startPosition?.y ?? (minY + maxY) / 2
+        const height = Math.max(spanY, 400)
+        minY = centerY - height / 2
+        maxY = centerY + height / 2
+      }
+
+      return {
+        minX,
+        minY,
+        maxX,
+        maxY,
+        polygon: null,
+        insetPolygon: null,
+        hasPolygon: false,
+        mode: 'elastic',
+      }
+    }
 
     if (contexto.tipo === 'plantas') {
       const planta = canvasStore.plantaPorId(contexto.id)
@@ -235,7 +329,8 @@ export function useAutoPaste() {
       ...bounds,
       polygon: polygonPoints,
       insetPolygon: insetPolygon,
-      hasPolygon: !!polygonPoints && polygonPoints.length > 0
+      hasPolygon: !!polygonPoints && polygonPoints.length > 0,
+      mode: 'fixed',
     }
   }
 
@@ -442,9 +537,16 @@ export function useAutoPaste() {
     let initialX, initialY
 
     if (startPosition) {
-      // Si se especifica una posición, usarla (con límites)
-      initialX = Math.max(areaBounds.minX, Math.min(startPosition.x, areaBounds.maxX - elementWidth))
-      initialY = Math.max(areaBounds.minY, Math.min(startPosition.y, areaBounds.maxY - elementHeight))
+      const desiredX = startPosition.x - elementWidth / 2
+      const desiredY = startPosition.y - elementHeight / 2
+      initialX = Math.max(
+        areaBounds.minX,
+        Math.min(desiredX, areaBounds.maxX - elementWidth),
+      )
+      initialY = Math.max(
+        areaBounds.minY,
+        Math.min(desiredY, areaBounds.maxY - elementHeight),
+      )
     } else if (areaBounds.hasPolygon && areaBounds.polygon) {
       // Si hay polígono, intentar usar su centroide como punto inicial
       const centroid = calculatePolygonCentroid(areaBounds.polygon)
@@ -548,7 +650,7 @@ export function useAutoPaste() {
   /**
    * Pega automáticamente el primer elemento del buffer
    */
-  const handlePaste = async () => {
+  const handlePaste = async (options = {}) => {
     // Verificar si ya hay una operación de pegado en progreso
     if (isOperationInProgress('paste')) {
       showToast('Ya hay una operación de pegado en curso. Espera a que termine.', 'warning')
@@ -556,6 +658,43 @@ export function useAutoPaste() {
     }
 
     let loadingId = null
+    const { startPosition: providedStart = null, viewportSize = null, viewportWorld = null } = options || {}
+
+    const contextKey = [
+      canvasStore.contextoActual?.tipo || 'unknown',
+      canvasStore.contextoActual?.id || 'unknown',
+      canvasStore.plantaActiva || 'none',
+    ].join(':')
+
+    if (contextKey !== lastPasteContextKey) {
+      lastPasteContextKey = contextKey
+      lastPasteAnchor = null
+      lastOffsetApplied = 0
+    }
+
+    const anchor =
+      providedStart &&
+      Number.isFinite(providedStart.x) &&
+      Number.isFinite(providedStart.y)
+        ? { x: providedStart.x, y: providedStart.y }
+        : null
+
+    let effectiveStart = anchor ? { ...anchor } : null
+    let pendingOffsetCount = 0
+    const OFFSET_THRESHOLD = 4
+
+    if (anchor && lastPasteAnchor) {
+      const dx = anchor.x - lastPasteAnchor.x
+      const dy = anchor.y - lastPasteAnchor.y
+      const distance = Math.hypot(dx, dy)
+      if (distance < OFFSET_THRESHOLD) {
+        pendingOffsetCount = lastOffsetApplied + 1
+        effectiveStart = {
+          x: anchor.x + pasteOffsetStep.x * pendingOffsetCount,
+          y: anchor.y + pasteOffsetStep.y * pendingOffsetCount,
+        }
+      }
+    }
 
     try {
       // Verificar que hay elementos en el buffer
@@ -591,15 +730,28 @@ export function useAutoPaste() {
       await new Promise(resolve => setTimeout(resolve, 100))
 
       // Obtener límites del área actual
-      const areaBounds = getAreaBounds()
+      const areaBounds = getAreaBounds({
+        startPosition: anchor ?? effectiveStart ?? null,
+        viewportSize,
+        viewportWorld,
+      })
 
-      if (areaBounds.maxX === 0 || areaBounds.maxY === 0) {
+      if (
+        !Number.isFinite(areaBounds.minX) ||
+        !Number.isFinite(areaBounds.maxX) ||
+        !Number.isFinite(areaBounds.minY) ||
+        !Number.isFinite(areaBounds.maxY)
+      ) {
         showToast('No se pudieron determinar los límites del área actual.', 'error')
         return false
       }
 
       // Buscar espacio disponible
-      const spaceResult = findAvailableSpace(elemento, areaBounds)
+      const spaceResult = findAvailableSpace(
+        elemento,
+        areaBounds,
+        effectiveStart || anchor || null,
+      )
 
       if (!spaceResult.found) {
         const elementType = elemento.ubicacion === 'pared' ? 'de pared' : 'de suelo'
@@ -636,6 +788,18 @@ export function useAutoPaste() {
         // Seleccionar el elemento recién pegado
         canvasStore.seleccionarElemento(elementoId)
         // canvasStore.destacarElemento(elementoId)
+
+        if (anchor) {
+          lastPasteAnchor = { ...anchor }
+          lastOffsetApplied = pendingOffsetCount
+        } else if (effectiveStart) {
+          lastPasteAnchor = { ...effectiveStart }
+          lastOffsetApplied = pendingOffsetCount
+        } else {
+          lastPasteAnchor = null
+          lastOffsetApplied = 0
+        }
+        lastPasteContextKey = contextKey
 
         return true
       } else {

--- a/src/inventory-smart/composables/useCacheOnDrag.js
+++ b/src/inventory-smart/composables/useCacheOnDrag.js
@@ -1,4 +1,5 @@
 import { watch, getCurrentInstance, onUnmounted } from 'vue'
+import { isPlantInfinite } from '@/inventory-smart/utils/polygonBounds'
 
 // Automatically enable Konva node caching during drag operations.
 // - On `dragstart`: calls `node.cache()` and `node.draw()`
@@ -17,6 +18,7 @@ export function useCacheOnDrag(refNode) {
 
   const onDragStart = () => {
     try {
+      if (isPlantInfinite()) return
       node && node.cache && node.cache()
       node && node.draw && node.draw()
     } catch {

--- a/src/inventory-smart/composables/useDimensionValidation.js
+++ b/src/inventory-smart/composables/useDimensionValidation.js
@@ -260,6 +260,10 @@ export function useDimensionValidation() {
     const parentId = elemento.padre || elemento.parentId;
     const padre = canvasStore.elementoPorId(parentId);
 
+    if (canvasStore.plantaActivaData?.isInfinite === true && canvasStore.estaEnPlanta) {
+      return { valida: true, razon: 'La planta activa es infinita, no aplica restricción de canvas adaptativo' };
+    }
+
     if (!padre || !padre.dimensiones) {
       return { valida: true, razon: 'No se encontró el contenedor padre o no tiene dimensiones' };
     }

--- a/src/inventory-smart/composables/useTransformer.js
+++ b/src/inventory-smart/composables/useTransformer.js
@@ -104,6 +104,31 @@ export function useTransformer({
           const MINW = 10
           const MINH = 10
           if (newBox.width <= 0 || newBox.height <= 0) return oldBox
+
+          let boundaryMode
+          if (typeof computeBoundary === 'function') {
+            try {
+              boundaryMode = computeBoundary()?.mode
+            } catch (err) {
+              console.warn('[transform-boundary-mode] Error obteniendo modo de boundary:', err)
+            }
+          }
+
+          const isElasticBoundary = boundaryMode === 'elastic'
+          const isInfiniteFloor = canvasStore.plantaActivaData?.isInfinite === true
+
+          const minWidth = Math.max(MINW, newBox.width)
+          const minHeight = Math.max(MINH, newBox.height)
+
+          // Para plantas infinitas o boundaries elásticos, nunca revertir a oldBox, solo asegurar mínimos
+          if (isInfiniteFloor || isElasticBoundary) {
+            if (elemento?.forma === 'circular') {
+              const size = Math.max(minWidth, minHeight)
+              return { ...newBox, width: size, height: size }
+            }
+            return { ...newBox, width: minWidth, height: minHeight }
+          }
+
           if (newBox.width < MINW || newBox.height < MINH) return oldBox
 
           // Para elementos circulares, mantener aspecto cuadrado
@@ -364,8 +389,17 @@ export function useTransformer({
         return
       }
 
-  // Usar el snapshot congelado para todas las operaciones
-  const elementoSnapshot = elemento
+      // Usar el snapshot congelado para todas las operaciones
+      const elementoSnapshot = elemento
+
+      let boundary = null
+      if (typeof computeBoundary === 'function') {
+        try {
+          boundary = computeBoundary()
+        } catch (boundaryErr) {
+          console.warn('[transform-boundary-compute] Error obteniendo límites activos:', boundaryErr)
+        }
+      }
 
       // Extraer valores de Konva (mantener valores originales para Konva y store)
       const width = node.width() * node.scaleX()
@@ -583,28 +617,25 @@ export function useTransformer({
 
       // VALIDACIÓN 2: Verificar que esté dentro del polígono de la planta
       try {
-        if (typeof computeBoundary === 'function') {
-          const boundary = computeBoundary()
-          if (boundary && boundary.type === 'polygon' && boundary.mode !== 'elastic') {
-            let isInsidePolygon = false
-            const polygon = boundary.inset || boundary.points
+        if (boundary && boundary.type === 'polygon' && boundary.mode !== 'elastic') {
+          let isInsidePolygon = false
+          const polygon = boundary.inset?.length ? boundary.inset : boundary.points
 
-            if (elemento?.forma === 'circular') {
-              // Para círculos, verificar que el círculo completo esté dentro
-              const radius = Math.min(width, height) / 2
-              const centerX = x + radius
-              const centerY = y + radius
-              isInsidePolygon = circleInPolygon({ x: centerX, y: centerY, radius }, polygon)
-            } else {
-              // Para rectángulos, usar verificación completa con muestreo denso
-              isInsidePolygon = isRectCompletelyInPolygon(x, y, width, height, polygon)
-            }
+          if (elemento?.forma === 'circular') {
+            // Para círculos, verificar que el círculo completo esté dentro
+            const radius = Math.min(width, height) / 2
+            const centerX = x + radius
+            const centerY = y + radius
+            isInsidePolygon = circleInPolygon({ x: centerX, y: centerY, radius }, polygon)
+          } else {
+            // Para rectángulos, usar verificación completa con muestreo denso
+            isInsidePolygon = isRectCompletelyInPolygon(x, y, width, height, polygon)
+          }
 
-            if (!isInsidePolygon) {
-              showToast('El elemento debe permanecer completamente dentro del área de la planta', 'warning')
-              revertTransform(elementId, 'elemento fuera del polígono')
-              return
-            }
+          if (!isInsidePolygon) {
+            showToast('El elemento debe permanecer completamente dentro del área de la planta', 'warning')
+            revertTransform(elementId, 'elemento fuera del polígono')
+            return
           }
         }
       } catch (err) {
@@ -614,12 +645,37 @@ export function useTransformer({
       // VALIDACIÓN 3: Placement validation (colisiones, área) - usar valores corregidos
       // Usar neighbors del snapshot para evitar cambios durante la validación
       const neighbors = Array.from(elementosSnapshot.values()).filter((e) => e.id !== elementId)
-      const areaBounds = {
-        minX: 0,
-        minY: 0,
-        maxX: layerConfig.value.width,
-        maxY: layerConfig.value.height,
-      }
+
+      const polygonForBounds = Array.isArray(boundary?.inset) && boundary.inset.length
+        ? boundary.inset
+        : (Array.isArray(boundary?.points) && boundary.points.length ? boundary.points : undefined)
+
+      const layerWidth = layerConfig?.value?.width ?? 0
+      const layerHeight = layerConfig?.value?.height ?? 0
+
+      const areaBounds = boundary
+        ? boundary.mode === 'elastic'
+          ? {
+              minX: 0,
+              minY: 0,
+              mode: 'elastic',
+              ...(polygonForBounds ? { polygon: polygonForBounds } : {}),
+            }
+          : {
+              minX: 0,
+              minY: 0,
+              mode: boundary.mode || 'fixed',
+              maxX: layerWidth,
+              maxY: layerHeight,
+              ...(polygonForBounds ? { polygon: polygonForBounds } : {}),
+            }
+        : {
+            minX: 0,
+            minY: 0,
+            mode: 'fixed',
+            maxX: layerWidth,
+            maxY: layerHeight,
+          }
       const elementoParaValidacion =
         elementoSnapshot?.forma === 'circular'
           ? {

--- a/src/inventory-smart/composables/useWeightValidation.js
+++ b/src/inventory-smart/composables/useWeightValidation.js
@@ -31,6 +31,7 @@ import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore.js'
 
 export function useWeightValidation() {
   const canvasStore = useCanvasStore()
+  const isInfinitePlant = computed(() => canvasStore.plantaActivaData?.isInfinite === true)
 
   /**
    * Calcula el peso máximo teórico total de todos los elementos hijos directos de un contenedor/elemento/planta
@@ -202,6 +203,19 @@ export function useWeightValidation() {
     // Peso total después de agregar el nuevo elemento
     const pesoTotalFinal = pesoActualTotal + pesoNuevoElemento
 
+    if (isInfinitePlant.value) {
+      return {
+        valido: true,
+        pesoActual: pesoActualTotal,
+        pesoNuevo: pesoNuevoElemento,
+        pesoTotal: pesoTotalFinal,
+        pesoMaximo: 0,
+        exceso: 0,
+        limiteDePeso: false,
+        modoInfinito: true,
+      }
+    }
+
     // Obtener el peso máximo soportado del padre
     let pesoMaximoSoportado = 0
 
@@ -254,6 +268,22 @@ export function useWeightValidation() {
    */
   const calcularPesoDisponible = (padreId, padreType, options = {}) => {
     const { validacionTeorica = true } = options
+    // Calcular el peso actual usado
+    const pesoUsado = validacionTeorica
+      ? calcularPesoTotal(padreId, padreType)
+      : calcularPesoRealTotal(padreId, padreType)
+
+    if (isInfinitePlant.value) {
+      return {
+        disponible: Infinity,
+        usado: pesoUsado,
+        maximo: 0,
+        porcentajeUsado: 0,
+        limiteDePeso: false,
+        modoInfinito: true,
+      }
+    }
+
     // Obtener el peso máximo soportado del padre
     let pesoMaximoSoportado = 0
 
@@ -269,17 +299,12 @@ export function useWeightValidation() {
     if (pesoMaximoSoportado === 0) {
       return {
         disponible: Infinity,
-        usado: 0,
+        usado: pesoUsado,
         maximo: 0,
         porcentajeUsado: 0,
         limiteDePeso: false,
       }
     }
-
-    // Calcular el peso actual usado
-    const pesoUsado = validacionTeorica
-      ? calcularPesoTotal(padreId, padreType)
-      : calcularPesoRealTotal(padreId, padreType)
 
     // Calcular el peso disponible
     const pesoDisponible = Math.max(0, pesoMaximoSoportado - pesoUsado)
@@ -373,6 +398,8 @@ export function useWeightValidation() {
    */
   const contextoActualTieneLimiteDePeso = computed(() => {
     const { tipo, id } = canvasStore.contextoActual
+
+    if (isInfinitePlant.value) return false
 
     if (tipo === 'plantas') {
       const planta = canvasStore.plantaPorId(id)

--- a/src/inventory-smart/composables/useZoom.js
+++ b/src/inventory-smart/composables/useZoom.js
@@ -6,6 +6,8 @@
 import { useCanvasStore } from './useCanvasStore'
 import { CM_TO_PX } from '../utils/constants'
 
+const CONTENT_MARGIN = 40
+
 export function useZoom(stageSize, layerConfig) {
   const canvasStore = useCanvasStore()
 
@@ -22,6 +24,9 @@ export function useZoom(stageSize, layerConfig) {
 
     // Contexto 2: planta activa -> priorizar contenido si existe
     if (canvasStore.plantaActivaData) {
+      const planta = canvasStore.plantaActivaData
+      const isInfinite = planta?.isInfinite === true
+
       // 2.a) BBox del contenido visible (elementos de la planta activa)
       const elems = (canvasStore.elementosVisibles || []).filter((e) => e?.visible !== false && e?.plantaId === canvasStore.plantaActiva)
       if (elems.length > 0) {
@@ -39,14 +44,22 @@ export function useZoom(stageSize, layerConfig) {
         if (Number.isFinite(minX) && Number.isFinite(minY) && Number.isFinite(maxX) && Number.isFinite(maxY)) {
           const width = Math.max(1, maxX - minX)
           const height = Math.max(1, maxY - minY)
+          if (isInfinite) {
+            const margin = CONTENT_MARGIN
+            return {
+              x: minX - margin,
+              y: minY - margin,
+              width: Math.max(1, width + margin * 2),
+              height: Math.max(1, height + margin * 2),
+            }
+          }
+
           return { x: minX, y: minY, width, height }
         }
       }
 
-      const planta = canvasStore.plantaActivaData
-
       // 2.b) Priorizar polígono si está disponible
-      if (planta.poligono && Array.isArray(planta.poligono) && planta.poligono.length > 0) {
+      if (!isInfinite && planta.poligono && Array.isArray(planta.poligono) && planta.poligono.length > 0) {
         const xs = planta.poligono.map((p) => p.x)
         const ys = planta.poligono.map((p) => p.y)
         const minX = Math.min(...xs)
@@ -67,15 +80,19 @@ export function useZoom(stageSize, layerConfig) {
       }
 
       // 2.c) Usar dimensiones físicas de la planta
-      if (planta.dimensiones && (planta.dimensiones.ancho || planta.dimensiones.largo)) {
+      if (!isInfinite && planta.dimensiones && (planta.dimensiones.ancho || planta.dimensiones.largo)) {
         const w = (planta.dimensiones.ancho || 100) * CM_TO_PX
         const h = (planta.dimensiones.largo || 100) * CM_TO_PX
         return { x: 0, y: 0, width: Math.max(1, w), height: Math.max(1, h) }
       }
+
+      if (isInfinite) {
+        return null
+      }
     }
 
     // Contexto 3: fallback al layerConfig
-    if (layerConfig.value?.width && layerConfig.value?.height) {
+    if (canvasStore.plantaActivaData?.isInfinite !== true && layerConfig.value?.width && layerConfig.value?.height) {
       return { x: 0, y: 0, width: Math.max(1, layerConfig.value.width), height: Math.max(1, layerConfig.value.height) }
     }
 
@@ -106,6 +123,10 @@ export function useZoom(stageSize, layerConfig) {
    * Calcula el zoom mínimo dinámico basado en el contexto actual
    */
   const getDynamicMinZoom = () => {
+    if (canvasStore.plantaActivaData?.isInfinite === true) {
+      return 0.001
+    }
+
     const margin = 40
     const vw = Math.max(16, stageSize.value.width - margin * 2)
     const vh = Math.max(16, stageSize.value.height - margin * 2)
@@ -186,20 +207,25 @@ export function useZoom(stageSize, layerConfig) {
 
       const dynamicMinZoom = getDynamicMinZoom()
 
+      const scaleX = chosen.width > 0 ? vw / chosen.width : 1
+      const scaleY = chosen.height > 0 ? vh / chosen.height : 1
+      const fitScale = Math.min(scaleX, scaleY)
+      const targetScale = Math.max(dynamicMinZoom, Number.isFinite(fitScale) && fitScale > 0 ? fitScale : dynamicMinZoom)
+
       // IMPORTANTE: Resetear transformaciones del stage antes de aplicar nuevas
       safeStageCall(stage, 'scale', { x: 1, y: 1 })
       safeStageCall(stage, 'position', { x: 0, y: 0 })
 
       // Calcular pan para centrar bbox en viewport (en coords de stage)
-      const stageX = (stageSize.value.width - chosen.width * dynamicMinZoom) / 2 - chosen.x * dynamicMinZoom
-      const stageY = (stageSize.value.height - chosen.height * dynamicMinZoom) / 2 - chosen.y * dynamicMinZoom
+      const stageX = (stageSize.value.width - chosen.width * targetScale) / 2 - chosen.x * targetScale
+      const stageY = (stageSize.value.height - chosen.height * targetScale) / 2 - chosen.y * targetScale
 
       // Aplicar transformaciones desde estado limpio
-      safeStageCall(stage, 'scale', { x: dynamicMinZoom, y: dynamicMinZoom })
+      safeStageCall(stage, 'scale', { x: targetScale, y: targetScale })
       safeStageCall(stage, 'position', { x: stageX, y: stageY })
 
       // Sincronizar con el store DESPUÉS de aplicar al stage
-      canvasStore.configurarZoom(dynamicMinZoom, dynamicMinZoom)
+      canvasStore.configurarZoom(targetScale, dynamicMinZoom)
       canvasStore.configurarPan(stageX, stageY)
 
       // Forzar redibujado

--- a/src/inventory-smart/utils/activeBounds.js
+++ b/src/inventory-smart/utils/activeBounds.js
@@ -77,6 +77,7 @@ export function getActiveBounds(canvasStore) {
   }
 
   const planta = canvasStore.plantaActual || canvasStore.plantaActivaData || {}
+  const isInfinite = !!planta.isInfinite
 
   // Normalizar modo del piso a una sola propiedad para reducir complejidad
   if (
@@ -88,17 +89,17 @@ export function getActiveBounds(canvasStore) {
   }
 
   // Actualizar flag global para validaciones de límites
-  setPlantInfiniteFlag(!!planta.isInfinite)
+  setPlantInfiniteFlag(isInfinite)
 
   if (planta.poligono && Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
     // Clonar superficial para evitar mutar store
     const polygonPx = planta.poligono.map(p => ({ x: p.x, y: p.y }))
     // Marcar metadata opcional
-    if (planta.isInfinite) {
+    if (isInfinite) {
       Object.defineProperty(polygonPx, '_isInfinite', { value: true, enumerable: false, configurable: true })
     }
     const boundsPx = bboxFromPolygon(polygonPx)
-    return { mode: 'fixed', boundsPx, polygonPx }
+    return { mode: isInfinite ? 'elastic' : 'fixed', boundsPx, polygonPx }
   }
 
   // Fallback: dimensiones rectangulares
@@ -112,8 +113,8 @@ export function getActiveBounds(canvasStore) {
     { x: width, y: height },
     { x: 0, y: height },
   ]
-  if (planta.isInfinite) {
+  if (isInfinite) {
     Object.defineProperty(polygonPx, '_isInfinite', { value: true, enumerable: false, configurable: true })
   }
-  return { mode: 'fixed', boundsPx: { width, height }, polygonPx }
+  return { mode: isInfinite ? 'elastic' : 'fixed', boundsPx: { width, height }, polygonPx }
 }

--- a/src/inventory-smart/utils/polygonBounds.js
+++ b/src/inventory-smart/utils/polygonBounds.js
@@ -7,6 +7,10 @@ export function setPlantInfiniteFlag(v) {
   __PLANT_IS_INFINITE__ = !!v
 }
 
+export function isPlantInfinite() {
+  return __PLANT_IS_INFINITE__
+}
+
 // Helper: detectar polígono con bypass de límites (planta infinita)
 function _isInfinitePoly(polyOrPlant) {
   if (__PLANT_IS_INFINITE__) return true


### PR DESCRIPTION
## Summary
- disable clipping, enable viewport-based culling and allow overflow when the active plant is infinite so dragged nodes remain visible
- guard drag/drop validations and context watchers to handle canvases without a populated contextoActual
- expose the plant infinity flag to cache helpers and update CanvasInfo to avoid watching undefined ids
- allow infinite plants and elastic boundaries to skip transformer clamps while propagating elastic area bounds so resize adjustments persist
- bypass parent containment validation when the active plant is infinite to avoid canvasAdaptativo rollbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1c2a42bc48321ad8c06d5f18d2f59