### PR TITLE
Fix infinite plant resizing rollback

### DIFF
--- a/src/inventory-smart/components/CanvasInfo.vue
+++ b/src/inventory-smart/components/CanvasInfo.vue
@@ -78,5 +78,11 @@ onUnmounted(() => {
   }
 })
 
-watch(() => [store.zoom, store.vistaActiva, store.contextoActual.id], () => nextTick(recompute))
+watch(
+  () => {
+    const ctx = store.contextoActual || {}
+    return [store.zoom, store.vistaActiva, ctx?.id]
+  },
+  () => nextTick(recompute),
+)
 </script>

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -15,7 +15,11 @@
   <div
     ref="containerRef"
     class="canvas-container"
-    :class="{ 'drag-over': isDragOverCanvas, 'cursor-grab': !dragModeGlobal }"
+    :class="{
+      'drag-over': isDragOverCanvas,
+      'cursor-grab': !dragModeGlobal,
+      'infinite-floor': isInfinitePlant,
+    }"
     @drop="handleDrop"
     @dragover="handleDragOver"
     @dragenter="handleDragEnter"
@@ -836,6 +840,7 @@ const stageConfig = computed(() => {
 })
 
 const activeBounds = computed(() => getActiveBounds(canvasStore))
+const isInfinitePlant = computed(() => canvasStore.plantaActivaData?.isInfinite === true)
 
 const plantPolygon = computed(() => activeBounds.value.polygonPx)
 
@@ -843,16 +848,34 @@ const insetPoly = computed(() => polygonInset(plantPolygon.value, 1))
 
 const plantPolygonFlat = computed(() => plantPolygon.value.flatMap((p) => [p.x, p.y]))
 
-const floorBoundary = computed(() => activeBounds.value.boundsPx)
+const floorBoundary = computed(() => {
+  const bounds = activeBounds.value.boundsPx || { width: 0, height: 0 }
+  if (!isInfinitePlant.value) {
+    return bounds
+  }
+  const zoom = canvasStore.zoom || 1
+  const viewWidth = stageSize.value.width / (zoom || 1)
+  const viewHeight = stageSize.value.height / (zoom || 1)
+  return {
+    width: Math.max(bounds.width || 0, viewWidth || 0),
+    height: Math.max(bounds.height || 0, viewHeight || 0),
+  }
+})
 
 // Configuración del layer - SIEMPRE USA CANVAS ADAPTATIVO
 const layerConfig = computed(() => {
-  // Usar siempre canvasAdaptativo como fuente única de verdad
-  const config = {
-    width: canvasStore.canvasAdaptativo.width,
-    height: canvasStore.canvasAdaptativo.height,
+  const baseWidth = canvasStore.canvasAdaptativo?.width || 0
+  const baseHeight = canvasStore.canvasAdaptativo?.height || 0
+  if (!isInfinitePlant.value) {
+    return { width: baseWidth, height: baseHeight }
   }
-  return config
+  const zoom = canvasStore.zoom || 1
+  const viewWidth = stageSize.value.width / (zoom || 1)
+  const viewHeight = stageSize.value.height / (zoom || 1)
+  return {
+    width: Math.max(baseWidth, viewWidth || 0),
+    height: Math.max(baseHeight, viewHeight || 0),
+  }
 })
 
 // Composable para zoom
@@ -865,7 +888,51 @@ const {
 // Elementos visibles en el canvas (excluye elementos ocultos)
 const elementosVisiblesEnCanvas = computed(() => {
   const visibles = canvasStore.elementosVisibles.filter((elemento) => elemento.visible !== false)
-  return visibles
+  if (!isInfinitePlant.value) {
+    return visibles
+  }
+
+  const zoom = canvasStore.zoom || 1
+  const stageWidth = stageSize.value.width || 0
+  const stageHeight = stageSize.value.height || 0
+
+  if (!stageWidth || !stageHeight || !Number.isFinite(zoom) || zoom <= 0) {
+    return visibles
+  }
+
+  const viewX = -canvasStore.panX / zoom
+  const viewY = -canvasStore.panY / zoom
+  const viewW = stageWidth / zoom
+  const viewH = stageHeight / zoom
+  const padding = 200 / zoom
+
+  const minX = viewX - padding
+  const maxX = viewX + viewW + padding
+  const minY = viewY - padding
+  const maxY = viewY + viewH + padding
+
+  const stage = stageRef.value?.getNode?.()
+
+  return visibles.filter((elemento) => {
+    const width = getDrawWidth(elemento) || 0
+    const height = getDrawHeight(elemento) || 0
+    const x = elemento.x ?? 0
+    const y = elemento.y ?? 0
+
+    const intersects = x + width >= minX && x <= maxX && y + height >= minY && y <= maxY
+    if (intersects) {
+      return true
+    }
+
+    if (stage) {
+      const node = stage.findOne?.(`#${elemento.id}`)
+      if (node && typeof node.isDragging === 'function' && node.isDragging()) {
+        return true
+      }
+    }
+
+    return false
+  })
 })
 
 // Detectar si existen pasillos visibles y toggle para su borde punteado
@@ -901,19 +968,33 @@ const gridLines = computed(() => {
 })
 
 watch(
-  plantPolygon,
-  (poly) => {
+  [plantPolygon, isInfinitePlant],
+  ([poly, infinite]) => {
     const layer = layerRef.value?.getNode?.()
-    if (layer && poly?.length) {
-      layer.clipFunc((ctx) => {
-        ctx.beginPath()
-        poly.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)))
-        ctx.closePath()
-      })
+    if (!layer) return
+
+    if (infinite || !poly?.length) {
+      try {
+        layer.clipFunc(null)
+        if (typeof layer.clipWidth === 'function') layer.clipWidth(null)
+        if (typeof layer.clipHeight === 'function') layer.clipHeight(null)
+        if (typeof layer.clipX === 'function') layer.clipX(0)
+        if (typeof layer.clipY === 'function') layer.clipY(0)
+      } catch {
+        /* ignore */
+      }
       layer.batchDraw?.()
+      return
     }
+
+    layer.clipFunc((ctx) => {
+      ctx.beginPath()
+      poly.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)))
+      ctx.closePath()
+    })
+    layer.batchDraw?.()
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 )
 
 // Contorno activo siempre expresado como polígono
