### PR TITLE
Add global editing mode controls and view-only gating

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -6,6 +6,10 @@
     <!-- Navegación jerárquica -->
     <NavegacionJerarquica />
 
+    <div class="app-mode-toggle">
+      <ModoEdicionToggle />
+    </div>
+
     <main class="app-main relative">
       <!-- Sidebar con tabs -->
       <div class="app-sidebar-left">
@@ -55,7 +59,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, computed, watch, provide } from 'vue'
+import { ref, computed, watch, provide } from 'vue'
 import SidebarPanel from './components/SidebarPanel.vue'
 import CanvasView from './components/CanvasView.vue'
 import PlantasPanel from './components/PlantasPanel.vue'
@@ -76,6 +80,8 @@ import { AUTOSAVE_CONFIG } from '@/inventory-smart/utils/constants'
 import ConfirmReplaceModal from '@/inventory-smart/components/modals/ConfirmReplaceModal.vue'
 import { useServicesStore } from './stores/services.js'
 import { useStatePersistence } from './composables/useStatePersistence'
+import { useEditingShortcuts } from './composables/useEditingShortcuts'
+import ModoEdicionToggle from './components/ModoEdicionToggle.vue'
 
 const props = defineProps({
   configCanvas: {
@@ -149,6 +155,8 @@ const externalServicesAPI = {
   isServiceLoading: servicesStore.isServiceLoading,
   getServiceError: servicesStore.getServiceError
 }
+
+provide('externalServicesAPI', externalServicesAPI)
 
 const canvasViewRef = ref(null)
 
@@ -228,48 +236,6 @@ const handleConfigChanged = (configSerializada) => {
   }
 }
 
-// Atajos de teclado globales
-const handleKeydown = (e) => {
-  // Solo procesar si no estamos en un input
-  if (e.target.matches('input, textarea, select, [contenteditable]')) {
-    return
-  }
-
-  // Bloquear si hay texto seleccionado
-  if (window.getSelection().toString()) {
-    return
-  }
-
-  // Bloquear si hay drag global activo
-  if (typeof window !== 'undefined' && window.__dvCanvasDragActive) {
-    return
-  }
-
-  if (e.ctrlKey || e.metaKey) {
-    if (e.key === 'z' && !e.shiftKey) {
-      e.preventDefault()
-      undo()
-    } else if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
-      e.preventDefault()
-      redo()
-    } else if (e.key === 'c') {
-      e.preventDefault()
-      handleCopyToBuffer()
-    } else if (e.key === 'v') {
-      e.preventDefault()
-      triggerPaste()
-    }
-  } else if (e.key === 'Delete' || e.key === 'Backspace') {
-    // Supr o Retroceso -> eliminar seleccionado
-    const hasSelection = !!canvasStore.elementoSeleccionado
-    if (hasSelection) {
-      e.preventDefault()
-      // No es necesario await; el modal gestiona la interacción
-      deleteSelected({ withConfirm: true })
-    }
-  }
-}
-
 // Handlers para buffer
 const handleCopyToBuffer = () => {
   const elementoSeleccionado = canvasStore.elementoSeleccionado
@@ -277,6 +243,15 @@ const handleCopyToBuffer = () => {
     buffer.copyToBuffer(elementoSeleccionado)
   }
 }
+
+useEditingShortcuts({
+  onUndo: undo,
+  onRedo: redo,
+  onCopy: handleCopyToBuffer,
+  onPaste: triggerPaste,
+  onDelete: () => deleteSelected({ withConfirm: true }),
+  hasSelection: () => Boolean(canvasStore.elementoSeleccionado),
+})
 
 const triggerPaste = () => {
   try {
@@ -386,23 +361,6 @@ const fmtDate = (iso) => {
   }
 }
 
-onMounted(() => {
-  try {
-    window.addEventListener('keydown', handleKeydown)
-
-    // Provide de la API de servicios externos para componentes hijos
-    provide('externalServicesAPI', externalServicesAPI)
-  } catch (error) {
-    window.removeEventListener('keydown', handleKeydown)
-    showToast('Ha ocurrido un error al importar la configuración', 'error')
-    console.error('Error al importar la configuración:', error)
-  }
-})
-
-onUnmounted(() => {
-  window.removeEventListener('keydown', handleKeydown)
-})
-
 watch(
   () => props.configCanvas,
   async (newConfig, oldConfig) => {
@@ -473,6 +431,14 @@ watch(
 
 <style>
 @import 'tailwindcss';
+
+/* Cambios recientes */
+.app-mode-toggle {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.75rem 1.5rem;
+  gap: 0.75rem;
+}
 
 /* Ignorar warning de unknown at rule */
 @theme {

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -688,6 +688,7 @@ import { useZoom } from '@/inventory-smart/composables/useZoom'
 import FloatingControls from '@/inventory-smart/components/FloatingControls.vue'
 import { toPrecisionCm } from '../utils/fixedDimensions'
 import { instantiateStructureOnCanvas } from '@/inventory-smart/composables/useStructureManager'
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
 
 // Espacio seguro a la derecha para no quedar debajo del panel
 const props = defineProps({
@@ -722,6 +723,7 @@ const {
   isLocked: ctxIsLocked,
   elementId: ctxElementId,
 } = ctx
+const { editingCapabilities } = useEditingCapabilities()
 const { deleteSelected } = useDeleteElement()
 const weightValidation = useWeightValidation()
 
@@ -2135,9 +2137,21 @@ const createElementFromTemplate = (data, dropEvent) => {
   instantiateStructureOnCanvas(canvasStore, payload, res.position)
 }
 
-// Modo arrastre global: si true, permite arrastrar cualquier elemento (salvo si está bloqueado)
-// Por defecto activado (true) para que el modo edición esté disponible al iniciar
-const dragModeGlobal = ref(true)
+// Modo arrastre global: sincronizado con el modo de edición global
+const dragModeGlobal = ref(editingCapabilities.value.canDragElements)
+
+watch(
+  () => editingCapabilities.value.canDragElements,
+  (enabled) => {
+    dragModeGlobal.value = enabled
+    if (!enabled) {
+      stageDragEnabled.value = true
+      editingElementId.value = null
+      clearGuides()
+    }
+  },
+  { immediate: true },
+)
 
 const isDragModeActive = computed(() => dragModeGlobal.value)
 
@@ -2163,6 +2177,7 @@ const toggleLockAndPreserveDrag = async (elementId) => {
   }
 }
 const toggleDragMode = () => {
+  if (!editingCapabilities.value.canDragElements) return
   // Alterna el modo arrastre global. Cuando se activa y hay un elemento seleccionado y no bloqueado,
   // se activa también la edición (transformer) para permitir cambiar dimensiones.
   dragModeGlobal.value = !dragModeGlobal.value
@@ -2186,6 +2201,7 @@ const toggleSnapping = () => {
 }
 
 const canDragElement = (elemento) => {
+  if (!editingCapabilities.value.canDragElements) return false
   // Solo permitir drag si el modo global está activo y el elemento no está bloqueado
   // Y si no hay cambios sin aplicar de otro elemento
   const isNotCurrentElement = canvasStore.elementoSeleccionado != elemento.id

--- a/src/inventory-smart/components/ContextMenu.vue
+++ b/src/inventory-smart/components/ContextMenu.vue
@@ -3,9 +3,9 @@
     <button
       class="ctx-item text-red-600 hover:bg-red-50"
       @click="onDelete"
-      :disabled="locked"
-      :aria-label="locked ? 'Elemento bloqueado — desbloquéalo para eliminar' : 'Eliminar (Supr)'"
-      :title="locked ? 'Elemento bloqueado — desbloquéalo para eliminar' : 'Eliminar (Supr)'"
+      :disabled="locked || viewOnly"
+      :aria-label="ariaLabel"
+      :title="tooltip"
     >
       Eliminar
     </button>
@@ -16,6 +16,7 @@
 import { computed } from 'vue'
 import { useDeleteElement } from '@/inventory-smart/composables/useDeleteElement'
 import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore'
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
 
 defineProps({
   visible: { type: Boolean, default: false },
@@ -26,14 +27,25 @@ defineProps({
 const emit = defineEmits(['close'])
 const { deleteSelected } = useDeleteElement()
 const store = useCanvasStore()
+const { editingCapabilities, viewOnlyTooltip } = useEditingCapabilities()
 
 const locked = computed(() => {
   const el = store.elementoSeleccionadoCompleto
   return !!(el && (el.bloqueado === true || el.locked === true))
 })
 
+const viewOnly = computed(() => editingCapabilities.value.isViewOnly)
+
+const ariaLabel = computed(() => {
+  if (locked.value) return 'Elemento bloqueado — desbloquéalo para eliminar'
+  if (viewOnly.value) return viewOnlyTooltip.value
+  return 'Eliminar (Supr)'
+})
+
+const tooltip = ariaLabel
+
 const onDelete = () => {
-  if (locked.value) return
+  if (locked.value || viewOnly.value) return
   deleteSelected({ withConfirm: true })
   emit('close')
 }

--- a/src/inventory-smart/components/ElementosCatalogo.vue
+++ b/src/inventory-smart/components/ElementosCatalogo.vue
@@ -101,14 +101,20 @@
     <div class="pb-2 flex justify-center">
       <UiTooltip
         :label="
-          'Crea y guarda un nuevo ' + (modo === 'cuarto' ? 'cuarto' : 'espacio') + ' en el catálogo'
+          isViewOnly
+            ? viewOnlyTooltip
+            : 'Crea y guarda un nuevo ' + (modo === 'cuarto' ? 'cuarto' : 'espacio') + ' en el catálogo'
         "
         position="bottom"
         :delay="500"
       >
         <button
-          @click="mostrarModalAgregarEspacio = true"
-          class="flex justify-center items-center flex-row px-2 py-1 cursor-pointer bg-primary hover:bg-primary-600 text-white rounded-xl text-xs"
+          @click="openCreateModal"
+          :disabled="isViewOnly"
+          :class="[
+            'flex justify-center items-center flex-row px-2 py-1 bg-primary text-white rounded-xl text-xs transition',
+            isViewOnly ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-primary-600'
+          ]"
         >
           <!-- icono de + -->
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -300,6 +306,7 @@ import SpaceOnWallIcon from '@/inventory-smart/icons/SpaceOnWallIcon.vue'
 import RoomIcon from '@/inventory-smart/icons/RoomIcon.vue'
 import { useToast } from '@/inventory-smart/composables/useToast'
 import { useConfirmDialog } from '@/inventory-smart/composables/useConfirmDialog'
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
 
 // Props
 const props = defineProps({
@@ -318,6 +325,16 @@ const catalogStore = useCatalogStore()
 const { filteredCatalogItems, catalogContext, searchText, selectedCategory, items } =
   storeToRefs(catalogStore)
 const confirmDialog = useConfirmDialog()
+const { editingCapabilities, viewOnlyTooltip } = useEditingCapabilities()
+const isViewOnly = computed(() => editingCapabilities.value.isViewOnly)
+
+const assertEditable = () => {
+  if (isViewOnly.value) {
+    showToast(viewOnlyTooltip.value, 'info')
+    return false
+  }
+  return true
+}
 
 // Estado local
 const filtroTexto = searchText
@@ -357,6 +374,11 @@ const mostrarModalAgregarEspacio = ref(false)
 const editingItem = ref(null) // item que se edita
 const editingForm = ref(null) // formulario derivado del item
 const kebabMenu = ref({ visible: false, x: 0, y: 0, item: null })
+
+const openCreateModal = () => {
+  if (!assertEditable()) return
+  mostrarModalAgregarEspacio.value = true
+}
 
 // Formulario para nuevo elemento
 const nuevoElemento = ref({
@@ -454,6 +476,10 @@ watch(hayElementosEnTab, (val) => {
 })
 
 const onGuardarEspacio = (datosEspacio) => {
+  if (!assertEditable()) {
+    mostrarModalAgregarEspacio.value = false
+    return
+  }
   try {
     if (editingItem.value) {
       // Editar existente
@@ -643,6 +669,7 @@ watch(
 // --- Lógica del menú kebab y edición/eliminación ---
 const toggleKebab = (evt, item) => {
   evt.preventDefault()
+  if (!assertEditable()) return
   if (isKebabRestricted(item)) return
   const isSame = kebabMenu.value.visible && kebabMenu.value.item?.id === item.id
   kebabMenu.value = isSame
@@ -655,6 +682,7 @@ const closeKebab = () => {
 }
 
 const startEdit = (item) => {
+  if (!assertEditable()) return closeKebab()
   if (!item) return closeKebab()
   const form = toFormFromCatalogItem(item)
   if (!form) return closeKebab()
@@ -671,6 +699,7 @@ const cancelEdit = () => {
 }
 
 const handleDeleteItem = async (item) => {
+  if (!assertEditable()) return closeKebab()
   if (!item) return closeKebab()
   const ok = await confirmDialog.confirm({
     title: 'Eliminar elemento',

--- a/src/inventory-smart/components/ModoEdicionToggle.vue
+++ b/src/inventory-smart/components/ModoEdicionToggle.vue
@@ -1,0 +1,22 @@
+<template>
+  <button
+    type="button"
+    class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+    @click="toggle"
+  >
+    <span v-if="editingCapabilities.isEditing">Finalizar</span>
+    <span v-else>Editar configuración</span>
+  </button>
+</template>
+
+<script setup>
+import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore'
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
+
+const canvasStore = useCanvasStore()
+const { editingCapabilities } = useEditingCapabilities()
+
+const toggle = () => {
+  canvasStore.setModoEdicion(!editingCapabilities.value.isEditing)
+}
+</script>

--- a/src/inventory-smart/components/PropiedadesPanel.vue
+++ b/src/inventory-smart/components/PropiedadesPanel.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="h-full flex flex-col bg-white border-l border-gray-200" data-properties-panel>
+  <div
+    ref="panelRef"
+    class="h-full flex flex-col bg-white border-l border-gray-200"
+    data-properties-panel
+  >
     <div class="p-4 border-b border-gray-200 flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-800">Propiedades</h2>
     </div>
@@ -514,6 +518,7 @@ import { useCatalogStore } from '@/inventory-smart/stores/catalog'
 import { toPrecisionCm } from '../utils/fixedDimensions'
 import IdentifyEslModal from './modals/IdentifyEslModal.vue'
 import { useDeleteElement } from '@/inventory-smart/composables/useDeleteElement';
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
 
 const canvasStore = useCanvasStore()
 const { showWarning, showSuccess } = useToast()
@@ -528,6 +533,10 @@ const {
 const { validarDimensiones } = useDimensionValidation()
 
 const catalogStore = useCatalogStore()
+const { editingCapabilities, viewOnlyTooltip } = useEditingCapabilities()
+
+const panelRef = ref(null)
+const isViewOnly = computed(() => editingCapabilities.value.isViewOnly)
 
 const elementoSeleccionado = computed(() => canvasStore.elementoSeleccionadoCompleto)
 
@@ -1463,6 +1472,7 @@ const guardarCodigoEsl = (payload) => {
 }
 
 const onKeydown = (e) => {
+  if (isViewOnly.value) return
   if ((e.ctrlKey || e.metaKey) && e.key === 's') {
     e.preventDefault()
     if (isDirty.value && !guardarDeshabilitado.value) {
@@ -1476,6 +1486,58 @@ const isElementRestricted = computed(() => {
    const restrictions = TIPOS_ENTIDAD.find(t => t.id === type)?.restrictions || [];
    return restrictions.includes('read-only-properties');
 })
+
+const syncViewModeControls = (viewOnly) => {
+  nextTick(() => {
+    const root = panelRef.value
+    if (!root) return
+    const controls = root.querySelectorAll('input, select, textarea, button')
+    controls.forEach((control) => {
+      if (viewOnly) {
+        if (!control.dataset.originalDisabled) {
+          control.dataset.originalDisabled = control.disabled ? 'true' : 'false'
+        }
+        if (!control.dataset.originalTitle) {
+          control.dataset.originalTitle = control.getAttribute('title') || ''
+        }
+        control.disabled = true
+        control.setAttribute('title', viewOnlyTooltip.value)
+      } else {
+        const prevDisabled = control.dataset.originalDisabled
+        if (prevDisabled === 'false') {
+          control.disabled = false
+        }
+        if (prevDisabled) delete control.dataset.originalDisabled
+
+        const prevTitle = control.dataset.originalTitle
+        if (typeof prevTitle === 'string') {
+          if (prevTitle) {
+            control.setAttribute('title', prevTitle)
+          } else {
+            control.removeAttribute('title')
+          }
+          delete control.dataset.originalTitle
+        }
+      }
+    })
+  })
+}
+
+watch(
+  () => isViewOnly.value,
+  (value) => {
+    syncViewModeControls(value)
+  },
+  { immediate: true, flush: 'post' },
+)
+
+watch(
+  () => canvasStore.elementoSeleccionado,
+  () => {
+    syncViewModeControls(isViewOnly.value)
+  },
+  { flush: 'post' },
+)
 
 onMounted(() => {
   window.addEventListener('keydown', onKeydown)

--- a/src/inventory-smart/components/tabs/CapasTab.vue
+++ b/src/inventory-smart/components/tabs/CapasTab.vue
@@ -193,11 +193,21 @@
             </UiTooltip>
             <UiTooltip
               position="left"
-              :label="elemento.visible === false ? 'Mostrar' : 'Ocultar'"
+              :label="
+                isViewOnly
+                  ? viewOnlyTooltip
+                  : elemento.visible === false
+                    ? 'Mostrar'
+                    : 'Ocultar'
+              "
             >
             <button
-              @click.stop="canvasStore.toggleElementoVisibilidad(elemento.id)"
-              class="p-0 text-gray-400 hover:text-gray-600 cursor-pointer"
+              @click.stop="toggleVisibility(elemento.id)"
+              :disabled="isViewOnly"
+              :class="[
+                'p-0 text-gray-400 transition',
+                isViewOnly ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:text-gray-600'
+              ]"
             >
               <svg
                 v-if="elemento.visible !== false"
@@ -247,11 +257,15 @@
             </UiTooltip>
             <UiTooltip
               position="left"
-              label="Eliminar elemento"
+              :label="isViewOnly ? viewOnlyTooltip : 'Eliminar elemento'"
             >
             <button
               @click.stop="onDelete(elemento.id)"
-              class="p-0 text-gray-400 hover:text-red-700 cursor-pointer"
+              :disabled="isViewOnly"
+              :class="[
+                'p-0 text-gray-400 transition',
+                isViewOnly ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:text-red-700'
+              ]"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 1024 1024"><path fill="currentColor" d="M360 184h-8c4.4 0 8-3.6 8-8zh304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32M731.3 840H292.7l-24.2-512h487z"/></svg>
             </button>
@@ -285,12 +299,23 @@ import { useToast } from '@/inventory-smart/composables/useToast'
 import SpaceIcon from '@/inventory-smart/icons/SpaceIcon.vue'
 import SpaceOnWallIcon from '@/inventory-smart/icons/SpaceOnWallIcon.vue'
 import RoomIcon from '@/inventory-smart/icons/RoomIcon.vue'
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
 const { showToast } = useToast()
 // Composables
 const canvasStore = useCanvasStore()
 
 const deleteElement = useDeleteElement();
 const confirmDialog = useConfirmDialog();
+const { editingCapabilities, viewOnlyTooltip } = useEditingCapabilities()
+const isViewOnly = computed(() => editingCapabilities.value.isViewOnly)
+
+const assertEditable = () => {
+  if (isViewOnly.value) {
+    showToast(viewOnlyTooltip.value, 'info')
+    return false
+  }
+  return true
+}
 
 // Estado local
 const filtroCategoria = ref('')
@@ -393,7 +418,13 @@ const limpiarFiltros = () => {
   canvasStore.limpiarSeleccion()
 }
 
+const toggleVisibility = (id) => {
+  if (!assertEditable()) return
+  canvasStore.toggleElementoVisibilidad(id)
+}
+
 const onDelete = async (id) => {
+  if (!assertEditable()) return
   if (!id) return
   if (canvasStore.cambiosNoAplicados) {
     showToast('No se pueden eliminar elementos con cambios pendientes de guardar', 'warn')
@@ -416,11 +447,13 @@ const onDelete = async (id) => {
 }
 
 const abrirModalCrearEtiqueta = (texto) => {
+  if (!assertEditable()) return
   textoNuevaEtiqueta.value = texto
   modalVisible.value = true
 }
 
 const guardarNuevaEtiqueta = (nuevaEtiqueta) => {
+  if (!assertEditable()) return
   canvasStore.agregarYSeleccionarEtiqueta(nuevaEtiqueta)
   modalVisible.value = false;
 }

--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -48,6 +48,25 @@ export const useCanvasStore = defineStore('canvas', () => {
   const historyInstance = ref(null)
 
   // Estado de plantas
+  const modoEdicion = ref(false)
+
+  const editingCapabilities = computed(() => {
+    const isEditing = modoEdicion.value === true
+    return {
+      isEditing,
+      isViewOnly: !isEditing,
+      canEditCanvas: isEditing,
+      canTransformElements: isEditing,
+      canDragElements: isEditing,
+      canEditProperties: isEditing,
+      canUseShortcuts: isEditing,
+      canPersistChanges: isEditing,
+      canUseContextMenus: isEditing,
+      canModifyCatalog: isEditing,
+      canManageLayers: isEditing,
+    }
+  })
+
   const plantas = ref([
     {
       id: 'planta_1',
@@ -1370,6 +1389,7 @@ export const useCanvasStore = defineStore('canvas', () => {
       templates: catalogStore.templates?.map?.(t => t?._custom?.value || t) || [],
       catalogItems: catalogStore.items?.map?.(i => i?._custom?.value || i) || [],
       catalogos: catalogos.value,
+      modoEdicion: modoEdicion.value === true,
     }
     // Incluir historial de cambios si existe
     try {
@@ -1449,7 +1469,10 @@ export const useCanvasStore = defineStore('canvas', () => {
         panY.value = 0
 
         // Canvas adaptativo se recalculará automáticamente por el watcher
-      }
+      },
+      setModoEdicion: (valor) => {
+        modoEdicion.value = valor === true
+      },
     }
 
   const ok = _deserialize(jsonString, storeActions)
@@ -2232,6 +2255,14 @@ export const useCanvasStore = defineStore('canvas', () => {
     // === FUNCIONES DE SERIALIZACIÓN ===
     serialize,
     deserialize,
+    modoEdicion,
+    editingCapabilities,
+    setModoEdicion: (valor) => {
+      modoEdicion.value = valor === true
+    },
+    toggleModoEdicion: () => {
+      modoEdicion.value = !modoEdicion.value
+    },
 
     // == Editor de planta
     abrirEditor,

--- a/src/inventory-smart/composables/useEditingCapabilities.js
+++ b/src/inventory-smart/composables/useEditingCapabilities.js
@@ -1,0 +1,31 @@
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useCanvasStore } from './useCanvasStore'
+
+const VIEW_ONLY_TOOLTIP = 'No disponible en modo visualización'
+
+export const useEditingCapabilities = () => {
+  const canvasStore = useCanvasStore()
+  const { modoEdicion, editingCapabilities } = storeToRefs(canvasStore)
+
+  const tooltip = computed(() =>
+    editingCapabilities.value.isViewOnly ? VIEW_ONLY_TOOLTIP : '',
+  )
+
+  const buildDisabledProps = (forcedDisabled = false) => {
+    const shouldDisable = Boolean(forcedDisabled) || editingCapabilities.value.isViewOnly
+    return {
+      disabled: shouldDisable,
+      title: shouldDisable && editingCapabilities.value.isViewOnly ? tooltip.value : undefined,
+    }
+  }
+
+  return {
+    modoEdicion,
+    editingCapabilities,
+    viewOnlyTooltip: tooltip,
+    buildDisabledProps,
+  }
+}
+
+export default useEditingCapabilities

--- a/src/inventory-smart/composables/useEditingShortcuts.js
+++ b/src/inventory-smart/composables/useEditingShortcuts.js
@@ -1,0 +1,88 @@
+import { ref, watch, onBeforeUnmount } from 'vue'
+import { useEditingCapabilities } from './useEditingCapabilities'
+
+const isTextInput = (target) =>
+  target && target.matches && target.matches('input, textarea, select, [contenteditable]')
+
+export const useEditingShortcuts = ({
+  onUndo,
+  onRedo,
+  onCopy,
+  onPaste,
+  onDelete,
+  hasSelection,
+}) => {
+  const { editingCapabilities } = useEditingCapabilities()
+  const registered = ref(false)
+
+  const handler = (e) => {
+    if (!editingCapabilities.value.canUseShortcuts) return
+    if (isTextInput(e.target)) return
+    if (window.getSelection && window.getSelection().toString()) return
+    if (typeof window !== 'undefined' && window.__dvCanvasDragActive) return
+
+    if (e.ctrlKey || e.metaKey) {
+      if (e.key === 'z' && !e.shiftKey) {
+        if (typeof onUndo === 'function') {
+          e.preventDefault()
+          onUndo()
+        }
+      } else if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
+        if (typeof onRedo === 'function') {
+          e.preventDefault()
+          onRedo()
+        }
+      } else if (e.key === 'c') {
+        if (typeof onCopy === 'function') {
+          e.preventDefault()
+          onCopy()
+        }
+      } else if (e.key === 'v') {
+        if (typeof onPaste === 'function') {
+          e.preventDefault()
+          onPaste()
+        }
+      }
+    } else if (e.key === 'Delete' || e.key === 'Backspace') {
+      if (typeof hasSelection === 'function' && !hasSelection()) return
+      if (typeof onDelete === 'function') {
+        e.preventDefault()
+        onDelete()
+      }
+    }
+  }
+
+  const register = () => {
+    if (registered.value) return
+    window.addEventListener('keydown', handler)
+    registered.value = true
+  }
+
+  const unregister = () => {
+    if (!registered.value) return
+    window.removeEventListener('keydown', handler)
+    registered.value = false
+  }
+
+  watch(
+    () => editingCapabilities.value.canUseShortcuts,
+    (canUse) => {
+      if (typeof window === 'undefined') return
+      if (canUse) {
+        register()
+      } else {
+        unregister()
+      }
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(() => unregister())
+
+  return {
+    register,
+    unregister,
+  }
+}
+
+export default useEditingShortcuts

--- a/src/inventory-smart/composables/useElementDrag.js
+++ b/src/inventory-smart/composables/useElementDrag.js
@@ -28,6 +28,7 @@ import {
   clampPointToPolygon,
 } from '@/inventory-smart/utils/polygonBounds'
 import { clampRectToRect } from '@/inventory-smart/utils/geometry'
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
 
 export function useElementDrag({
   canvasStore,
@@ -46,6 +47,7 @@ export function useElementDrag({
   setLiveConflictsThrottled,
   computeBoundary,
 }) {
+  const { editingCapabilities } = useEditingCapabilities()
   // Estado del drag
   const isElementDragging = ref(false)
   const stageDragEnabled = ref(true)
@@ -252,6 +254,11 @@ export function useElementDrag({
   }
 
   const startElementDrag = (elementId) => {
+    if (!editingCapabilities.value.canDragElements) {
+      isElementDragging.value = false
+      stageDragEnabled.value = false
+      return
+    }
     if (isElementLocked(elementId)) {
       // Si está bloqueado, no iniciar drag ni mover el layer
       isElementDragging.value = false
@@ -827,6 +834,15 @@ export function useElementDrag({
   }
 
   const onShapeDragStart = (e, el) => {
+    if (!editingCapabilities.value.canDragElements) {
+      try {
+        e?.target?.stopDrag?.()
+      } catch {
+        /* noop */
+      }
+      stageDragEnabled.value = false
+      return
+    }
     if (!canvasStore.estaEnPlanta) {
       const shape = e.target
       const parent =
@@ -856,6 +872,7 @@ export function useElementDrag({
   }
 
   const onShapeDragMove = (e, el) => {
+    if (!editingCapabilities.value.canDragElements) return
     const data = innerSessions.get(el.id)
     if (data) {
       const { session, parent } = data
@@ -922,6 +939,11 @@ export function useElementDrag({
   }
 
   const onShapeDragEnd = (e, el) => {
+    if (!editingCapabilities.value.canDragElements) {
+      stageDragEnabled.value = false
+      isElementDragging.value = false
+      return
+    }
     const data = innerSessions.get(el.id)
     if (data) {
       const { session, parent, initial } = data

--- a/src/inventory-smart/composables/useStatePersistence.js
+++ b/src/inventory-smart/composables/useStatePersistence.js
@@ -49,6 +49,8 @@ export const useStatePersistence = () => {
         })
       },
 
+      modoEdicion: state.modoEdicion === true,
+
       // Catálogos dinámicos (pueden sobrescribir los defaults)
       catalogos: {
         tiposEspacio: state.catalogos?.tiposEspacio || DEFAULT_TIPOS_ESPACIO,
@@ -407,6 +409,15 @@ export const useStatePersistence = () => {
           tiposCuarto: DEFAULT_TIPOS_CUARTO,
           tiposProductoAdmitidos: DEFAULT_TIPOS_PRODUCTO_ADMITIDOS,
         })
+      }
+
+      if (typeof storeActions.setModoEdicion === 'function') {
+        try {
+          storeActions.setModoEdicion(state.modoEdicion === true)
+        } catch (error) {
+          console.warn('No se pudo restaurar modoEdicion desde la configuración:', error)
+          storeActions.setModoEdicion(false)
+        }
       }
 
       // === RESTAURAR PLANTAS CON VALIDACIÓN INDIVIDUAL ===

--- a/src/inventory-smart/composables/useTransformer.js
+++ b/src/inventory-smart/composables/useTransformer.js
@@ -6,6 +6,7 @@ import { circleInPolygon, isRectCompletelyInPolygon } from '@/inventory-smart/ut
 import { boundaryToAreaBounds } from '@/inventory-smart/utils/bounds'
 import { correctTransformValues } from '@/inventory-smart/utils/precision'
 import { toTransformerPrecision } from '../utils/fixedDimensions'
+import { useEditingCapabilities } from '@/inventory-smart/composables/useEditingCapabilities'
 
 /**
  * Composable para manejar la lógica de transformación de elementos en el canvas
@@ -34,6 +35,7 @@ export function useTransformer({
   const editingElementId = ref(null)
   const transformInitialState = new Map()
   const transformState = new Map()
+  const { editingCapabilities } = useEditingCapabilities()
 
   // Cleanup automático para prevenir memory leaks
   const cleanupStaleStates = () => {
@@ -57,7 +59,9 @@ export function useTransformer({
 
   // Computeds
   const isEditingSelected = computed(
-    () => editingElementId.value === canvasStore.elementoSeleccionado,
+    () =>
+      editingCapabilities.value.canTransformElements &&
+      editingElementId.value === canvasStore.elementoSeleccionado,
   )
 
   const selectedElementLocked = computed(() => {
@@ -212,6 +216,21 @@ export function useTransformer({
     }
   }
 
+  watch(
+    () => editingCapabilities.value.canTransformElements,
+    (enabled) => {
+      if (!enabled && editingElementId.value) {
+        try {
+          clearTransformVisualFeedback(editingElementId.value)
+        } catch (error) {
+          console.warn('[transform-clear-feedback] Error al limpiar feedback por modo visualización:', error)
+        }
+        editingElementId.value = null
+      }
+    },
+    { immediate: true },
+  )
+
   // Revertir transformación visual y en el store
   const revertTransform = (elementId, reason = '') => {
     const elemento = canvasStore.elementosVisibles.find((e) => e.id === elementId)
@@ -262,6 +281,7 @@ export function useTransformer({
 
   // Inicio de transformación - guardar estado inicial
   const handleTransformStart = (e, element) => {
+    if (!editingCapabilities.value.canTransformElements) return
     if (element?.restrictions && element.restrictions.include('drag')) return;
     isInteractingWithTransformer.value = true
     try {
@@ -314,6 +334,7 @@ export function useTransformer({
 
   // Durante transformación - feedback visual optimizado
   const handleTransformMove = (e, elementId) => {
+    if (!editingCapabilities.value.canTransformElements) return
     try {
       const node = e.target
       if (!node) {
@@ -370,6 +391,10 @@ export function useTransformer({
 
   // Fin de transformación - validación completa y persistencia
   const handleTransformEnd = (e, elementId) => {
+    if (!editingCapabilities.value.canTransformElements) {
+      isInteractingWithTransformer.value = false
+      return
+    }
     isInteractingWithTransformer.value = false
     try {
       const node = e.target
@@ -802,6 +827,10 @@ export function useTransformer({
 
   // Activar/desactivar edición del elemento seleccionado
   const toggleEditingMode = (elementId, dragModeActive) => {
+    if (!editingCapabilities.value.canTransformElements) {
+      editingElementId.value = null
+      return
+    }
     if (!dragModeActive) {
       editingElementId.value = null
     } else {


### PR DESCRIPTION
## Summary
- add a global `modoEdicion` flag with derived editing capabilities in the canvas store and persist it during serialization
- introduce a mode toggle UI, scoped keyboard shortcuts, and capability helpers to disable drag/transform/context actions when viewing
- gate catalog, layers, and the properties panel in view-only mode while surfacing tooltips for disabled inputs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc011cd1a48321a5d3f1c815126eb6