### PR TITLE
feat: add three js preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Constantes útiles en `src/inventory-smart/utils/constants.js`:
 
 El componente gestiona conflictos entre backups locales y configuraciones provenientes del servidor mostrando un aviso cuando la versión del servidor es más reciente.
 
+## Vista previa 3D
+
+- Ruta dedicada: [`/three-preview`](src/pages/ThreePreviewPage.vue) (accesible desde la pantalla principal con el botón **Abrir visor 3D**).
+- Acción Pinia: `serializeForThreePreview` en `useCanvasStore` devuelve el JSON listo para Three.js sin métricas ni historial.
+- Documentación detallada y flujo de trabajo en [`docs/three-preview.md`](docs/three-preview.md).
+
 ## Atajos de teclado
 
 - Ctrl/Cmd + Z — Deshacer

--- a/docs/three-preview.md
+++ b/docs/three-preview.md
@@ -1,0 +1,36 @@
+# Visor 3D del Canvas
+
+El visor 3D permite validar la jerarquía, dimensiones y orientaciones exportadas por `useStatePersistence.serialize` dentro de una escena WebGL basada en Three.js.
+
+## Instalación
+
+1. Instala la dependencia necesaria:
+
+   ```bash
+   npm install three
+   ```
+
+2. Ejecuta el entorno de desarrollo habitual:
+
+   ```bash
+   npm run dev
+   ```
+
+## Flujo de uso
+
+1. Desde la vista principal (`/`) utiliza el botón **Abrir visor 3D** para navegar a `/three-preview`.
+2. La página consulta al store `useCanvasStore` mediante la acción `serializeForThreePreview`, que devuelve el JSON serializado sin métricas ni historial.
+3. `ThreePreviewPage.vue` entrega dicho JSON a `ThreeScene.vue`, que levanta la escena con cámara, luces, OrbitControls y el mapeo jerárquico completo.
+4. Usa el botón **Recargar datos** para re-sincronizar el visor con el estado actual del canvas.
+
+## Cobertura de datos
+
+- `useStatePersistence.serialize` conserva las dimensiones (`ancho`, `largo`, `alto`), orientación (`orientacion`) y relaciones padre/hijo (`padre`, `hijos`) necesarias para reconstruir el espacio tridimensional.
+- Las unidades se normalizan de centímetros a metros y se trasladan del plano 2D (X/Y) al espacio 3D (X/Z), elevando las alturas en el eje Y.
+
+## Componentes clave
+
+- `src/pages/ThreePreviewPage.vue`: página dedicada para el visor.
+- `src/inventory-smart/components/three/ThreeScene.vue`: escena Three.js con cámara, luces y controles.
+- `src/inventory-smart/utils/three/mapElementToMesh.js`: helper para traducir nodos del JSON a geometrías/mallas.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.12",
         "konva": "^9.3.22",
+        "three": "^0.170.0",
         "pinia": "^3.0.3",
         "tailwindcss": "^4.1.12",
         "vue": "^3.5.18",
@@ -6835,6 +6836,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-CnXGr0CcsMEY0S8NxV+4CSkiUbSSjMBDuNIQP5CKEM5Qn2ATqNnS/xP8Gr3HdWu3UwG+329xNXmLKcKD5WmZdw==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
     "konva": "^9.3.22",
+    "three": "^0.170.0",
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.12",
     "vue": "^3.5.18",

