### PR TITLE
fix: prevent infinite fit fallback when content exists

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -2368,9 +2368,11 @@ const fitToPlanta = () => {
     } catch { /* ignore */ }
 
     if (isInfinitePlant.value) {
-      const hasVisibleElements = elementosVisiblesEnCanvas.value.length > 0
+      const hasRenderableElements = Array.isArray(canvasStore.elementosVisibles)
+        ? canvasStore.elementosVisibles.some((el) => el?.visible !== false)
+        : false
 
-      if (!hasVisibleElements) {
+      if (!hasRenderableElements) {
         const fallbackZoom = Math.min(
           MAX_ZOOM,
           Math.max(dynamicMinZoom, DEFAULT_INFINITE_INITIAL_ZOOM),


### PR DESCRIPTION
## Summary
- avoid triggering the infinite-floor fit fallback when the planta already has visible elements by checking the store instead of the viewport cache

## Testing
- npm run lint
- npm run test:unit -- --run *(fails: multiple pre-existing spec failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d463dd608483219b3b6060746032a9