### PR TITLE
feat: add placement suggestion modal

### DIFF
--- a/src/inventory-smart/__tests__/placement-suggestions.spec.js
+++ b/src/inventory-smart/__tests__/placement-suggestions.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { buildPlacementSuggestion, applyPlacementSuggestion } from '@/inventory-smart/utils/placementSuggestions'
+
+describe('placementSuggestions', () => {
+  it('proposes capacity adjustment when weight exceeds limit', () => {
+    const suggestion = buildPlacementSuggestion({
+      failure: {
+        type: 'weight',
+        message: 'Excede capacidad',
+        element: { capacidadCarga: 200 },
+        weightResult: {
+          valido: false,
+          capacidadCarga: 500,
+          pesoActual: 450,
+        },
+      },
+    })
+    expect(suggestion).not.toBeNull()
+    expect(suggestion.adjustments[0].type).toBe('capacity')
+    const applied = applyPlacementSuggestion({ capacidadCarga: 200 }, suggestion)
+    expect(applied.capacidadCarga).toBeCloseTo(50)
+  })
+
+  it('proposes dimension adjustment when scale is required', () => {
+    const suggestion = buildPlacementSuggestion({
+      failure: {
+        type: 'space',
+        message: 'No cabe',
+        dimsCm: { ancho: 120, largo: 80, alto: 30 },
+        pixelSize: { width: 120, height: 80 },
+        areaBounds: { minX: 0, minY: 0, maxX: 60, maxY: 80 },
+        conflicts: [],
+        view: 'XY',
+      },
+    })
+    expect(suggestion).not.toBeNull()
+    expect(suggestion.adjustments[0].type).toBe('dimensions')
+    const applied = applyPlacementSuggestion({ dimensiones: { ancho: 120, largo: 80, alto: 30 } }, suggestion)
+    expect(applied.dimensiones.ancho).toBeLessThan(120)
+    expect(applied.dimensiones.largo).toBeLessThan(80)
+  })
+
+  it('returns null when no adjustment is needed', () => {
+    const suggestion = buildPlacementSuggestion({
+      failure: {
+        type: 'space',
+        message: 'Todo ok',
+        dimsCm: { ancho: 60, largo: 40, alto: 30 },
+        pixelSize: { width: 60, height: 40 },
+        areaBounds: { minX: 0, minY: 0, maxX: 100, maxY: 100 },
+        conflicts: [],
+        view: 'XY',
+      },
+    })
+    expect(suggestion).toBeNull()
+  })
+})

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -653,6 +653,13 @@
       @close="closeTemplateModal"
     />
 
+    <PlacementSuggestionModal
+      :open="suggestionModalOpen"
+      :suggestion="currentSuggestion"
+      @accept="handleSuggestionAccept"
+      @cancel="handleSuggestionCancel"
+    />
+
     <CanvasInfo />
 
     <FloatingControls
@@ -710,6 +717,9 @@ import { useTransformer } from '@/inventory-smart/composables/useTransformer'
 import { useElementDrag } from '@/inventory-smart/composables/useElementDrag'
 import { useMarqueeSelection } from '@/inventory-smart/composables/useMarqueeSelection'
 import TemplateSaveModal from '@/inventory-smart/components/TemplateSaveModal.vue'
+import PlacementSuggestionModal from '@/inventory-smart/components/modals/PlacementSuggestionModal.vue'
+import { usePlacementSuggestionState } from '@/inventory-smart/composables/usePlacementSuggestionState'
+import { buildPlacementSuggestion, applyPlacementSuggestion } from '@/inventory-smart/utils/placementSuggestions'
 import CanvasInfo from '@/inventory-smart/components/CanvasInfo.vue'
 import { useZoom } from '@/inventory-smart/composables/useZoom'
 import FloatingControls from '@/inventory-smart/components/FloatingControls.vue'
@@ -775,6 +785,29 @@ const openTemplateModal = (elementId) => {
 }
 const closeTemplateModal = () => {
   templateModalOpen.value = false
+}
+const {
+  isOpen: suggestionModalOpen,
+  currentSuggestion,
+  openSuggestion,
+  closeSuggestion,
+} = usePlacementSuggestionState()
+const pendingPlacement = ref(null)
+
+const handleSuggestionCancel = () => {
+  pendingPlacement.value = null
+  closeSuggestion()
+}
+
+const handleSuggestionAccept = () => {
+  const pending = pendingPlacement.value
+  pendingPlacement.value = null
+  closeSuggestion()
+  if (!pending) return
+  const adjustedElement = applyPlacementSuggestion(pending.element, pending.suggestion)
+  if (pending.origin === 'catalog') {
+    createElementFromDrop({ elemento: adjustedElement }, pending.dropEvent, { skipSuggestions: true })
+  }
 }
 const dimensionValidation = useDimensionValidation()
 
