### PR TITLE
Fix infinite plant detail auto fit

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -662,7 +662,7 @@ import { insideAreaModel } from '@/inventory-smart/utils/isPlacementValid'
 import { dimsCmFor, clampInsideArea } from '@/inventory-smart/utils/bounds'
 import { handleCanvasHotkeys } from '@/inventory-smart/utils/canvasHotkeys'
 import { polygonInset } from '@/inventory-smart/utils/polygonInset'
-import { GRID_SIZE, CM_TO_PX, CATALOGO, OFFSETS } from '@/inventory-smart/utils/constants'
+import { GRID_SIZE, CM_TO_PX, CATALOGO, OFFSETS, DEFAULT_FIT_VIEW_PADDING } from '@/inventory-smart/utils/constants'
 import { computeDimsByAxisScale, toCanvasSizePx } from '@/inventory-smart/utils/dimensionPolicy'
 import { cmToPx, pxToCm, fmtCm, formatLengthsCm } from '@/inventory-smart/utils/units'
 import { useViewportStore } from '@/inventory-smart/stores/viewport'
@@ -710,6 +710,11 @@ const indicatorsLayerRef = ref(null)
 
 // Composable con historial integrado
 const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistory()
+
+const getFitViewPadding = () => {
+  const raw = Number(canvasStore.fitViewPadding ?? DEFAULT_FIT_VIEW_PADDING)
+  return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_FIT_VIEW_PADDING
+}
 const { onDragStartGuard, onDragMoveGuard, onDragEndGuard, onTransformEndGuard } =
   usePlacementGuards()
 const buffer = useCanvasBuffer()
@@ -2339,6 +2344,12 @@ const fitToPlanta = () => {
       return
     }
 
+    const contextType = canvasStore.contextoActual?.tipo
+    if (contextType && contextType !== 'plantas') {
+      fitToContent(stage)
+      return
+    }
+
     // Ajustar directamente al contenido (BBox + margen)
     fitToContent(stage)
 
