### PR TITLE
feat: align infinite detail fit behaviour

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -662,7 +662,14 @@ import { insideAreaModel } from '@/inventory-smart/utils/isPlacementValid'
 import { dimsCmFor, clampInsideArea } from '@/inventory-smart/utils/bounds'
 import { handleCanvasHotkeys } from '@/inventory-smart/utils/canvasHotkeys'
 import { polygonInset } from '@/inventory-smart/utils/polygonInset'
-import { GRID_SIZE, CM_TO_PX, CATALOGO, OFFSETS } from '@/inventory-smart/utils/constants'
+import {
+  GRID_SIZE,
+  CM_TO_PX,
+  CATALOGO,
+  OFFSETS,
+  FIT_VIEWPORT_PADDING,
+  INFINITE_DETAIL_FIT_PADDING,
+} from '@/inventory-smart/utils/constants'
 import { computeDimsByAxisScale, toCanvasSizePx } from '@/inventory-smart/utils/dimensionPolicy'
 import { cmToPx, pxToCm, fmtCm, formatLengthsCm } from '@/inventory-smart/utils/units'
 import { useViewportStore } from '@/inventory-smart/stores/viewport'
@@ -2328,6 +2335,21 @@ watch(
   { deep: true },
 )
 
+const DETAIL_CONTEXTS = ['elementos', 'contenedores']
+
+const resolveFitPaddingOptions = () => {
+  const basePadding = FIT_VIEWPORT_PADDING
+  if (canvasStore.plantaActivaData?.isInfinite === true) {
+    const ctxTipo = canvasStore.contextoActual?.tipo
+    if (DETAIL_CONTEXTS.includes(ctxTipo)) {
+      const padding = INFINITE_DETAIL_FIT_PADDING
+      return { viewportPadding: padding, infinitePadding: padding }
+    }
+    return { viewportPadding: basePadding, infinitePadding: basePadding }
+  }
+  return { viewportPadding: basePadding, infinitePadding: basePadding }
+}
+
 // Ajustar la vista para encuadrar la planta activa
 const fitToPlanta = () => {
   try {
@@ -2339,8 +2361,15 @@ const fitToPlanta = () => {
       return
     }
 
+    const fitOptions = resolveFitPaddingOptions()
+
     // Ajustar directamente al contenido (BBox + margen)
-    fitToContent(stage)
+    fitToContent(stage, fitOptions)
+
+    const contextoTipo = canvasStore.contextoActual?.tipo
+    if (contextoTipo && contextoTipo !== 'plantas') {
+      return
+    }
 
     // Sincronizar llamada explícita para compatibilidad con pruebas:
     // intentar usar el bbox del polígono crudo (sin interpretar unidades)
@@ -2357,7 +2386,7 @@ const fitToPlanta = () => {
         const maxY = Math.max(...ys)
         const bw = Math.max(1, maxX - minX)
         const bh = Math.max(1, maxY - minY)
-        const margin = 40
+        const margin = Number(fitOptions?.viewportPadding) || FIT_VIEWPORT_PADDING
         const vw = Math.max(16, stageSize.value.width - margin * 2)
         const vh = Math.max(16, stageSize.value.height - margin * 2)
         const sx = vw / bw
@@ -2417,7 +2446,26 @@ watch(
     await nextTick()
     await nextTick()
 
-    if (ctx.tipo === 'plantas' && isInfinitePlant.value) {
+    if (ctx.tipo === 'plantas') {
+      if (isInfinitePlant.value) {
+        await nextTick()
+        fitToPlanta()
+        return
+      }
+
+      const dynamicMinZoom = getDynamicMinZoom()
+      canvasStore.configurarZoom(dynamicMinZoom, dynamicMinZoom)
+
+      const stage = stageRef.value?.getNode?.()
+      if (stage) {
+        const centerX = stageSize.value.width / 2
+        const centerY = stageSize.value.height / 2
+        canvasStore.configurarPan(centerX, centerY)
+      }
+      return
+    }
+
+    if (isInfinitePlant.value && DETAIL_CONTEXTS.includes(ctx.tipo)) {
       await nextTick()
       fitToPlanta()
       return

--- a/src/inventory-smart/composables/useZoom.js
+++ b/src/inventory-smart/composables/useZoom.js
@@ -4,17 +4,29 @@
  */
 
 import { useCanvasStore } from './useCanvasStore'
-import { CM_TO_PX } from '../utils/constants'
+import { CM_TO_PX, FIT_VIEWPORT_PADDING, INFINITE_DETAIL_FIT_PADDING } from '../utils/constants'
 
-const CONTENT_MARGIN = 40
+const DEFAULT_VIEWPORT_PADDING = FIT_VIEWPORT_PADDING
+const DEFAULT_INFINITE_PADDING = INFINITE_DETAIL_FIT_PADDING
 
 export function useZoom(stageSize, layerConfig) {
   const canvasStore = useCanvasStore()
 
+  const resolvePadding = (options = {}) => {
+    const viewportPadding = Number.isFinite(options.viewportPadding)
+      ? Math.max(0, Number(options.viewportPadding))
+      : DEFAULT_VIEWPORT_PADDING
+    const infinitePadding = Number.isFinite(options.infinitePadding)
+      ? Math.max(0, Number(options.infinitePadding))
+      : DEFAULT_INFINITE_PADDING
+    return { viewportPadding, infinitePadding }
+  }
+
   /**
    * Calcula el bounding box para diferentes contextos
    */
-  const calculateBoundingBox = () => {
+  const calculateBoundingBox = (options = {}) => {
+    const { infinitePadding } = resolvePadding(options)
     // Contexto 1: si no estamos en planta (navegando dentro de un elemento)
     if ((!canvasStore.estaEnPlanta) && canvasStore.estructuraContenedorActual) {
       const localW = layerConfig.value.width || Math.max(1, canvasStore.estructuraContenedorActual.width || 1)
@@ -65,7 +77,7 @@ export function useZoom(stageSize, layerConfig) {
           const width = Math.max(1, maxX - minX)
           const height = Math.max(1, maxY - minY)
           if (isInfinite) {
-            const margin = CONTENT_MARGIN
+            const margin = infinitePadding
             return {
               x: minX - margin,
               y: minY - margin,
@@ -147,7 +159,8 @@ export function useZoom(stageSize, layerConfig) {
       return 0.001
     }
 
-    const margin = 40
+    const { viewportPadding } = resolvePadding()
+    const margin = viewportPadding
     const vw = Math.max(16, stageSize.value.width - margin * 2)
     const vh = Math.max(16, stageSize.value.height - margin * 2)
 
@@ -208,15 +221,16 @@ export function useZoom(stageSize, layerConfig) {
    * Ajusta la vista para encuadrar perfectamente el contenido activo
    * Versión avanzada que maneja múltiples contextos y centra inteligentemente
    */
-  const fitToContent = (stage) => {
+  const fitToContent = (stage, options = {}) => {
     if (!stage) return
 
     try {
-      const margin = 40
+      const { viewportPadding, infinitePadding } = resolvePadding(options)
+      const margin = viewportPadding
       const vw = Math.max(16, stageSize.value.width - margin * 2)
       const vh = Math.max(16, stageSize.value.height - margin * 2)
 
-      const bbox = calculateBoundingBox()
+      const bbox = calculateBoundingBox({ infinitePadding })
       const chosen = chooseBestBoundingBox(bbox, { width: vw, height: vh })
 
       if (!chosen) {

--- a/src/inventory-smart/utils/constants.js
+++ b/src/inventory-smart/utils/constants.js
@@ -266,6 +266,12 @@ export const ELEMENTOS_PREDEFINIDOS = [
   },
 ]
 
+// === CONFIGURACIÓN DE VISTA ===
+// Padding predeterminado (en px) usado al encuadrar contenido en la vista.
+export const FIT_VIEWPORT_PADDING = 40
+// Padding extra aplicado al encuadrar elementos dentro de plantas infinitas.
+export const INFINITE_DETAIL_FIT_PADDING = 40
+
 // === CATEGORÍAS POR TIPO ===
 export const CATEGORIAS_ELEMENTOS = [
   { id: 'anaqueles', nombre: 'Anaqueles', color: '#3b82f6', tipo: 'elementos' },


### PR DESCRIPTION
## Summary
- add configurable fit padding constants for canvas framing
- allow the zoom composable to accept padding overrides when computing fit-to-content
- reuse the same fit logic for infinite plants when entering element detail or using "Ajustar vista"

## Testing
- npm run lint
- npm run test:unit *(fails: multiple suites asserting selection/history behaviour and wrapper.vm.innerSessions access)*

------
https://chatgpt.com/codex/tasks/task_e_68d559f83f5c8321b7ea58fc1658e984