--- a/src/inventory-smart/__tests__/three_preview_serialization.spec.js
+++ b/src/inventory-smart/__tests__/three_preview_serialization.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore'
+
+describe('Serialización para visor 3D', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('incluye dimensiones, jerarquía y orientación necesarias', () => {
+    const canvas = useCanvasStore()
+
+    canvas.elementos.push({
+      id: 'root_el',
+      tipo: 'contenedores',
+      categoria: 'contenedores',
+      nombre: 'Contenedor Principal',
+      plantaId: 'planta_1',
+      orientacion: 90,
+      posicion: { x: 120, y: 340, z: 0, rotation: 0 },
+      alturaRespectoAlSuelo: 50,
+      dimensiones: { ancho: 200, largo: 100, alto: 300 },
+      hijos: ['child_el'],
+      padre: null,
+      visible: true,
+    })
+
+    canvas.elementos.push({
+      id: 'child_el',
+      tipo: 'elementos',
+      categoria: 'anaqueles',
+      nombre: 'Nivel Superior',
+      plantaId: 'planta_1',
+      orientacion: 0,
+      posicion: { x: 10, y: 20, z: 30 },
+      dimensiones: { ancho: 50, largo: 40, alto: 20 },
+      hijos: [],
+      padre: 'root_el',
+      visible: true,
+    })
+
+    const snapshot = canvas.serializeForThreePreview()
+
+    expect(snapshot).toBeTruthy()
+    expect(Array.isArray(snapshot.plantas)).toBe(true)
+    expect(Array.isArray(snapshot.elementos)).toBe(true)
+
+    const root = snapshot.elementos.find((el) => el.id === 'root_el')
+    const child = snapshot.elementos.find((el) => el.id === 'child_el')
+
+    expect(root).toBeTruthy()
+    expect(child).toBeTruthy()
+
+    expect(root.dimensiones).toMatchObject({ alto: 300, ancho: 200, largo: 100 })
+    expect(root.orientacion).toBe(90)
+    expect(root.hijos).toContain('child_el')
+
+    expect(child.padre).toBe('root_el')
+    expect(child.dimensiones).toMatchObject({ alto: 20, ancho: 50, largo: 40 })
+    expect(child.posicion).toMatchObject({ x: 10, y: 20 })
+  })
+})
+