@@ -2357,7 +2368,7 @@ const fitToPlanta = () => {
         const maxY = Math.max(...ys)
         const bw = Math.max(1, maxX - minX)
         const bh = Math.max(1, maxY - minY)
-        const margin = 40
+        const margin = getFitViewPadding()
         const vw = Math.max(16, stageSize.value.width - margin * 2)
         const vh = Math.max(16, stageSize.value.height - margin * 2)
         const sx = vw / bw
@@ -2417,7 +2428,7 @@ watch(
     await nextTick()
     await nextTick()
 
-    if (ctx.tipo === 'plantas' && isInfinitePlant.value) {
+    if (isInfinitePlant.value) {
       await nextTick()
       fitToPlanta()
       return

--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -18,7 +18,14 @@ import { assignCodigoNombre } from '@/inventory-smart/utils/codeNameAssigner.js'
 
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
-import { CM_TO_PX, DIMENSIONS, CATALOGO, OFFSETS, TIPOS_ENTIDAD } from '@/inventory-smart/utils/constants'
+import {
+  CM_TO_PX,
+  DIMENSIONS,
+  CATALOGO,
+  OFFSETS,
+  TIPOS_ENTIDAD,
+  DEFAULT_FIT_VIEW_PADDING,
+} from '@/inventory-smart/utils/constants'
 import { computeDimsByAxisScale, toCanvasSizePx } from '@/inventory-smart/utils/dimensionPolicy'
 import { useToast } from '@/inventory-smart/composables/useToast'
 import { useStatePersistence, DEFAULT_TIPOS_ESPACIO, DEFAULT_TIPOS_CUARTO, DEFAULT_TIPOS_PRODUCTO_ADMITIDOS } from '@/inventory-smart/composables/useStatePersistence'
@@ -151,6 +158,14 @@ export const useCanvasStore = defineStore('canvas', () => {
   // Por defecto desactivamos la cuadrícula (0 = sin cuadricula visual ni snap a grilla)
   const gridSize = ref(0) // px entre líneas de grilla (0 desactiva)
   const snapGridEps = ref(10) // px de proximidad para aplicar snap al soltar
+
+  const fitViewPadding = ref(DEFAULT_FIT_VIEW_PADDING)
+
+  const setFitViewPadding = (paddingPx) => {
+    const parsed = Number(paddingPx)
+    if (!Number.isFinite(parsed)) return
+    fitViewPadding.value = Math.max(0, parsed)
+  }
 
   const setGridSize = (sizePx) => {
     const s = Number(sizePx)
@@ -1685,6 +1700,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     panY,
     gridSize,
     snapGridEps,
+    fitViewPadding,
     crearPlanta,
     plantaEnEdicion,
     etiquetas,
@@ -1733,6 +1749,7 @@ export const useCanvasStore = defineStore('canvas', () => {
     configurarPan,
     setGridSize,
     setSnapGridEps,
+    setFitViewPadding,
 
     // Actions - Plantas
     seleccionarPlanta,

--- a/src/inventory-smart/composables/useZoom.js
+++ b/src/inventory-smart/composables/useZoom.js
@@ -4,12 +4,15 @@
  */
 
 import { useCanvasStore } from './useCanvasStore'
-import { CM_TO_PX } from '../utils/constants'
-
-const CONTENT_MARGIN = 40
+import { CM_TO_PX, DEFAULT_FIT_VIEW_PADDING } from '../utils/constants'
 
 export function useZoom(stageSize, layerConfig) {
   const canvasStore = useCanvasStore()
+
+  const getFitPadding = () => {
+    const raw = Number(canvasStore.fitViewPadding ?? DEFAULT_FIT_VIEW_PADDING)
+    return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_FIT_VIEW_PADDING
+  }
 
   /**
    * Calcula el bounding box para diferentes contextos
@@ -65,7 +68,7 @@ export function useZoom(stageSize, layerConfig) {
           const width = Math.max(1, maxX - minX)
           const height = Math.max(1, maxY - minY)
           if (isInfinite) {
-            const margin = CONTENT_MARGIN
+            const margin = getFitPadding()
             return {
               x: minX - margin,
               y: minY - margin,
@@ -147,7 +150,7 @@ export function useZoom(stageSize, layerConfig) {
       return 0.001
     }
 
-    const margin = 40
+    const margin = getFitPadding()
     const vw = Math.max(16, stageSize.value.width - margin * 2)
     const vh = Math.max(16, stageSize.value.height - margin * 2)
 
@@ -212,7 +215,7 @@ export function useZoom(stageSize, layerConfig) {
     if (!stage) return
 
     try {
-      const margin = 40
+      const margin = getFitPadding()
       const vw = Math.max(16, stageSize.value.width - margin * 2)
       const vh = Math.max(16, stageSize.value.height - margin * 2)
 

--- a/src/inventory-smart/utils/constants.js
+++ b/src/inventory-smart/utils/constants.js
@@ -444,6 +444,9 @@ export const SNAP_EPS = 4
 // Tamaño de grilla para snap y búsqueda en espiral
 export const GRID_SIZE = 0
 
+// Padding por defecto para ajustar la vista al contenido (en px)
+export const DEFAULT_FIT_VIEW_PADDING = 40
+
 // === CONFIGURACIÓN DE PRECISIÓN ===
 // Precisión decimal para dimensiones en centímetros (0.01 = 2 decimales)
 export const PRECISION_CM = 0.01


### PR DESCRIPTION
## Summary
- add a default fit-view padding constant and expose a setter on the canvas store so the padding can be configured
- reuse the shared padding when computing zoom bounds in `useZoom` and when calculating polygon fallback zooms in `CanvasView`
- call the same fit logic after context changes and when the "Ajustar vista" control is pressed inside infinite plants

## Testing
- npm run lint
- npm run test:unit *(fails: suite relies on extensive mocks; see run for details)*

------
https://chatgpt.com/codex/tasks/task_e_68d559f83f5c8321b7ea58fc1658e984