@@ -1702,8 +1735,18 @@ const getWorldCoordinatesFromPointer = (dropEvent) => {
 }
 
 // Pipeline unificado de validaciones previas al drop
-const runPreDropValidations = (elemento, dropEvent) => {
-  if (!elemento) return { ok: false, reason: 'invalid' }
+const runPreDropValidations = (elemento, dropEvent, options = {}) => {
+  const silent = options.silent === true
+  const fail = (reason, failure = {}) => {
+    if (!silent && failure.message) {
+      showToast(failure.message, failure.toastType || 'error')
+    }
+    return { ok: false, reason, failure }
+  }
+
+  if (!elemento) {
+    return fail('invalid', { type: 'invalid', message: 'Elemento inválido.' })
+  }
 
   const contextoActual = canvasStore.contextoActual?.tipo || 'plantas'
   const tipoElemento = elemento.tipo
@@ -1727,8 +1770,8 @@ const runPreDropValidations = (elemento, dropEvent) => {
       contenedores: 'No puedes agregar elementos dentro de niveles.',
       pasillos: 'No puedes agregar elementos dentro de pasillos.',
     }
-    showToast(msgMap[contextoActual] || 'No puedes agregar este tipo aquí.', 'error')
-    return { ok: false, reason: 'hierarchy' }
+    const message = msgMap[contextoActual] || 'No puedes agregar este tipo aquí.'
+    return fail('hierarchy', { type: 'hierarchy', message })
   }
 
   // Si es pasillo, ajustar alto al de la planta ANTES de validar
@@ -1760,11 +1803,13 @@ const runPreDropValidations = (elemento, dropEvent) => {
       tipoPadre = 'el elemento'
     }
     // El elemento excedería el peso máximo permitido
-    showToast(
-      `No se puede agregar: excedería el peso máximo soportado de ${tipoPadre} (${resultadoValidacionPeso.exceso} kg más)`,
-      'error',
-    )
-    return { ok: false, reason: 'weight' }
+    const message = `No se puede agregar: excedería el peso máximo soportado de ${tipoPadre} (${resultadoValidacionPeso.exceso} kg más)`
+    return fail('weight', {
+      type: 'weight',
+      message,
+      element: elementoParaPeso,
+      weightResult: resultadoValidacionPeso,
+    })
   }
 
   let { width, height } = getElementPixelDimensions(elemento)