@@ -1096,6 +1177,9 @@ const toStageCoords = (pos) => {
 // Drag bound para cada elemento y forma (clamp mínimo al contorno)
 const dragBoundForElement = (pos, elemento) => {
   try {
+    if (isInfinitePlant.value) {
+      return pos
+    }
     const lp = toLayerCoords(pos)
     const boundary = computeBoundary()
     const { w_cm, h_cm } = dimsCmFor(elemento, canvasStore.vistaActiva)
@@ -1237,7 +1321,7 @@ const getWorldCoordinatesFromPointer = (dropEvent) => {
 const runPreDropValidations = (elemento, dropEvent) => {
   if (!elemento) return { ok: false, reason: 'invalid' }
 
-  const contextoActual = canvasStore.contextoActual.tipo
+  const contextoActual = canvasStore.contextoActual?.tipo || 'plantas'
   const tipoElemento = elemento.tipo
 
   // Reglas de jerarquía actualizadas
@@ -1989,8 +2073,13 @@ const fitToPlanta = () => {
 
 // Auto-ajustar siempre que cambia el contexto (planta / elemento / contenedor)
 watch(
-  () => [canvasStore.contextoActual.tipo, canvasStore.contextoActual.id],
+  () => {
+    const ctx = canvasStore.contextoActual || {}
+    return [ctx?.tipo, ctx?.id]
+  },
   async () => {
+    const ctx = canvasStore.contextoActual
+    if (!ctx || !ctx.tipo) return
     // Esperar a que el store recalcule canvasAdaptativo y layerConfig
     await nextTick()
     await nextTick()
@@ -2102,6 +2191,10 @@ const onDelete = async (id) => {
   background: #f8fafc;
   border: 1px solid #e2e8f0;
   transition: all 0.2s ease;
+}
+
+.canvas-container.infinite-floor {
+  overflow: visible;
 }
 
 .canvas-container.drag-over {

--- a/src/inventory-smart/composables/useCacheOnDrag.js
+++ b/src/inventory-smart/composables/useCacheOnDrag.js
@@ -1,4 +1,5 @@
 import { watch, getCurrentInstance, onUnmounted } from 'vue'
+import { isPlantInfinite } from '@/inventory-smart/utils/polygonBounds'
 
 // Automatically enable Konva node caching during drag operations.
 // - On `dragstart`: calls `node.cache()` and `node.draw()`
@@ -17,6 +18,7 @@ export function useCacheOnDrag(refNode) {
 
   const onDragStart = () => {
     try {
+      if (isPlantInfinite()) return
       node && node.cache && node.cache()
       node && node.draw && node.draw()
     } catch {

--- a/src/inventory-smart/composables/useDimensionValidation.js
+++ b/src/inventory-smart/composables/useDimensionValidation.js
@@ -264,6 +264,10 @@ export function useDimensionValidation() {
       return { valida: true, razon: 'No se encontró el contenedor padre o no tiene dimensiones' };
     }
 
+    if (canvasStore.plantaActivaData?.isInfinite === true) {
+      return { valida: true, razon: 'La planta activa es infinita; no aplica contención por canvas adaptativo' };
+    }
+
     const vista = canvasStore.vistaActiva || 'XY'
     const esVistaFrontal = vista === 'XZ'
 

--- a/src/inventory-smart/composables/useTransformer.js
+++ b/src/inventory-smart/composables/useTransformer.js
@@ -104,16 +104,33 @@ export function useTransformer({
           const MINW = 10
           const MINH = 10
           if (newBox.width <= 0 || newBox.height <= 0) return oldBox
-          if (newBox.width < MINW || newBox.height < MINH) return oldBox
+
+          const boundary = typeof computeBoundary === 'function' ? computeBoundary() : null
+          const boundaryMode = boundary?.mode
+          const isElasticBoundary = boundaryMode === 'elastic'
+          const floorIsInfinite = canvasStore.plantaActivaData?.isInfinite === true
+          const allowElasticResize = floorIsInfinite || isElasticBoundary
+
+          if (!allowElasticResize && (newBox.width < MINW || newBox.height < MINH)) {
+            return oldBox
+          }
+
+          let adjustedBox = allowElasticResize
+            ? {
+                ...newBox,
+                width: Math.max(MINW, newBox.width),
+                height: Math.max(MINH, newBox.height),
+              }
+            : newBox
 
           // Para elementos circulares, mantener aspecto cuadrado
           if (elemento?.forma === 'circular') {
-            const size = Math.max(newBox.width, newBox.height)
-            return { ...newBox, width: size, height: size }
+            const size = Math.max(adjustedBox.width, adjustedBox.height)
+            adjustedBox = { ...adjustedBox, width: size, height: size }
           }
 
           // NO aplicar clamping aquí - permitir transformación libre
-          return newBox
+          return adjustedBox
         },
       })
       trComp.getLayer()?.batchDraw?.()
@@ -364,8 +381,20 @@ export function useTransformer({
         return
       }
 
-  // Usar el snapshot congelado para todas las operaciones
-  const elementoSnapshot = elemento
+      // Usar el snapshot congelado para todas las operaciones
+      const elementoSnapshot = elemento
+
+      let boundary = null
+      if (typeof computeBoundary === 'function') {
+        try {
+          boundary = computeBoundary() || null
+        } catch (boundaryErr) {
+          console.warn('[transform-boundary-compute-error]', boundaryErr)
+        }
+      }
+
+      const floorIsInfinite = canvasStore.plantaActivaData?.isInfinite === true
+      const boundaryMode = boundary?.mode || (floorIsInfinite ? 'elastic' : 'fixed')
 
       // Extraer valores de Konva (mantener valores originales para Konva y store)
       const width = node.width() * node.scaleX()
@@ -583,28 +612,25 @@ export function useTransformer({
 
       // VALIDACIÓN 2: Verificar que esté dentro del polígono de la planta
       try {
-        if (typeof computeBoundary === 'function') {
-          const boundary = computeBoundary()
-          if (boundary && boundary.type === 'polygon' && boundary.mode !== 'elastic') {
-            let isInsidePolygon = false
-            const polygon = boundary.inset || boundary.points
+        if (boundary && boundary.type === 'polygon' && boundary.mode !== 'elastic') {
+          let isInsidePolygon = false
+          const polygon = boundary.inset || boundary.points
 
-            if (elemento?.forma === 'circular') {
-              // Para círculos, verificar que el círculo completo esté dentro
-              const radius = Math.min(width, height) / 2
-              const centerX = x + radius
-              const centerY = y + radius
-              isInsidePolygon = circleInPolygon({ x: centerX, y: centerY, radius }, polygon)
-            } else {
-              // Para rectángulos, usar verificación completa con muestreo denso
-              isInsidePolygon = isRectCompletelyInPolygon(x, y, width, height, polygon)
-            }
+          if (elemento?.forma === 'circular') {
+            // Para círculos, verificar que el círculo completo esté dentro
+            const radius = Math.min(width, height) / 2
+            const centerX = x + radius
+            const centerY = y + radius
+            isInsidePolygon = circleInPolygon({ x: centerX, y: centerY, radius }, polygon)
+          } else {
+            // Para rectángulos, usar verificación completa con muestreo denso
+            isInsidePolygon = isRectCompletelyInPolygon(x, y, width, height, polygon)
+          }
 
-            if (!isInsidePolygon) {
-              showToast('El elemento debe permanecer completamente dentro del área de la planta', 'warning')
-              revertTransform(elementId, 'elemento fuera del polígono')
-              return
-            }
+          if (!isInsidePolygon) {
+            showToast('El elemento debe permanecer completamente dentro del área de la planta', 'warning')
+            revertTransform(elementId, 'elemento fuera del polígono')
+            return
           }
         }
       } catch (err) {
@@ -614,11 +640,15 @@ export function useTransformer({
       // VALIDACIÓN 3: Placement validation (colisiones, área) - usar valores corregidos
       // Usar neighbors del snapshot para evitar cambios durante la validación
       const neighbors = Array.from(elementosSnapshot.values()).filter((e) => e.id !== elementId)
+      const layerBounds = layerConfig?.value || { width: 0, height: 0 }
       const areaBounds = {
         minX: 0,
         minY: 0,
-        maxX: layerConfig.value.width,
-        maxY: layerConfig.value.height,
+        mode: boundaryMode || 'fixed',
+      }
+      if ((boundaryMode || 'fixed') !== 'elastic') {
+        areaBounds.maxX = layerBounds.width
+        areaBounds.maxY = layerBounds.height
       }
       const elementoParaValidacion =
         elementoSnapshot?.forma === 'circular'

--- a/src/inventory-smart/utils/activeBounds.js
+++ b/src/inventory-smart/utils/activeBounds.js
@@ -77,6 +77,7 @@ export function getActiveBounds(canvasStore) {
   }
 
   const planta = canvasStore.plantaActual || canvasStore.plantaActivaData || {}
+  const isInfinite = !!planta.isInfinite
 
   // Normalizar modo del piso a una sola propiedad para reducir complejidad
   if (
@@ -88,17 +89,17 @@ export function getActiveBounds(canvasStore) {
   }
 
   // Actualizar flag global para validaciones de límites
-  setPlantInfiniteFlag(!!planta.isInfinite)
+  setPlantInfiniteFlag(isInfinite)
 
   if (planta.poligono && Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
     // Clonar superficial para evitar mutar store
     const polygonPx = planta.poligono.map(p => ({ x: p.x, y: p.y }))
     // Marcar metadata opcional
-    if (planta.isInfinite) {
+    if (isInfinite) {
       Object.defineProperty(polygonPx, '_isInfinite', { value: true, enumerable: false, configurable: true })
     }
     const boundsPx = bboxFromPolygon(polygonPx)
-    return { mode: 'fixed', boundsPx, polygonPx }
+    return { mode: isInfinite ? 'elastic' : 'fixed', boundsPx, polygonPx }
   }
 
   // Fallback: dimensiones rectangulares
@@ -112,8 +113,8 @@ export function getActiveBounds(canvasStore) {
     { x: width, y: height },
     { x: 0, y: height },
   ]
-  if (planta.isInfinite) {
+  if (isInfinite) {
     Object.defineProperty(polygonPx, '_isInfinite', { value: true, enumerable: false, configurable: true })
   }
-  return { mode: 'fixed', boundsPx: { width, height }, polygonPx }
+  return { mode: isInfinite ? 'elastic' : 'fixed', boundsPx: { width, height }, polygonPx }
 }

--- a/src/inventory-smart/utils/polygonBounds.js
+++ b/src/inventory-smart/utils/polygonBounds.js
@@ -7,6 +7,10 @@ export function setPlantInfiniteFlag(v) {
   __PLANT_IS_INFINITE__ = !!v
 }
 
+export function isPlantInfinite() {
+  return __PLANT_IS_INFINITE__
+}
+
 // Helper: detectar polígono con bypass de límites (planta infinita)
 function _isInfinitePoly(polyOrPlant) {
   if (__PLANT_IS_INFINITE__) return true


### PR DESCRIPTION
## Summary
- disable clipping, enable viewport-based culling and allow overflow when the active plant is infinite so dragged nodes remain visible
- guard drag/drop validations and context watchers to handle canvases without a populated contextoActual
- expose the plant infinity flag to cache helpers and update CanvasInfo to avoid watching undefined ids
- allow transformer bound boxes, placement validation and dimension checks to respect elastic/infinite floors so resize operations persist

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1c2a42bc48321ad8c06d5f18d2f59