### PR TITLE
fix: auto fit infinite plants on context change

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -2395,6 +2395,12 @@ watch(
     await nextTick()
     await nextTick()
 
+    if (ctx.tipo === 'plantas' && isInfinitePlant.value) {
+      await nextTick()
+      fitToPlanta()
+      return
+    }
+
     const dynamicMinZoom = getDynamicMinZoom()
     canvasStore.configurarZoom(dynamicMinZoom, dynamicMinZoom)
 


### PR DESCRIPTION
## Summary
- trigger canvas auto-fit when switching to an infinite planta context so users immediately see its contents

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4586d575883219ef47c7be6d36f93