@@ -1838,8 +1883,14 @@ const runPreDropValidations = (elemento, dropEvent) => {
     let local = sess.toLocal({ x: candX, y: candY }, parent)
     local = sess.finalizeLocal(local)
     if (!sess.isValidLocal(local)) {
-      showToast('No hay espacio suficiente aquí para colocar el elemento.', 'error')
-      return { ok: false, reason: 'bounds' }
+      return fail('bounds', {
+        type: 'space',
+        message: 'No hay espacio suficiente aquí para colocar el elemento.',
+        dimsCm: { ancho: anchoCm, largo: largoCm, alto: altoCm },
+        pixelSize: { width: finalWidth, height: finalHeight },
+        areaBounds: null,
+        view: canvasStore.vistaActiva,
+      })
     }
     const worldPos = sess.toWorld(local, parent)
     candX = worldPos.x
@@ -1913,14 +1964,32 @@ const runPreDropValidations = (elemento, dropEvent) => {
   }
 
   if (!ok) {
-    showToast('No fue posible colocar el elemento dentro de los límites de la planta.', 'error')
-    return { ok: false, reason: 'bounds' }
+    return fail('bounds', {
+      type: 'space',
+      message: 'No fue posible colocar el elemento dentro de los límites de la planta.',
+      dimsCm: { ancho: anchoCm, largo: largoCm, alto: altoCm },
+      pixelSize: { width: finalWidth, height: finalHeight },
+      areaBounds,
+      boundary,
+      candidate: { x: candX, y: candY },
+      conflicts: blocking,
+      view: canvasStore.vistaActiva,
+    })
   }
 
   // Validación final: asegurar que la posición final sea válida con la misma lógica que drag
   if (!insideAreaModel(finalPos, { ...tempEl, x: finalPos.x, y: finalPos.y }, areaBounds, 0.5)) {
-    showToast('El elemento quedaría fuera del área permitida.', 'error')
-    return { ok: false, reason: 'bounds' }
+    return fail('bounds', {
+      type: 'space',
+      message: 'El elemento quedaría fuera del área permitida.',
+      dimsCm: { ancho: anchoCm, largo: largoCm, alto: altoCm },
+      pixelSize: { width: finalWidth, height: finalHeight },
+      areaBounds,
+      boundary,
+      candidate: { x: finalPos.x, y: finalPos.y },
+      conflicts: blocking,
+      view: canvasStore.vistaActiva,
+    })
   }
 
   return {
@@ -1932,10 +2001,33 @@ const runPreDropValidations = (elemento, dropEvent) => {
   }
 }
 
-const createElementFromDrop = (data, dropEvent) => {
-  const elemento = data.elemento
-  const res = runPreDropValidations(elemento, dropEvent)
-  if (!res.ok) return
+const createElementFromDrop = (data, dropEvent, options = {}) => {
+  const elementSource = options.elementOverride || data.elemento
+  if (!elementSource) return
+
+  const elemento = JSON.parse(JSON.stringify(elementSource))
+  const skipSuggestions = options.skipSuggestions === true
+  const res = runPreDropValidations(elemento, dropEvent, { silent: !skipSuggestions })
+  if (!res.ok) {
+    const failure = res.failure
+    if (!skipSuggestions) {
+      const suggestion = buildPlacementSuggestion({ failure })
+      if (suggestion) {
+        pendingPlacement.value = {
+          origin: 'catalog',
+          element: elemento,
+          dropEvent,
+          suggestion,
+        }
+        openSuggestion(suggestion)
+        return
+      }
+    }
+    if (failure?.message) {
+      showToast(failure.message, 'error')
+    }
+    return
+  }
 
   let { ancho: anchoCm, largo: largoCm, alto: altoCm } = res.dimsCm
   let finalWidth = res.width
@@ -1950,8 +2042,6 @@ const createElementFromDrop = (data, dropEvent) => {
     id: `${elemento.tipo || elemento.categoria || 'elemento'}_${Date.now()}`,
     tipo: elemento.tipo,
     categoria: elemento.categoria,
-    // Para pasillos: si vienen con nombre desde el catálogo, preservarlo;
-    // si no, dejar que el store genere el nombre por defecto.
     nombre: elemento.nombre || 'Nuevo elemento',
     dimensiones: { ancho: anchoCm, largo: largoCmFinal, alto: altoCm },
     x: finalPosition.x,

--- a/src/inventory-smart/components/modals/PlacementSuggestionModal.vue
+++ b/src/inventory-smart/components/modals/PlacementSuggestionModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="placementSuggestionTitle"
+    >
+      <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" @click="emit('cancel')" />
+      <div class="relative w-full max-w-lg rounded-lg bg-white shadow-xl">
+        <header class="border-b border-gray-200 px-6 py-4">
+          <h2 id="placementSuggestionTitle" class="text-lg font-semibold text-gray-900">
+            Ajustes para colocar el elemento
+          </h2>
+          <p class="mt-1 text-sm text-gray-600">
+            {{ suggestion?.reason }}
+          </p>
+        </header>
+
+        <section class="space-y-4 px-6 py-5 text-sm text-gray-700">
+          <div v-for="(adjustment, index) in suggestion?.adjustments || []" :key="index">
+            <h3 class="font-medium text-gray-900">{{ adjustment.title }}</h3>
+            <p class="mt-1 text-gray-600">{{ adjustment.message }}</p>
+
+            <dl v-if="adjustment.type === 'dimensions' && adjustment.newDimensions" class="mt-3 grid grid-cols-2 gap-2">
+              <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-500">Ancho</dt>
+                <dd class="text-sm font-medium text-gray-900">{{ adjustment.newDimensions.ancho }} cm</dd>
+              </div>
+              <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-500">Largo</dt>
+                <dd class="text-sm font-medium text-gray-900">{{ adjustment.newDimensions.largo }} cm</dd>
+              </div>
+              <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-500">Alto</dt>
+                <dd class="text-sm font-medium text-gray-900">{{ adjustment.newDimensions.alto }} cm</dd>
+              </div>
+            </dl>
+
+            <div v-else-if="adjustment.type === 'capacity'" class="mt-3 rounded-md bg-blue-50 p-3">
+              <p class="text-sm font-medium text-blue-900">
+                Nueva capacidad: {{ adjustment.newValue }} kg
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <footer class="flex items-center justify-end gap-3 border-t border-gray-200 px-6 py-4">
+          <button
+            type="button"
+            class="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            @click="emit('cancel')"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            class="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            @click="emit('accept')"
+          >
+            Aplicar ajustes y colocar
+          </button>
+        </footer>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  suggestion: { type: Object, default: () => null },
+})
+
+const emit = defineEmits(['accept', 'cancel'])
+
+// Referenciar props para evitar warning de lint
+void props
+</script>

--- a/src/inventory-smart/composables/usePlacementSuggestionState.js
+++ b/src/inventory-smart/composables/usePlacementSuggestionState.js
@@ -1,0 +1,29 @@
+import { computed, reactive } from 'vue'
+
+const suggestionState = reactive({
+  open: false,
+  suggestion: null,
+})
+
+export function usePlacementSuggestionState() {
+  const isOpen = computed(() => suggestionState.open)
+  const currentSuggestion = computed(() => suggestionState.suggestion)
+
+  const openSuggestion = (suggestion) => {
+    suggestionState.open = true
+    suggestionState.suggestion = suggestion || null
+  }
+
+  const closeSuggestion = () => {
+    suggestionState.open = false
+    suggestionState.suggestion = null
+  }
+
+  return {
+    isOpen,
+    currentSuggestion,
+    openSuggestion,
+    closeSuggestion,
+  }
+}
+

--- a/src/inventory-smart/utils/placementSuggestions.js
+++ b/src/inventory-smart/utils/placementSuggestions.js
@@ -1,0 +1,153 @@
+import { CM_TO_PX } from '@/inventory-smart/utils/constants'
+
+const MIN_DIM_CM = 5
+const ROUND_PRECISION = 2
+
+function formatNumber(value) {
+  if (!Number.isFinite(value)) return 0
+  return Number.parseFloat(value.toFixed(ROUND_PRECISION))
+}
+
+function computeAreaScale({ widthPx, heightPx, areaBounds }) {
+  if (!areaBounds) return 1
+  const { minX = 0, minY = 0, maxX = Infinity, maxY = Infinity } = areaBounds
+  const availableWidth = Math.max(0, maxX - minX)
+  const availableHeight = Math.max(0, maxY - minY)
+  let scale = 1
+  if (Number.isFinite(availableWidth) && availableWidth > 0 && widthPx > availableWidth) {
+    scale = Math.min(scale, (availableWidth - 1) / widthPx)
+  }
+  if (Number.isFinite(availableHeight) && availableHeight > 0 && heightPx > availableHeight) {
+    scale = Math.min(scale, (availableHeight - 1) / heightPx)
+  }
+  return scale
+}
+
+function computeConflictScale({ widthPx, heightPx, conflicts }) {
+  if (!Array.isArray(conflicts) || conflicts.length === 0) return 1
+  let scale = 1
+  for (const conflict of conflicts) {
+    const ra = conflict?.ra
+    const rb = conflict?.rb
+    if (!ra || !rb) continue
+    const overlapX = Math.max(0, Math.min(ra.x + ra.w, rb.x + rb.w) - Math.max(ra.x, rb.x))
+    const overlapY = Math.max(0, Math.min(ra.y + ra.h, rb.y + rb.h) - Math.max(ra.y, rb.y))
+    if (overlapX > 0 && widthPx > 0) {
+      scale = Math.min(scale, Math.max(0, (widthPx - overlapX) / widthPx))
+    }
+    if (overlapY > 0 && heightPx > 0) {
+      scale = Math.min(scale, Math.max(0, (heightPx - overlapY) / heightPx))
+    }
+  }
+  return scale
+}
+
+function buildDimensionAdjustment({ dimsCm, widthPx, heightPx, areaBounds, conflicts, view }) {
+  if (!dimsCm) return null
+  if (!Number.isFinite(widthPx) || widthPx <= 0 || !Number.isFinite(heightPx) || heightPx <= 0) {
+    return null
+  }
+  const areaScale = computeAreaScale({ widthPx, heightPx, areaBounds })
+  const conflictScale = computeConflictScale({ widthPx, heightPx, conflicts })
+  const scale = Math.min(areaScale, conflictScale)
+  if (!Number.isFinite(scale) || scale >= 1 || scale <= 0) return null
+
+  const isXZ = view === 'XZ'
+  const nextDims = { ...dimsCm }
+
+  const anchoEscalado = Math.max(MIN_DIM_CM, (dimsCm.ancho ?? MIN_DIM_CM) * scale)
+  nextDims.ancho = formatNumber(anchoEscalado)
+
+  if (isXZ) {
+    const altoEscalado = Math.max(MIN_DIM_CM, (dimsCm.alto ?? MIN_DIM_CM) * scale)
+    nextDims.alto = formatNumber(altoEscalado)
+  } else {
+    const largoEscalado = Math.max(MIN_DIM_CM, (dimsCm.largo ?? MIN_DIM_CM) * scale)
+    nextDims.largo = formatNumber(largoEscalado)
+  }
+
+  const target = isXZ ? 'ancho y altura' : 'ancho y largo'
+  const reduction = formatNumber((1 - scale) * 100)
+
+  return {
+    type: 'dimensions',
+    title: 'Ajustar dimensiones para que quepa',
+    message: `Reducir ${target} en ${reduction}% manteniendo proporción.`,
+    newDimensions: nextDims,
+    scale,
+  }
+}
+
+function buildCapacityAdjustment({ element, weightResult }) {
+  if (!weightResult || weightResult.valido) return null
+  const capacidadMaxima = Number(weightResult.capacidadCarga)
+  const pesoActual = Number(weightResult.pesoActual)
+  if (!Number.isFinite(capacidadMaxima) || !Number.isFinite(pesoActual)) return null
+  const disponible = Math.max(0, capacidadMaxima - pesoActual)
+  const actual = Number(element?.capacidadCarga || 0)
+  if (!Number.isFinite(actual)) return null
+  if (disponible <= 0 || disponible >= actual) return null
+  return {
+    type: 'capacity',
+    title: 'Reducir carga para respetar el límite',
+    message: `Ajustar la capacidad consumida del elemento a ${formatNumber(disponible)} kg (disponibles ${formatNumber(disponible)} kg).`,
+    property: 'capacidadCarga',
+    newValue: formatNumber(disponible),
+  }
+}
+
+export function buildPlacementSuggestion({ failure }) {
+  if (!failure) return null
+  if (failure.type === 'weight') {
+    const capacityAdjustment = buildCapacityAdjustment({ element: failure.element, weightResult: failure.weightResult })
+    if (capacityAdjustment) {
+      return {
+        reason: failure.message || 'El elemento excede la capacidad permitida.',
+        adjustments: [capacityAdjustment],
+      }
+    }
+    return null
+  }
+
+  if (failure.type === 'space') {
+    const dims = failure.dimsCm
+    const widthPx = failure.pixelSize?.width ?? (dims?.ancho ? dims.ancho * CM_TO_PX : 0)
+    const heightPx = failure.pixelSize?.height ?? (dims?.largo ? dims.largo * CM_TO_PX : 0)
+    const dimensionAdjustment = buildDimensionAdjustment({
+      dimsCm: dims,
+      widthPx,
+      heightPx,
+      areaBounds: failure.areaBounds,
+      conflicts: failure.conflicts,
+      view: failure.view,
+    })
+    if (dimensionAdjustment) {
+      return {
+        reason: failure.message || 'No hay espacio suficiente en la posición objetivo.',
+        adjustments: [dimensionAdjustment],
+      }
+    }
+    return null
+  }
+
+  return null
+}
+
+export function applyPlacementSuggestion(element, suggestion) {
+  if (!suggestion?.adjustments?.length) return element
+  const next = { ...element }
+  for (const adj of suggestion.adjustments) {
+    if (adj.type === 'dimensions' && adj.newDimensions) {
+      const dims = {
+        ...(next.dimensiones || {}),
+        ...adj.newDimensions,
+      }
+      next.dimensiones = dims
+    }
+    if (adj.type === 'capacity' && adj.property) {
+      next[adj.property] = adj.newValue
+    }
+  }
+  return next
+}
+


### PR DESCRIPTION
## Summary
- add reusable helpers to compute capacity and dimension adjustments when a placement fails
- surface a placement suggestion modal in CanvasView so drops can apply element-level fixes without editing parents
- cover placement suggestion builders with targeted unit tests

## Testing
- npm run test:unit *(fails: jsdom test environment reports `document is not defined` when mounting FloatingControls and related suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e035b7e5048321a4dba8208665dca3