### PR TITLE
fix: recalcular limites al salir de planta infinita

### DIFF
--- a/src/inventory-smart/composables/useElementDrag.js
+++ b/src/inventory-smart/composables/useElementDrag.js
@@ -14,7 +14,7 @@ import { finalizePlacement } from '@/inventory-smart/utils/finalizeDrag'
 import { isPlacementValid } from '@/inventory-smart/utils/isPlacementValid'
 import { makeInnerSession } from '@/inventory-smart/composables/useInnerNoOverlap'
 import { GRID_SIZE, CM_TO_PX } from '@/inventory-smart/utils/constants'
-import { getActiveBounds } from '@/inventory-smart/utils/activeBounds'
+import { getActiveBounds, deriveAreaBounds } from '@/inventory-smart/utils/activeBounds'
 import {
   detectConflictsFor,
   computeMTD,
@@ -294,7 +294,7 @@ export function useElementDrag({
         const onValidateLight = throttle2((bbox) => {
           // Overlay rojo/ok basado en el MISMO predicado de validez (modelo puro)
           const active = getActiveBounds(canvasStore)
-          const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height, polygon: active.polygonPx }
+          const areaBounds = deriveAreaBounds(active, layerConfig.value.width, layerConfig.value.height)
           const elemento = canvasStore.elementosVisibles.find((el) => el.id === elementId)
           if (!elemento) return
           const moving = {
@@ -339,10 +339,8 @@ export function useElementDrag({
           if (!shape) return
           const elemento = canvasStore.elementosVisibles.find((el) => el.id === elementId)
           if (!elemento) return
-          const W = layerConfig.value.width
-          const H = layerConfig.value.height
           const activeForFrame = getActiveBounds(canvasStore)
-          const areaBounds = { minX: 0, minY: 0, maxX: W, maxY: H, polygon: activeForFrame.polygonPx }
+          const areaBounds = deriveAreaBounds(activeForFrame, layerConfig.value.width, layerConfig.value.height)
 
           // Para círculos, desiredPos ya es top-left (convertido en updateElementPosition)
           const asRect =
@@ -379,7 +377,7 @@ export function useElementDrag({
           if (!elemento) return false
           const neighbors = canvasStore.elementosVisibles.filter((e) => e.id !== elementId)
           const activeForValidate = getActiveBounds(canvasStore)
-          const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height, polygon: activeForValidate.polygonPx }
+          const areaBounds = deriveAreaBounds(activeForValidate, layerConfig.value.width, layerConfig.value.height)
           return isPlacementValid({ pos, movingEl: elemento, neighbors, areaBounds, CM_TO_PX, epsPx: 0.5 })
         }
 
@@ -484,8 +482,8 @@ export function useElementDrag({
       const layer = layerRef.value.getNode()
       const shape = stage.findOne(`#${elementId}`)
       if (shape && layer) {
-          const activeFinalize = getActiveBounds(canvasStore)
-          const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height, polygon: activeFinalize.polygonPx }
+        const activeFinalize = getActiveBounds(canvasStore)
+        const areaBounds = deriveAreaBounds(activeFinalize, layerConfig.value.width, layerConfig.value.height)
         const elementoActual = canvasStore.elementosVisibles.find((e) => e.id === elementId)
         if (elementoActual) {
           // Candidato desde el shape (bbox de modelo)
@@ -682,8 +680,8 @@ export function useElementDrag({
 
       if (storeEl && posDiff) {
         // Validar que la posición final está dentro del área y es válida según el validador común
-  const active2 = getActiveBounds(canvasStore)
-  const areaBounds = { minX: 0, minY: 0, maxX: layerConfig.value.width, maxY: layerConfig.value.height, polygon: active2.polygonPx }
+        const active2 = getActiveBounds(canvasStore)
+        const areaBounds = deriveAreaBounds(active2, layerConfig.value.width, layerConfig.value.height)
         const neighbors = canvasStore.elementosVisibles.filter((e) => e.id !== elementId)
         const isValidNow = isPlacementValid({
           pos: { x: finalX, y: finalY },

--- a/src/inventory-smart/composables/useTransformer.js
+++ b/src/inventory-smart/composables/useTransformer.js
@@ -3,6 +3,7 @@ import { throttleEveryNFrames } from '@/inventory-smart/utils/dragMath'
 import { isPlacementValid } from '@/inventory-smart/utils/isPlacementValid'
 import { CM_TO_PX, TIPOS_ENTIDAD } from '@/inventory-smart/utils/constants'
 import { circleInPolygon, isRectCompletelyInPolygon } from '@/inventory-smart/utils/polygonBounds'
+import { deriveAreaBounds, getActiveBounds } from '@/inventory-smart/utils/activeBounds'
 import { correctTransformValues } from '@/inventory-smart/utils/precision'
 import { toTransformerPrecision } from '../utils/fixedDimensions'
 
@@ -652,30 +653,16 @@ export function useTransformer({
 
       const layerWidth = layerConfig?.value?.width ?? 0
       const layerHeight = layerConfig?.value?.height ?? 0
-
-      const areaBounds = boundary
-        ? boundary.mode === 'elastic'
-          ? {
-              minX: 0,
-              minY: 0,
-              mode: 'elastic',
-              ...(polygonForBounds ? { polygon: polygonForBounds } : {}),
-            }
-          : {
-              minX: 0,
-              minY: 0,
-              mode: boundary.mode || 'fixed',
-              maxX: layerWidth,
-              maxY: layerHeight,
-              ...(polygonForBounds ? { polygon: polygonForBounds } : {}),
-            }
-        : {
-            minX: 0,
-            minY: 0,
-            mode: 'fixed',
-            maxX: layerWidth,
-            maxY: layerHeight,
-          }
+      const activeBounds = getActiveBounds(canvasStore)
+      const areaBounds = deriveAreaBounds(activeBounds, layerWidth, layerHeight)
+      if (boundary?.mode === 'elastic') {
+        areaBounds.mode = 'elastic'
+      } else if (boundary?.mode) {
+        areaBounds.mode = boundary.mode
+      }
+      if (polygonForBounds) {
+        areaBounds.polygon = polygonForBounds
+      }
       const elementoParaValidacion =
         elementoSnapshot?.forma === 'circular'
           ? {

--- a/src/inventory-smart/utils/activeBounds.js
+++ b/src/inventory-smart/utils/activeBounds.js
@@ -118,3 +118,60 @@ export function getActiveBounds(canvasStore) {
   }
   return { mode: isInfinite ? 'elastic' : 'fixed', boundsPx: { width, height }, polygonPx }
 }
+
+function computePolygonBBox(points) {
+  if (!Array.isArray(points) || points.length < 3) return null
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let hasFinite = false
+  for (const point of points) {
+    const x = Number(point?.x ?? point?.[0])
+    const y = Number(point?.y ?? point?.[1])
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+    hasFinite = true
+    if (x < minX) minX = x
+    if (y < minY) minY = y
+    if (x > maxX) maxX = x
+    if (y > maxY) maxY = y
+  }
+  if (!hasFinite) return null
+  return { minX, minY, maxX, maxY }
+}
+
+export function deriveAreaBounds(active, fallbackWidth = 0, fallbackHeight = 0) {
+  const mode = active?.mode || 'fixed'
+  const polygon = Array.isArray(active?.polygonPx) && active.polygonPx.length >= 3 ? active.polygonPx : null
+  const polygonIsInfinite = !!(polygon && polygon._isInfinite === true)
+
+  let minX = 0
+  let minY = 0
+  let maxX = Number(fallbackWidth) || 0
+  let maxY = Number(fallbackHeight) || 0
+
+  if (polygon && !polygonIsInfinite) {
+    const bbox = computePolygonBBox(polygon)
+    if (bbox) {
+      minX = bbox.minX
+      minY = bbox.minY
+      maxX = bbox.maxX
+      maxY = bbox.maxY
+    }
+  } else if (active?.boundsPx) {
+    const width = Number(active.boundsPx.width)
+    const height = Number(active.boundsPx.height)
+    if (Number.isFinite(width) && width > 0) {
+      maxX = width
+    }
+    if (Number.isFinite(height) && height > 0) {
+      maxY = height
+    }
+  }
+
+  const area = { minX, minY, maxX, maxY, mode }
+  if (polygon) {
+    area.polygon = polygon
+  }
+  return area
+}


### PR DESCRIPTION
## Summary
- derivar límites activos desde el polígono para evitar offsets residuales al salir de modo infinito
- reutilizar los nuevos límites en los flujos de drag y transform para mantener clamps y validaciones coherentes

## Testing
- npm run lint
- npm run test:unit *(falla por casos existentes que requieren vi.mocked y dependencias de entorno en los specs)*

------
https://chatgpt.com/codex/tasks/task_e_68d445172e2083219b647ecdde547199