--- a/src/inventory-smart/components/three/ThreeScene.vue
+++ b/src/inventory-smart/components/three/ThreeScene.vue
@@ -1,0 +1,199 @@
+<template>
+  <div ref="canvasWrapper" class="three-scene__wrapper">
+    <div v-if="!hasContent" class="three-scene__empty">
+      No hay datos para renderizar.
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { buildSceneGraphFromState } from '@/inventory-smart/utils/three/mapElementToMesh.js'
+
+const props = defineProps({
+  data: {
+    type: Object,
+    required: true,
+  },
+})
+
+const canvasWrapper = ref(null)
+const hasContent = ref(false)
+
+let renderer = null
+let scene = null
+let camera = null
+let controls = null
+let animationId = null
+let currentGraph = null
+
+const disposeGraph = () => {
+  if (currentGraph?.dispose) {
+    currentGraph.dispose()
+  }
+  if (currentGraph?.group && scene) {
+    scene.remove(currentGraph.group)
+  }
+  currentGraph = null
+  hasContent.value = false
+}
+
+const fitCameraToBounds = (bounds) => {
+  if (!bounds || bounds.isEmpty() || !camera || !controls) return
+
+  const size = new THREE.Vector3()
+  bounds.getSize(size)
+  const center = new THREE.Vector3()
+  bounds.getCenter(center)
+
+  const maxDim = Math.max(size.x, size.y, size.z)
+  const fitHeightDistance = maxDim / (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov / 2)))
+  const distance = fitHeightDistance * 1.5 + maxDim * 0.5
+
+  camera.position.set(center.x + distance, center.y + distance * 0.6, center.z + distance)
+  camera.near = Math.max(distance / 100, 0.1)
+  camera.far = Math.max(distance * 20, 500)
+  camera.lookAt(center)
+  camera.updateProjectionMatrix()
+
+  controls.target.copy(center)
+  controls.update()
+}
+
+const renderGraph = (data) => {
+  if (!scene) return
+  disposeGraph()
+  if (!data) return
+
+  const graph = buildSceneGraphFromState(data)
+  currentGraph = graph
+  if (graph?.group) {
+    scene.add(graph.group)
+    hasContent.value = true
+    if (graph.bounds) {
+      fitCameraToBounds(graph.bounds)
+    }
+  }
+}
+
+const handleResize = () => {
+  if (!canvasWrapper.value || !renderer || !camera) return
+  const { clientWidth, clientHeight } = canvasWrapper.value
+  renderer.setSize(clientWidth, clientHeight)
+  camera.aspect = clientWidth / Math.max(clientHeight, 1)
+  camera.updateProjectionMatrix()
+}
+
+const initScene = () => {
+  if (!canvasWrapper.value) return
+
+  scene = new THREE.Scene()
+  scene.background = new THREE.Color('#020617')
+
+  const { clientWidth, clientHeight } = canvasWrapper.value
+  camera = new THREE.PerspectiveCamera(60, clientWidth / Math.max(clientHeight, 1), 0.1, 2000)
+  camera.position.set(10, 10, 10)
+
+  renderer = new THREE.WebGLRenderer({ antialias: true })
+  renderer.shadowMap.enabled = true
+  renderer.setSize(clientWidth, clientHeight)
+  renderer.setPixelRatio(window.devicePixelRatio || 1)
+  canvasWrapper.value.appendChild(renderer.domElement)
+  handleResize()
+
+  controls = new OrbitControls(camera, renderer.domElement)
+  controls.enableDamping = true
+  controls.dampingFactor = 0.05
+  controls.target.set(0, 0, 0)
+
+  const ambientLight = new THREE.AmbientLight(0xffffff, 0.6)
+  scene.add(ambientLight)
+
+  const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8)
+  directionalLight.position.set(10, 20, 10)
+  directionalLight.castShadow = true
+  scene.add(directionalLight)
+
+  const gridHelper = new THREE.GridHelper(50, 50, 0x1d4ed8, 0x1e293b)
+  scene.add(gridHelper)
+
+  const axesHelper = new THREE.AxesHelper(2)
+  scene.add(axesHelper)
+
+  const animate = () => {
+    animationId = requestAnimationFrame(animate)
+    controls.update()
+    renderer.render(scene, camera)
+  }
+
+  animate()
+
+  window.addEventListener('resize', handleResize)
+}
+
+onMounted(() => {
+  initScene()
+  renderGraph(props.data)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', handleResize)
+  disposeGraph()
+  if (animationId) {
+    cancelAnimationFrame(animationId)
+  }
+  if (controls) {
+    controls.dispose()
+    controls = null
+  }
+  if (renderer) {
+    renderer.dispose()
+    if (renderer.domElement?.parentNode) {
+      renderer.domElement.parentNode.removeChild(renderer.domElement)
+    }
+    renderer = null
+  }
+  scene = null
+  camera = null
+})
+
+watch(
+  () => props.data,
+  (newData) => {
+    renderGraph(newData)
+  },
+  { deep: true }
+)
+</script>
+
+<style scoped>
+.three-scene__wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(circle at top, rgba(30, 41, 59, 0.9), #020617);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.three-scene__wrapper canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.three-scene__empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #e2e8f0;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+</style>
+

--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -1327,17 +1327,22 @@ export const useCanvasStore = defineStore('canvas', () => {
 
   // === FUNCIONES DE SERIALIZACIÓN ===
 
+  const buildSerializableState = () => ({
+    plantas: plantas.value.map(p => p?._custom?.value || p),
+    elementos: elementos.value.map(e => e?._custom?.value || e),
+    catalogos: catalogos.value,
+  })
+
   /**
    * Serializa el estado completo del canvas a JSON
    * @returns {string} JSON string con todo el estado
    */
   const serialize = (saveTimestamp = false) => {
+    const baseState = buildSerializableState()
     const state = {
-      plantas: plantas.value.map(p => p?._custom?.value || p),
-      elementos: elementos.value.map(e => e?._custom?.value || e),
+      ...baseState,
       templates: catalogStore.templates?.map?.(t => t?._custom?.value || t) || [],
       catalogItems: catalogStore.items?.map?.(i => i?._custom?.value || i) || [],
-      catalogos: catalogos.value,
     }
     // Incluir historial de cambios si existe
     try {
@@ -1370,6 +1375,42 @@ export const useCanvasStore = defineStore('canvas', () => {
     } catch (e) {
       console.warn('No se pudo post-procesar JSON para plantillas', e)
       return jsonStr
+    }
+  }
+
+  /**
+   * Serializa el estado para el visor 3D sin métricas ni historial
+   * @param {Object} options
+   * @param {boolean} [options.includeMetrics=false]
+   * @param {boolean} [options.includeChangeHistory=false]
+   * @returns {Object|null} Snapshot serializado listo para usar en la escena 3D
+   */
+  const serializeForThreePreview = (options = {}) => {
+    const {
+      includeMetrics = false,
+      includeChangeHistory = false,
+      validateBeforeSerialize = true,
+    } = options
+
+    const state = buildSerializableState()
+
+    try {
+      const jsonStr = _serialize(state, {
+        validateBeforeSerialize,
+        includeMetrics,
+        includeChangeHistory,
+      })
+      const parsed = JSON.parse(jsonStr)
+      if (!includeMetrics && parsed?.meta) {
+        delete parsed.meta.metrics
+      }
+      if (!includeChangeHistory) {
+        delete parsed.changeHistory
+      }
+      return parsed
+    } catch (error) {
+      console.warn('No se pudo serializar el estado para visor 3D', error)
+      return null
     }
   }
 
@@ -2078,6 +2119,7 @@ export const useCanvasStore = defineStore('canvas', () => {
 
     // === FUNCIONES DE SERIALIZACIÓN ===
     serialize,
+    serializeForThreePreview,
     deserialize,
 
     // == Editor de planta

--- a/src/inventory-smart/utils/three/mapElementToMesh.js
+++ b/src/inventory-smart/utils/three/mapElementToMesh.js
@@ -1,0 +1,145 @@
+import * as THREE from 'three'
+
+const CM_TO_M = 0.01
+
+const TYPE_COLOR_MAP = {
+  plantas: '#1f2937',
+  pisos: '#0ea5e9',
+  cuartos: '#10b981',
+  contenedores: '#f59e0b',
+  elementos: '#6366f1',
+}
+
+const DEFAULT_ELEMENT_COLOR = '#94a3b8'
+const FLOOR_THICKNESS = 0.1
+
+const disposeObject = (object) => {
+  object.traverse((child) => {
+    if (child.isMesh) {
+      child.geometry?.dispose?.()
+      if (Array.isArray(child.material)) {
+        child.material.forEach((material) => material?.dispose?.())
+      } else {
+        child.material?.dispose?.()
+      }
+    }
+  })
+}
+
+const createFloorMesh = (planta) => {
+  const ancho = Math.max(1, planta?.dimensiones?.ancho || 1000) * CM_TO_M
+  const largo = Math.max(1, planta?.dimensiones?.largo || 1000) * CM_TO_M
+  const geometry = new THREE.BoxGeometry(ancho, FLOOR_THICKNESS, largo)
+  const material = new THREE.MeshStandardMaterial({ color: TYPE_COLOR_MAP.plantas, transparent: true, opacity: 0.6 })
+  const floor = new THREE.Mesh(geometry, material)
+  floor.receiveShadow = true
+  floor.position.y = FLOOR_THICKNESS / 2
+  floor.name = `planta:${planta?.id || 'sin-id'}`
+  return floor
+}
+
+const resolveColor = (elemento) => {
+  const tipo = (elemento?.tipo || '').toLowerCase()
+  const categoria = (elemento?.categoria || '').toLowerCase()
+  return TYPE_COLOR_MAP[tipo] || TYPE_COLOR_MAP[categoria] || elemento?.color || DEFAULT_ELEMENT_COLOR
+}
+
+export const mapElementToMesh = (elemento) => {
+  const ancho = Math.max(1, elemento?.dimensiones?.ancho || 10) * CM_TO_M
+  const alto = Math.max(1, elemento?.dimensiones?.alto || 10) * CM_TO_M
+  const largo = Math.max(1, elemento?.dimensiones?.largo || 10) * CM_TO_M
+
+  const geometry = new THREE.BoxGeometry(ancho, alto, largo)
+  const material = new THREE.MeshStandardMaterial({
+    color: resolveColor(elemento),
+    transparent: true,
+    opacity: elemento?.visible === false ? 0.35 : 0.9,
+  })
+
+  const mesh = new THREE.Mesh(geometry, material)
+  mesh.castShadow = true
+  mesh.receiveShadow = true
+
+  const group = new THREE.Group()
+  group.name = elemento?.nombre || elemento?.id || 'elemento'
+  group.userData = { id: elemento?.id, tipo: elemento?.tipo }
+  group.add(mesh)
+
+  const posicion = elemento?.posicion || {}
+  const rotationDeg = Number.isFinite(elemento?.orientacion)
+    ? elemento.orientacion
+    : Number.isFinite(posicion.rotation)
+      ? posicion.rotation
+      : 0
+
+  const altura = Number.isFinite(elemento?.alturaRespectoAlSuelo) ? elemento.alturaRespectoAlSuelo : 0
+  const offsetZ = Number.isFinite(posicion.z) ? posicion.z : 0
+
+  group.position.set(
+    (Number.isFinite(posicion.x) ? posicion.x : 0) * CM_TO_M,
+    (altura + offsetZ) * CM_TO_M + alto / 2,
+    (Number.isFinite(posicion.y) ? posicion.y : 0) * CM_TO_M,
+  )
+
+  group.rotation.y = THREE.MathUtils.degToRad(rotationDeg)
+
+  return {
+    group,
+    dispose: () => disposeObject(group),
+  }
+}
+
+export const buildSceneGraphFromState = (state) => {
+  const root = new THREE.Group()
+  root.name = 'inventory-scene-root'
+
+  const elementos = Array.isArray(state?.elementos) ? state.elementos : []
+  const plantas = Array.isArray(state?.plantas) ? state.plantas : []
+
+  const elementosPorId = new Map()
+  elementos.forEach((el) => {
+    if (el?.id) elementosPorId.set(el.id, el)
+  })
+
+  const attachChildren = (elementoId, parentGroup) => {
+    const elemento = elementosPorId.get(elementoId)
+    if (!elemento) return
+
+    const { group } = mapElementToMesh(elemento)
+    parentGroup.add(group)
+
+    const hijos = Array.isArray(elemento?.hijos) ? elemento.hijos : []
+    hijos.forEach((childId) => attachChildren(childId, group))
+  }
+
+  plantas.forEach((planta) => {
+    const plantaGroup = new THREE.Group()
+    plantaGroup.name = planta?.nombre || planta?.id || 'planta'
+    plantaGroup.userData = { id: planta?.id, tipo: 'planta' }
+
+    const floor = createFloorMesh(planta)
+    plantaGroup.add(floor)
+
+    const rootElements = elementos.filter((elemento) => {
+      const mismoNivel = elemento?.plantaId === planta?.id
+      const sinPadre = !elemento?.padre
+      return mismoNivel && sinPadre
+    })
+
+    rootElements.forEach((elemento) => {
+      if (!elemento?.id) return
+      attachChildren(elemento.id, plantaGroup)
+    })
+
+    root.add(plantaGroup)
+  })
+
+  const bounds = new THREE.Box3().setFromObject(root)
+
+  return {
+    group: root,
+    bounds,
+    dispose: () => disposeObject(root),
+  }
+}
+

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -1,5 +1,8 @@
 <template>
   <div id="app">
+    <nav class="three-entry">
+      <RouterLink class="three-entry__link" to="/three-preview">Abrir visor 3D</RouterLink>
+    </nav>
     <InventorySmart
       :configCanvas="initialConfig"
       :externalServices="externalServices"
@@ -113,4 +116,29 @@ onMounted(() => {
 })
 </script>
 
-<style scoped></style>
+<style scoped>
+.three-entry {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.three-entry__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #2563eb, #22d3ee);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.three-entry__link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 40px rgba(45, 212, 191, 0.3);
+}
+</style>

--- a/src/pages/ThreePreviewPage.vue
+++ b/src/pages/ThreePreviewPage.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="three-preview">
+    <header class="three-preview__header">
+      <div>
+        <h1>Visor 3D de Inventario</h1>
+        <p>Explora la jerarquía actual del canvas en un entorno tridimensional.</p>
+      </div>
+      <div class="three-preview__actions">
+        <button type="button" class="three-preview__button" @click="loadScene" :disabled="isLoading">
+          {{ isLoading ? 'Cargando…' : 'Recargar datos' }}
+        </button>
+      </div>
+    </header>
+
+    <section class="three-preview__content">
+      <div v-if="error" class="three-preview__error">
+        <p>{{ error }}</p>
+        <button type="button" class="three-preview__button" @click="loadScene">Reintentar</button>
+      </div>
+      <div v-else class="three-preview__scene">
+        <ThreeScene v-if="sceneData" :data="sceneData" />
+        <div v-else class="three-preview__placeholder">
+          <span v-if="isLoading">Preparando datos…</span>
+          <span v-else>No se encontró información para renderizar.</span>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import ThreeScene from '@/inventory-smart/components/three/ThreeScene.vue'
+import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore'
+
+const canvasStore = useCanvasStore()
+
+const sceneData = ref(null)
+const isLoading = ref(false)
+const error = ref('')
+
+const loadScene = async () => {
+  try {
+    isLoading.value = true
+    error.value = ''
+    const serialized = await canvasStore.serializeForThreePreview({ validateBeforeSerialize: false })
+    if (!serialized) {
+      sceneData.value = null
+      error.value = 'No fue posible obtener el estado del canvas.'
+    } else {
+      sceneData.value = serialized
+    }
+  } catch (err) {
+    console.error(err)
+    error.value = 'Ocurrió un error al preparar el visor 3D.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(() => {
+  loadScene()
+})
+</script>
+
+<style scoped>
+.three-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.three-preview__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.three-preview__header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+  color: #0f172a;
+}
+
+.three-preview__header p {
+  margin: 0.25rem 0 0;
+  color: #475569;
+  max-width: 42rem;
+}
+
+.three-preview__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.three-preview__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+}
+
+.three-preview__button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.three-preview__button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.25);
+}
+
+.three-preview__content {
+  flex: 1;
+  min-height: 400px;
+  background: #0f172a;
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+  display: flex;
+}
+
+.three-preview__scene {
+  flex: 1;
+  display: flex;
+}
+
+.three-preview__placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #cbd5f5;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.three-preview__error {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+  color: #fecaca;
+}
+
+.three-preview__error p {
+  margin: 0;
+}
+</style>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,11 @@ const router = createRouter({
       name: 'Inicio',
       component: () => import('@/pages/HomePage.vue')
     },
+    {
+      path: '/three-preview',
+      name: 'ThreePreview',
+      component: () => import('@/pages/ThreePreviewPage.vue')
+    },
   ],
 })
 


### PR DESCRIPTION
## Summary
- add a serializeForThreePreview action in the canvas store and document the 3D snapshot coverage
- introduce the /three-preview route with ThreePreviewPage, ThreeScene, and mesh mapping helpers powered by three.js
- add documentation, navigation entry, and a regression test covering orientation, dimensions, and hierarchy in the export

## Testing
- npm run test:unit *(fails: existing suite reports multiple legacy expectation mismatches before the new three_preview_serialization spec runs)*

------
https://chatgpt.com/codex/tasks/task_e_68d708697f388321a28ab290a7fe90c8