### PR TITLE
Adjust floor label placement outside plant bounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+﻿# Repository Guidelines
+
+## Project Structure & Module Organization
+The Vite-powered Vue 3 app lives under `src/`, with `main.js` mounting `App.vue`. Feature logic is grouped inside `src/inventory-smart`, which splits concerns into `components/`, stateful `stores/`, reusable `composables/`, domain-specific `modules/`, and helper `utils/`. UI routes live in `src/pages`, the router in `src/router`, and shared global styles in `src/styles`. Public assets ship from `public/`, while project docs stay in `docs/`.
+
+## Build, Test, and Development Commands
+Run `npm install` once to sync dependencies. Use `npm run dev` for Vite hot-module development, `npm run build` for production bundles, and `npm run preview` to smoke-test the build locally. Quality gates include `npm run lint` (ESLint with autofix), `npm run format` (Prettier on `src/`), and `npm run test:unit` (Vitest + Vue Test Utils).
+
+## Coding Style & Naming Conventions
+Follow the repo `.editorconfig`: two-space indents, spaces over tabs, LF endings, and max 100 characters per line. Prettier enforces single quotes and no semicolons; do not override these defaults. Favor PascalCase for Vue SFC filenames (e.g., `HomePage.vue`), camelCase for functions and variables, and prefix composables with `use` (e.g., `useSelection`). Keep stores inside Pinia modules named `useXStore`.
+
+## Testing Guidelines
+Vitest drives both unit and integration specs, with setup in `src/__tests__/test-setup.js`. Place new tests in `src/inventory-smart/__tests__` using the `*.spec.js` pattern already in place. Mirror the feature folder structure when practical, and cover canvas interactions with high-level integration specs plus targeted geometry/unit checks. Run `npm run test:unit` before pushing; include new edge cases whenever business rules expand.
+
+## Commit & Pull Request Guidelines
+Match the existing Conventional Commit style (`feat:`, `fix:`, `test:`, etc.) and keep messages under 72 characters on the subject line. Squash local noise before opening a PR, then provide a concise summary, list impacted areas, and link Jira/GitLab issues. Attach screenshots or GIFs for UI-facing changes and note any follow-up work. Always state which checks you ran (e.g., lint, tests) in the PR description.
+
+## Environment & Tooling Notes
+Use Node.js 20.19+ (see `package.json` engines) and ensure pnpm/yarn lockfiles are not committed. Docker support exists via `Dockerfile` and `docker-compose.yml` for parity with staging; rebuild containers whenever dependencies change. Keep secrets out of the repo—leverage `.env.local` entries and document required keys in `docs/` without committing values.
+
+## Reglas de Trabajo (IA & Devs)
+- Estilos: agregar en los bloques `<style>` locales de componentes existentes (preferir `InventorySmart.vue` o el componente afectado). Si se requiere un estilo global, usar `src/styles/index.css`.
+- Constantes: reutilizar o ampliar las existentes; si se requiere una nueva y ya hay un módulo afín, definirla ahí para evitar archivos sueltos.
+- Redacción: no modificar ortografía, signos o símbolos de textos existentes a menos que se pida de forma explícita.
+- Codificación: mantener siempre intactos acentos, emojis, caracteres especiales y comentarios. No reescribir ni reinterpretar texto en otro encoding (UTF-8 se asume por defecto). Cualquier tarea pedida debe limitarse a la lógica/estructura indicada sin introducir cambios accidentales de codificación.

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -997,7 +997,7 @@ const floorLabelPositions = computed(() => {
   const rectX = Number(rect.x)
   const rectY = Number(rect.y)
   const baseX = (Number.isFinite(rectX) ? rectX : 0) + padWorld
-  const baseY = (Number.isFinite(rectY) ? rectY : 0) + padWorld
+  const baseY = (Number.isFinite(rectY) ? rectY : 0) - (lineGapWorld + padWorld)
 
   return {
     main: { x: baseX, y: baseY },

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -997,7 +997,7 @@ const floorLabelPositions = computed(() => {
   const rectX = Number(rect.x)
   const rectY = Number(rect.y)
   const baseX = (Number.isFinite(rectX) ? rectX : 0) + padWorld
-  const baseY = (Number.isFinite(rectY) ? rectY : 0) - (lineGapWorld + padWorld)
+  const baseY = (Number.isFinite(rectY) ? rectY : 0) - (lineGapWorld + padWorld) - 10
 
   return {
     main: { x: baseX, y: baseY },


### PR DESCRIPTION
## Summary
- position the floor info labels above the plant boundary again so they render outside the canvas area

## Testing
- npm run test:unit -- --run *(fails: existing Vitest suite has numerous pre-existing failures in multiple specs)*

------
https://chatgpt.com/codex/tasks/task_e_68d437cd08748321a948fba7fa93a284