### PR TITLE
Adjust plant rect anchoring

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -724,29 +724,6 @@ const isSnappingEnabled = ref(true)
  * @returns {Object} - { width: number, height: number } en píxeles
  */
 const viewport = useViewportStore()
-
-let textMeasureCtx = null
-const ensureMeasureContext = () => {
-  if (typeof document === 'undefined') return null
-  if (textMeasureCtx) return textMeasureCtx
-  try {
-    const canvas = document.createElement('canvas')
-    textMeasureCtx = canvas.getContext('2d') || null
-  } catch {
-    textMeasureCtx = null
-  }
-  return textMeasureCtx
-}
-
-const measureTextWidth = (text, fontPx) => {
-  const ctx = ensureMeasureContext()
-  if (!ctx) {
-    const length = String(text || '').length
-    return length * fontPx * 0.6
-  }
-  ctx.font = `${fontPx}px Arial`
-  return ctx.measureText(String(text || '')).width
-}
 const getElementPixelDimensions = (elemento) => {
   // Si ya tiene width/height en píxeles, usarlos solo si no tiene dimensiones en cm
   // Esto es para compatibilidad con elementos legacy que solo tienen width/height
@@ -1008,20 +985,16 @@ const floorLabelPositions = computed(() => {
   }
 
   const rect = plantRect.value || { x: 0, y: 0, width: 0, height: 0 }
-  const paddingPx = 14
-  const rightEdge = (Number(rect.x) || 0) + (Number(rect.width) || 0) - paddingPx / zoom
+  const rectX = Number(rect.x) || 0
+  const rectY = Number(rect.y) || 0
+  const paddingPx = 10
+  const paddingWorld = paddingPx / zoom
+  const lineSpacingPx = 18
 
-  const mainText = mainFloorInfoText.value || ''
-  const mainWidthWorld = measureTextWidth(mainText, 12) / zoom
-  const safeMainWidth = Number.isFinite(mainWidthWorld) ? mainWidthWorld : 0
-  const mainX = Number.isFinite(rightEdge) ? rightEdge - safeMainWidth : 0
-  const mainY = (Number(rect.y) || 0) - (39 / zoom)
-
-  const secondaryText = plantElementsText.value || ''
-  const secondaryWidthWorld = measureTextWidth(secondaryText, 11) / zoom
-  const safeSecondaryWidth = Number.isFinite(secondaryWidthWorld) ? secondaryWidthWorld : 0
-  const secondaryX = Number.isFinite(rightEdge) ? rightEdge - safeSecondaryWidth : 0
-  const secondaryY = (Number(rect.y) || 0) - (19 / zoom)
+  const mainX = rectX + paddingWorld
+  const mainY = rectY + paddingWorld
+  const secondaryX = mainX
+  const secondaryY = mainY + lineSpacingPx / zoom
 
   return {
     main: { x: mainX, y: mainY },

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -47,10 +47,12 @@
         <!-- Dibujar grid solo si gridSize > 0 -->
         <template v-if="(canvasStore.gridSize || 0) > 0">
           <v-line
-            v-for="i in gridLines.vertical"
-            :key="`v-${i}`"
+            v-for="x in gridLines.vertical"
+            :key="`v-${Math.round(x * 1000)}`"
             :config="{
-              points: [i, 0, i, floorBoundary.height],
+              points: isInfinitePlant
+                ? [x, 0, x, floorBoundary.height]
+                : [x, floorBoundary.y, x, floorBoundary.y + floorBoundary.height],
               stroke: '#e5e7eb',
               strokeWidth: 1,
               opacity: 0.5,
@@ -58,10 +60,12 @@
             }"
           />
           <v-line
-            v-for="i in gridLines.horizontal"
-            :key="`h-${i}`"
+            v-for="y in gridLines.horizontal"
+            :key="`h-${Math.round(y * 1000)}`"
             :config="{
-              points: [0, i, floorBoundary.width, i],
+              points: isInfinitePlant
+                ? [0, y, floorBoundary.width, y]
+                : [floorBoundary.x, y, floorBoundary.x + floorBoundary.width, y],
               stroke: '#e5e7eb',
               strokeWidth: 1,
               opacity: 0.5,
@@ -451,11 +455,9 @@
         <v-text
           v-if="!canvasStore.estaEnPlanta || canvasStore.plantaActivaData?.isInfinite !== true"
           :config="{
-            x: 10,
-            y: -(39 / canvasStore.zoom),
-            text: !canvasStore.estaEnPlanta
-              ? `${canvasStore.estructuraContenedorActual?.nombre} - ${formatLengthsCm([layerConfig.width * viewport.cmPerPx, layerConfig.height * viewport.cmPerPx])}`
-              : `${canvasStore.plantaActivaData?.nombre} - ${formatLengthsCm([layerConfig.width * viewport.cmPerPx, layerConfig.height * viewport.cmPerPx])}`,
+            x: floorLabelPositions.main.x,
+            y: floorLabelPositions.main.y,
+            text: mainFloorInfoText,
             fontSize: 12 / canvasStore.zoom,
             fontFamily: 'Arial',
             fill: '#3b82f6',
@@ -466,9 +468,9 @@
         <v-text
           v-if="canvasStore.estaEnPlanta && canvasStore.plantaActivaData?.isInfinite !== true"
           :config="{
-            x: 10,
-            y: -(11 / canvasStore.zoom) - 8 / canvasStore.zoom,
-            text: `Elementos: ${elementosVisiblesEnCanvas.length}`,
+            x: floorLabelPositions.secondary.x,
+            y: floorLabelPositions.secondary.y,
+            text: plantElementsText,
             fontSize: 11 / canvasStore.zoom,
             fontFamily: 'Arial',
             fill: '#6b7280',
@@ -722,6 +724,29 @@ const isSnappingEnabled = ref(true)
  * @returns {Object} - { width: number, height: number } en píxeles
  */
 const viewport = useViewportStore()
+
+let textMeasureCtx = null
+const ensureMeasureContext = () => {
+  if (typeof document === 'undefined') return null
+  if (textMeasureCtx) return textMeasureCtx
+  try {
+    const canvas = document.createElement('canvas')
+    textMeasureCtx = canvas.getContext('2d') || null
+  } catch {
+    textMeasureCtx = null
+  }
+  return textMeasureCtx
+}
+
+const measureTextWidth = (text, fontPx) => {
+  const ctx = ensureMeasureContext()
+  if (!ctx) {
+    const length = String(text || '').length
+    return length * fontPx * 0.6
+  }
+  ctx.font = `${fontPx}px Arial`
+  return ctx.measureText(String(text || '')).width
+}
 const getElementPixelDimensions = (elemento) => {
   // Si ya tiene width/height en píxeles, usarlos solo si no tiene dimensiones en cm
   // Esto es para compatibilidad con elementos legacy que solo tienen width/height
@@ -851,17 +876,93 @@ const insetPoly = computed(() => polygonInset(plantPolygon.value, 1))
 
 const plantPolygonFlat = computed(() => plantPolygon.value.flatMap((p) => [p.x, p.y]))
 
-const floorBoundary = computed(() => {
-  const bounds = activeBounds.value.boundsPx || { width: 0, height: 0 }
-  if (!isInfinitePlant.value) {
-    return bounds
+const plantRect = computed(() => {
+  const adapt = canvasStore.canvasAdaptativo || {}
+  const frame = adapt?.frame
+  if (
+    frame &&
+    Number.isFinite(Number(frame.x)) &&
+    Number.isFinite(Number(frame.y))
+  ) {
+    return {
+      x: Number(frame.x) || 0,
+      y: Number(frame.y) || 0,
+      width: Number(frame.width) || 0,
+      height: Number(frame.height) || 0,
+    }
   }
+
+  const poly = plantPolygon.value
+  if (Array.isArray(poly) && poly.length >= 3) {
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+    for (const point of poly) {
+      const x = Number(point?.x)
+      const y = Number(point?.y)
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+      minX = Math.min(minX, x)
+      minY = Math.min(minY, y)
+      maxX = Math.max(maxX, x)
+      maxY = Math.max(maxY, y)
+    }
+    if (
+      Number.isFinite(minX) &&
+      Number.isFinite(minY) &&
+      Number.isFinite(maxX) &&
+      Number.isFinite(maxY) &&
+      maxX >= minX &&
+      maxY >= minY
+    ) {
+      return {
+        x: Math.floor(minX),
+        y: Math.floor(minY),
+        width: Math.max(0, Math.ceil(maxX) - Math.floor(minX)),
+        height: Math.max(0, Math.ceil(maxY) - Math.floor(minY)),
+      }
+    }
+  }
+
+  const bounds = activeBounds.value.boundsPx || { width: 0, height: 0 }
+  const width = Number(bounds.width) || Number(adapt.width) || 0
+  const height = Number(bounds.height) || Number(adapt.height) || 0
+  return { x: 0, y: 0, width, height }
+})
+
+const floorBoundary = computed(() => {
+  if (!isInfinitePlant.value) {
+    const rect = plantRect.value
+    const width = Number(rect.width) || 0
+    const height = Number(rect.height) || 0
+    const x = Number(rect.x) || 0
+    const y = Number(rect.y) || 0
+    return {
+      width,
+      height,
+      x,
+      y,
+      minX: x,
+      minY: y,
+      maxX: x + width,
+      maxY: y + height,
+    }
+  }
+  const bounds = activeBounds.value.boundsPx || { width: 0, height: 0 }
   const zoom = canvasStore.zoom || 1
   const viewWidth = stageSize.value.width / (zoom || 1)
   const viewHeight = stageSize.value.height / (zoom || 1)
+  const width = Math.max(bounds.width || 0, viewWidth || 0)
+  const height = Math.max(bounds.height || 0, viewHeight || 0)
   return {
-    width: Math.max(bounds.width || 0, viewWidth || 0),
-    height: Math.max(bounds.height || 0, viewHeight || 0),
+    width,
+    height,
+    x: 0,
+    y: 0,
+    minX: 0,
+    minY: 0,
+    maxX: width,
+    maxY: height,
   }
 })
 
@@ -878,6 +979,53 @@ const layerConfig = computed(() => {
   return {
     width: Math.max(baseWidth, viewWidth || 0),
     height: Math.max(baseHeight, viewHeight || 0),
+  }
+})
+
+const mainFloorInfoText = computed(() => {
+  const dimsText = formatLengthsCm([
+    (layerConfig.value.width || 0) * viewport.cmPerPx,
+    (layerConfig.value.height || 0) * viewport.cmPerPx,
+  ])
+  if (!canvasStore.estaEnPlanta) {
+    const name = canvasStore.estructuraContenedorActual?.nombre || ''
+    return `${name} - ${dimsText}`
+  }
+  return `${canvasStore.plantaActivaData?.nombre || ''} - ${dimsText}`
+})
+
+const plantElementsText = computed(() => `Elementos: ${elementosVisiblesEnCanvas.value.length}`)
+
+const floorLabelPositions = computed(() => {
+  const zoom = canvasStore.zoom || 1
+  const fallback = {
+    main: { x: 10, y: -(39 / zoom) },
+    secondary: { x: 10, y: -(19 / zoom) },
+  }
+
+  if (!canvasStore.estaEnPlanta || isInfinitePlant.value) {
+    return fallback
+  }
+
+  const rect = plantRect.value || { x: 0, y: 0, width: 0, height: 0 }
+  const paddingPx = 14
+  const rightEdge = (Number(rect.x) || 0) + (Number(rect.width) || 0) - paddingPx / zoom
+
+  const mainText = mainFloorInfoText.value || ''
+  const mainWidthWorld = measureTextWidth(mainText, 12) / zoom
+  const safeMainWidth = Number.isFinite(mainWidthWorld) ? mainWidthWorld : 0
+  const mainX = Number.isFinite(rightEdge) ? rightEdge - safeMainWidth : 0
+  const mainY = (Number(rect.y) || 0) - (39 / zoom)
+
+  const secondaryText = plantElementsText.value || ''
+  const secondaryWidthWorld = measureTextWidth(secondaryText, 11) / zoom
+  const safeSecondaryWidth = Number.isFinite(secondaryWidthWorld) ? secondaryWidthWorld : 0
+  const secondaryX = Number.isFinite(rightEdge) ? rightEdge - safeSecondaryWidth : 0
+  const secondaryY = (Number(rect.y) || 0) - (19 / zoom)
+
+  return {
+    main: { x: mainX, y: mainY },
+    secondary: { x: secondaryX, y: secondaryY },
   }
 })
 
@@ -956,15 +1104,30 @@ const gridLines = computed(() => {
   }
 
   // Usar las dimensiones del layer (planta) para el grid
-  const layerWidth = floorBoundary.value.width
-  const layerHeight = floorBoundary.value.height
+  const boundary = floorBoundary.value
+  const layerWidth = Number(boundary.width) || 0
+  const layerHeight = Number(boundary.height) || 0
 
-  for (let i = 0; i <= layerWidth; i += gridSizePx) {
-    vertical.push(i)
-  }
+  if (!isInfinitePlant.value) {
+    const startX = Number(boundary.x) || 0
+    const endX = startX + layerWidth
+    for (let x = startX; x <= endX + 0.5; x += gridSizePx) {
+      vertical.push(x)
+    }
 
-  for (let i = 0; i <= layerHeight; i += gridSizePx) {
-    horizontal.push(i)
+    const startY = Number(boundary.y) || 0
+    const endY = startY + layerHeight
+    for (let y = startY; y <= endY + 0.5; y += gridSizePx) {
+      horizontal.push(y)
+    }
+  } else {
+    for (let x = 0; x <= layerWidth; x += gridSizePx) {
+      vertical.push(x)
+    }
+
+    for (let y = 0; y <= layerHeight; y += gridSizePx) {
+      horizontal.push(y)
+    }
   }
 
   return { vertical, horizontal }

--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -556,23 +556,72 @@ export const useCanvasStore = defineStore('canvas', () => {
   }
 
   const calcularCanvasAdaptativoPlanta = (planta) => {
-    // Calcular tamaño del canvas basado en las dimensiones de la planta
+    // Calcular tamaño y origen del canvas basado en la planta activa
     if (!planta) {
-      // Fallback por defecto
       canvasAdaptativo.value = {
         width: 800,
         height: 600,
         escala: 1,
+        frame: { x: 0, y: 0, width: 800, height: 600 },
       }
       return
     }
 
-    // Convertir dimensiones de cm a pixels usando la constante CM_TO_PX
-    // Para plantas, usamos la conversión directa 1:1 (sin factor de escala adicional)
+    const dims = planta.dimensiones || {}
+    const widthPxFromDims = (Number(dims.ancho) || 0) * CM_TO_PX
+    const heightPxFromDims = (Number(dims.largo) || 0) * CM_TO_PX
+
+    let originX = 0
+    let originY = 0
+    let frameWidth = widthPxFromDims
+    let frameHeight = heightPxFromDims
+
+    if (Array.isArray(planta.poligono) && planta.poligono.length >= 3) {
+      let minX = Infinity
+      let minY = Infinity
+      let maxX = -Infinity
+      let maxY = -Infinity
+
+      for (const point of planta.poligono) {
+        const x = Number(point?.x ?? point?.[0])
+        const y = Number(point?.y ?? point?.[1])
+        if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+        minX = Math.min(minX, x)
+        minY = Math.min(minY, y)
+        maxX = Math.max(maxX, x)
+        maxY = Math.max(maxY, y)
+      }
+
+      if (
+        Number.isFinite(minX) &&
+        Number.isFinite(minY) &&
+        Number.isFinite(maxX) &&
+        Number.isFinite(maxY) &&
+        maxX > minX &&
+        maxY > minY
+      ) {
+        originX = Math.floor(minX)
+        originY = Math.floor(minY)
+        frameWidth = Math.max(1, Math.ceil(maxX) - originX)
+        frameHeight = Math.max(1, Math.ceil(maxY) - originY)
+      }
+    }
+
+    if (!Number.isFinite(frameWidth) || frameWidth <= 0) frameWidth = widthPxFromDims || 0
+    if (!Number.isFinite(frameHeight) || frameHeight <= 0) frameHeight = heightPxFromDims || 0
+
     canvasAdaptativo.value = {
-      width: planta.dimensiones.ancho * CM_TO_PX, // ancho = x
-      height: planta.dimensiones.largo * CM_TO_PX, // largo = y
-      escala: CM_TO_PX, // La escala es la conversión cm->px
+      width: frameWidth || widthPxFromDims,
+      height: frameHeight || heightPxFromDims,
+      escala: CM_TO_PX,
+      originX,
+      originY,
+      frame: {
+        x: originX,
+        y: originY,
+        width: frameWidth || widthPxFromDims,
+        height: frameHeight || heightPxFromDims,
+      },
     }
   }
 

--- a/src/inventory-smart/composables/useZoom.js
+++ b/src/inventory-smart/composables/useZoom.js
@@ -27,6 +27,26 @@ export function useZoom(stageSize, layerConfig) {
       const planta = canvasStore.plantaActivaData
       const isInfinite = planta?.isInfinite === true
 
+      if (!isInfinite) {
+        const frame = canvasStore.canvasAdaptativo?.frame
+        const frameWidth = Number(frame?.width)
+        const frameHeight = Number(frame?.height)
+        if (
+          frame &&
+          Number.isFinite(frameWidth) &&
+          Number.isFinite(frameHeight) &&
+          frameWidth > 0 &&
+          frameHeight > 0
+        ) {
+          return {
+            x: Number(frame.x) || 0,
+            y: Number(frame.y) || 0,
+            width: Math.max(1, frameWidth),
+            height: Math.max(1, frameHeight),
+          }
+        }
+      }
+
       // 2.a) BBox del contenido visible (elementos de la planta activa)
       const elems = (canvasStore.elementosVisibles || []).filter((e) => e?.visible !== false && e?.plantaId === canvasStore.plantaActiva)
       if (elems.length > 0) {


### PR DESCRIPTION
## Summary
- derive the adaptive canvas frame for plants from the polygon bounding box so width/height and x/y origin are preserved when exiting elastic mode
- let the zoom helper prefer the stored plant frame when computing fit-to-view so finite floors center correctly
- in the Konva view, compute the plant rectangle once, offset grid lines and attach the info label to the frame with safe text measurement fallbacks

## Testing
- npm run test:unit -- --run src/inventory-smart/__tests__/context_menu.spec.js *(fails: jsdom does not implement HTMLCanvasElement.getContext)*

------
https://chatgpt.com/codex/tasks/task_e_68d4172b1adc83218e7e47c2ef0a6890