### PR TITLE
feat: suggest adjustments when drop validations fail

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -668,6 +668,12 @@
       @zoom-out="zoomOut()"
       @fit="fitToPlanta"
     />
+    <DropSuggestionModal
+      :open="dropSuggestionState.open"
+      :suggestions="dropSuggestionState.suggestions"
+      @accept="acceptDropSuggestions"
+      @cancel="cancelDropSuggestions"
+    />
   </div>
 </template>
 
@@ -713,6 +719,9 @@ import TemplateSaveModal from '@/inventory-smart/components/TemplateSaveModal.vu
 import CanvasInfo from '@/inventory-smart/components/CanvasInfo.vue'
 import { useZoom } from '@/inventory-smart/composables/useZoom'
 import FloatingControls from '@/inventory-smart/components/FloatingControls.vue'
+import DropSuggestionModal from '@/inventory-smart/components/modals/DropSuggestionModal.vue'
+import { useDropSuggestionModal } from '@/inventory-smart/composables/useDropSuggestionModal'
+import { applyElementOverrides, generateDropSuggestions } from '@/inventory-smart/modules/drop/dropPlacementAdjustments'
 import { toPrecisionCm } from '../utils/fixedDimensions'
 import { instantiateStructureOnCanvas } from '@/inventory-smart/composables/useStructureManager'
 
@@ -777,6 +786,12 @@ const closeTemplateModal = () => {
   templateModalOpen.value = false
 }
 const dimensionValidation = useDimensionValidation()
+const {
+  state: dropSuggestionState,
+  showSuggestions,
+  accept: acceptDropSuggestions,
+  cancel: cancelDropSuggestions,
+} = useDropSuggestionModal()
 
 // Object snapping
 const { activeGuides: snapGuides, isSnapping, performSnap, clearGuides } = useObjectSnapping()
@@ -1702,10 +1717,14 @@ const getWorldCoordinatesFromPointer = (dropEvent) => {
 }
 
 // Pipeline unificado de validaciones previas al drop
-const runPreDropValidations = (elemento, dropEvent) => {
+const runPreDropValidations = (elemento, dropEvent, options = {}) => {
+  const { silent = false } = options
   if (!elemento) return { ok: false, reason: 'invalid' }
 
-  const contextoActual = canvasStore.contextoActual?.tipo || 'plantas'
+  const rawContext = canvasStore.contextoActual || {}
+  const contextoId =
+    rawContext.id || canvasStore.plantaActiva || canvasStore.plantaActivaData?.id || null
+  const contextoActual = rawContext.tipo || 'plantas'
   const tipoElemento = elemento.tipo
 
   // Reglas de jerarquía actualizadas
@@ -1727,8 +1746,9 @@ const runPreDropValidations = (elemento, dropEvent) => {
       contenedores: 'No puedes agregar elementos dentro de niveles.',
       pasillos: 'No puedes agregar elementos dentro de pasillos.',
     }
-    showToast(msgMap[contextoActual] || 'No puedes agregar este tipo aquí.', 'error')
-    return { ok: false, reason: 'hierarchy' }
+    const message = msgMap[contextoActual] || 'No puedes agregar este tipo aquí.'
+    if (!silent) showToast(message, 'error')
+    return { ok: false, reason: 'hierarchy', message }
   }
 
   // Si es pasillo, ajustar alto al de la planta ANTES de validar
@@ -1742,8 +1762,8 @@ const runPreDropValidations = (elemento, dropEvent) => {
 
   const resultadoValidacionPeso = weightValidation.validarPesoElemento(
     elementoParaPeso,
-    canvasStore.contextoActual.id,
-    canvasStore.contextoActual.tipo,
+    contextoId,
+    contextoActual,
   )
 
   if (!resultadoValidacionPeso.valido) {
@@ -1760,11 +1780,15 @@ const runPreDropValidations = (elemento, dropEvent) => {
       tipoPadre = 'el elemento'
     }
     // El elemento excedería el peso máximo permitido
-    showToast(
-      `No se puede agregar: excedería el peso máximo soportado de ${tipoPadre} (${resultadoValidacionPeso.exceso} kg más)`,
-      'error',
-    )
-    return { ok: false, reason: 'weight' }
+    const message =
+      `No se puede agregar: excedería el peso máximo soportado de ${tipoPadre} (${resultadoValidacionPeso.exceso} kg más)`
+    if (!silent) showToast(message, 'error')
+    return {
+      ok: false,
+      reason: 'weight',
+      message,
+      details: { weight: resultadoValidacionPeso, parentLabel: tipoPadre },
+    }
   }
 
   let { width, height } = getElementPixelDimensions(elemento)
@@ -1811,6 +1835,7 @@ const runPreDropValidations = (elemento, dropEvent) => {
   const MIN_HEIGHT = 10
   let finalWidth = Math.max(width, MIN_WIDTH)
   let finalHeight = Math.max(height, MIN_HEIGHT)
+  const dimsSnapshot = { ancho: anchoCm, largo: largoCm, alto: altoCm }
 
   const world = getWorldCoordinatesFromPointer(dropEvent)
   let candX = world.x - finalWidth / 2
@@ -1838,8 +1863,9 @@ const runPreDropValidations = (elemento, dropEvent) => {
     let local = sess.toLocal({ x: candX, y: candY }, parent)
     local = sess.finalizeLocal(local)
     if (!sess.isValidLocal(local)) {
-      showToast('No hay espacio suficiente aquí para colocar el elemento.', 'error')
-      return { ok: false, reason: 'bounds' }
+      const message = 'No hay espacio suficiente aquí para colocar el elemento.'
+      if (!silent) showToast(message, 'error')
+      return { ok: false, reason: 'bounds', message, details: { dimsCm: dimsSnapshot } }
     }
     const worldPos = sess.toWorld(local, parent)
     candX = worldPos.x
@@ -1913,14 +1939,30 @@ const runPreDropValidations = (elemento, dropEvent) => {
   }
 
   if (!ok) {
-    showToast('No fue posible colocar el elemento dentro de los límites de la planta.', 'error')
-    return { ok: false, reason: 'bounds' }
+    const message = 'No fue posible colocar el elemento dentro de los límites de la planta.'
+    if (!silent) showToast(message, 'error')
+    return {
+      ok: false,
+      reason: 'bounds',
+      message,
+      details: {
+        dimsCm: dimsSnapshot,
+        blocking,
+        boundary,
+      },
+    }
   }
 
   // Validación final: asegurar que la posición final sea válida con la misma lógica que drag
   if (!insideAreaModel(finalPos, { ...tempEl, x: finalPos.x, y: finalPos.y }, areaBounds, 0.5)) {
-    showToast('El elemento quedaría fuera del área permitida.', 'error')
-    return { ok: false, reason: 'bounds' }
+    const message = 'El elemento quedaría fuera del área permitida.'
+    if (!silent) showToast(message, 'error')
+    return {
+      ok: false,
+      reason: 'bounds',
+      message,
+      details: { dimsCm: dimsSnapshot, boundary },
+    }
   }
 
   return {
@@ -1932,10 +1974,57 @@ const runPreDropValidations = (elemento, dropEvent) => {
   }
 }
 
-const createElementFromDrop = (data, dropEvent) => {
-  const elemento = data.elemento
-  const res = runPreDropValidations(elemento, dropEvent)
-  if (!res.ok) return
+const handleDropFailureWithSuggestions = ({
+  baseElement,
+  data,
+  dropEvent,
+  validation,
+  overrides = {},
+}) => {
+  const elementWithOverrides = applyElementOverrides(baseElement, overrides)
+  const runProbe = (overridePayload = {}) => {
+    const merged = { ...overrides, ...overridePayload }
+    const candidate = applyElementOverrides(baseElement, merged)
+    return runPreDropValidations(candidate, dropEvent, { silent: true })
+  }
+
+  const suggestions = generateDropSuggestions({
+    element: elementWithOverrides,
+    failure: validation,
+    runProbe,
+  })
+
+  if (!suggestions) return false
+
+  showSuggestions({
+    suggestions,
+    apply: () =>
+      createElementFromDrop(data, dropEvent, { ...overrides, ...suggestions.overrides }),
+    onCancel: () => {
+      if (validation.message) showToast(validation.message, 'error')
+    },
+  })
+
+  return true
+}
+
+const createElementFromDrop = (data, dropEvent, overrides = {}) => {
+  const baseElement = data.elemento
+  const elemento = applyElementOverrides(baseElement, overrides)
+  const res = runPreDropValidations(elemento, dropEvent, { silent: true })
+  if (!res.ok) {
+    const handled = handleDropFailureWithSuggestions({
+      baseElement,
+      data,
+      dropEvent,
+      validation: res,
+      overrides,
+    })
+    if (!handled && res.message) {
+      showToast(res.message, 'error')
+    }
+    return
+  }
 
   let { ancho: anchoCm, largo: largoCm, alto: altoCm } = res.dimsCm
   let finalWidth = res.width
@@ -1968,7 +2057,7 @@ const createElementFromDrop = (data, dropEvent) => {
     volumenMaximo: (anchoCm * largoCmFinal * altoCm) / 100,
     dimensionLock: false,
     systemTypeKey: elemento.id,
-    uso: { volumen: 0, peso: 0 },
+    uso: elemento.uso ? { ...elemento.uso } : { volumen: 0, peso: 0 },
     descripcion: elemento.descripcion || '',
     contenedores: elemento.contenedores ? [...elemento.contenedores] : [],
     hijos: [],
@@ -2253,8 +2342,11 @@ const createElementFromBuffer = (data, dropEvent) => {
   }
 
   // Delegar todas las validaciones a la ruta unificada
-  const res = runPreDropValidations(bufferItem.elemento, dropEvent)
-  if (!res.ok) return
+  const res = runPreDropValidations(bufferItem.elemento, dropEvent, { silent: true })
+  if (!res.ok) {
+    if (res.message) showToast(res.message, 'error')
+    return
+  }
 
   const newElementId = buffer.pasteFromBuffer(data.bufferItemId, res.position)
   if (newElementId) {
@@ -2269,8 +2361,9 @@ const createElementFromTemplate = (data, dropEvent) => {
     showToast('No se pudo insertar la plantilla', 'error')
     return
   }
-  const res = runPreDropValidations(root, dropEvent)
+  const res = runPreDropValidations(root, dropEvent, { silent: true })
   if (!res.ok) {
+    if (res.message) showToast(res.message, 'error')
     return
   }
   // Unificar instanciación de estructuras (plantillas/cuarto/espacio)

--- a/src/inventory-smart/components/modals/DropSuggestionModal.vue
+++ b/src/inventory-smart/components/modals/DropSuggestionModal.vue
@@ -1,0 +1,187 @@
+<template>
+  <Teleport to="body">
+    <transition name="fade">
+      <div v-if="open" class="modal-backdrop">
+        <div class="modal-card" role="dialog" aria-modal="true">
+          <header class="modal-header">
+            <h2 class="modal-title">Sugerencias para colocar el elemento</h2>
+          </header>
+          <section class="modal-body">
+            <p class="modal-description">
+              El elemento no se pudo colocar con los valores actuales. Te proponemos estos ajustes para continuar
+              sin modificar su contenedor.
+            </p>
+            <ul class="suggestions-list">
+              <li v-if="dimensionSuggestion" class="suggestion-item">
+                <h3 class="suggestion-title">Dimensiones ajustadas</h3>
+                <p class="suggestion-text">{{ dimensionSuggestion }}</p>
+              </li>
+              <li v-if="capacitySuggestion" class="suggestion-item">
+                <h3 class="suggestion-title">Carga efectiva sugerida</h3>
+                <p class="suggestion-text">{{ capacitySuggestion }}</p>
+              </li>
+            </ul>
+          </section>
+          <footer class="modal-footer">
+            <button type="button" class="btn-secondary" @click="emit('cancel')">
+              Cancelar
+            </button>
+            <button type="button" class="btn-primary" @click="emit('accept')">
+              Aceptar ajustes y colocar
+            </button>
+          </footer>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  suggestions: { type: Object, default: null },
+})
+const emit = defineEmits(['accept', 'cancel'])
+
+const dimensionSuggestion = computed(() => {
+  const dims = props.suggestions?.dimension
+  if (!dims?.newDims) return ''
+  const { newDims, original, scale } = dims
+  const parts = []
+  if (Number.isFinite(newDims.ancho)) parts.push(`Ancho: ${newDims.ancho} cm`)
+  if (Number.isFinite(newDims.largo)) parts.push(`Largo: ${newDims.largo} cm`)
+  if (Number.isFinite(newDims.alto)) parts.push(`Alto: ${newDims.alto} cm`)
+  const base = parts.join(' · ')
+  if (!Number.isFinite(scale) || !Number.isFinite(original?.ancho) || !Number.isFinite(original?.largo)) {
+    return base
+  }
+  const percentage = Math.round(scale * 100)
+  return `${base} (escala ${percentage}% respecto a las dimensiones originales)`
+})
+
+const capacitySuggestion = computed(() => {
+  const cap = props.suggestions?.capacity
+  if (!cap) return ''
+  const prev = Number.isFinite(cap.previous) ? `${cap.previous} ${cap.unit}` : 'valor actual'
+  return `Aplicaremos ${cap.newValue} ${cap.unit} en lugar de ${prev}.`
+})
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.18s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1050;
+}
+
+.modal-card {
+  width: min(480px, 100%);
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  padding: 1.25rem 1.5rem 0.75rem;
+}
+
+.modal-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.modal-body {
+  padding: 0.75rem 1.5rem 1.25rem;
+  color: #1f2937;
+}
+
+.modal-description {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  margin-bottom: 1rem;
+}
+
+.suggestions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.suggestion-item {
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid #e2e8f0;
+}
+
+.suggestion-title {
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 0.35rem;
+}
+
+.suggestion-text {
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0.75rem 1.5rem 1.5rem;
+}
+
+.btn-primary,
+.btn-secondary {
+  min-width: 0;
+  padding: 0.65rem 1rem;
+  font-weight: 600;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn-primary {
+  background: #2563eb;
+  color: #ffffff;
+  border: none;
+}
+
+.btn-primary:hover {
+  background: #1d4ed8;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.2);
+}
+
+.btn-secondary {
+  background: #f1f5f9;
+  color: #0f172a;
+  border: none;
+}
+
+.btn-secondary:hover {
+  background: #e2e8f0;
+}
+</style>

--- a/src/inventory-smart/composables/useDropSuggestionModal.js
+++ b/src/inventory-smart/composables/useDropSuggestionModal.js
@@ -1,0 +1,47 @@
+import { ref } from 'vue'
+
+export function useDropSuggestionModal() {
+  const state = ref({
+    open: false,
+    suggestions: null,
+    apply: null,
+    onCancel: null,
+  })
+
+  const showSuggestions = ({ suggestions, apply, onCancel }) => {
+    state.value = {
+      open: true,
+      suggestions,
+      apply: typeof apply === 'function' ? apply : null,
+      onCancel: typeof onCancel === 'function' ? onCancel : null,
+    }
+  }
+
+  const reset = () => {
+    state.value = {
+      open: false,
+      suggestions: null,
+      apply: null,
+      onCancel: null,
+    }
+  }
+
+  const accept = () => {
+    const action = state.value.apply
+    reset()
+    action?.()
+  }
+
+  const cancel = () => {
+    const handler = state.value.onCancel
+    reset()
+    handler?.()
+  }
+
+  return {
+    state,
+    showSuggestions,
+    accept,
+    cancel,
+  }
+}

--- a/src/inventory-smart/modules/drop/__tests__/dropPlacementAdjustments.spec.js
+++ b/src/inventory-smart/modules/drop/__tests__/dropPlacementAdjustments.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { generateDropSuggestions } from '@/inventory-smart/modules/drop/dropPlacementAdjustments'
+
+describe('dropPlacementAdjustments', () => {
+  it('sugiere nueva capacidad cuando hay espacio disponible', () => {
+    const element = { capacidadCarga: 300 }
+    const failure = {
+      reason: 'weight',
+      details: {
+        weight: {
+          capacidadCarga: 500,
+          pesoActual: 250,
+          exceso: 50,
+        },
+      },
+    }
+    const runProbe = vi.fn().mockReturnValue({ ok: true })
+
+    const suggestions = generateDropSuggestions({ element, failure, runProbe })
+
+    expect(runProbe).toHaveBeenCalledWith({ capacidadCarga: 250 })
+    expect(suggestions?.capacity?.newValue).toBe(250)
+    expect(suggestions?.overrides?.capacidadCarga).toBe(250)
+  })
+
+  it('propone ajuste de dimensiones proporcional cuando un factor pasa la validación', () => {
+    const element = { dimensiones: { ancho: 200, largo: 120, alto: 50 } }
+    const failure = {
+      reason: 'bounds',
+      details: {
+        dimsCm: { ancho: 200, largo: 120, alto: 50 },
+      },
+    }
+    const runProbe = vi
+      .fn()
+      .mockReturnValueOnce({ ok: false })
+      .mockReturnValueOnce({ ok: true, dimsCm: { ancho: 180, largo: 108, alto: 45 } })
+
+    const suggestions = generateDropSuggestions({ element, failure, runProbe })
+
+    expect(runProbe).toHaveBeenCalledTimes(2)
+    expect(suggestions?.dimension?.newDims).toEqual({ ancho: 180, largo: 108, alto: 45 })
+    expect(suggestions?.overrides?.dimensiones).toEqual({ ancho: 180, largo: 108, alto: 45 })
+  })
+
+  it('retorna null cuando no encuentra ajustes viables', () => {
+    const element = { capacidadCarga: 120 }
+    const failure = {
+      reason: 'weight',
+      details: {
+        weight: {
+          capacidadCarga: 200,
+          pesoActual: 80,
+        },
+      },
+    }
+    const runProbe = vi.fn().mockReturnValue({ ok: false })
+
+    const suggestions = generateDropSuggestions({ element, failure, runProbe })
+
+    expect(suggestions).toBeNull()
+  })
+})

--- a/src/inventory-smart/modules/drop/dropPlacementAdjustments.js
+++ b/src/inventory-smart/modules/drop/dropPlacementAdjustments.js
@@ -1,0 +1,141 @@
+const SCALE_STEPS = [
+  0.95,
+  0.9,
+  0.85,
+  0.8,
+  0.75,
+  0.7,
+  0.65,
+  0.6,
+  0.55,
+  0.5,
+  0.45,
+  0.4,
+  0.35,
+  0.3,
+]
+
+const DEFAULT_DECIMALS = 2
+
+const roundValue = (value, decimals = DEFAULT_DECIMALS) => {
+  if (!Number.isFinite(value)) return value
+  const factor = 10 ** decimals
+  return Math.round((value + Number.EPSILON) * factor) / factor
+}
+
+const cloneElement = (element = {}) => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(element)
+  }
+  return JSON.parse(JSON.stringify(element))
+}
+
+export function applyElementOverrides(element = {}, overrides = {}) {
+  const clone = cloneElement(element)
+  if (!overrides) return clone
+
+  if (Object.prototype.hasOwnProperty.call(overrides, 'capacidadCarga')) {
+    clone.capacidadCarga = overrides.capacidadCarga
+  }
+
+  if (overrides?.uso && typeof overrides.uso === 'object') {
+    clone.uso = { ...(clone.uso || {}), ...overrides.uso }
+  }
+
+  if (overrides?.dimensiones && typeof overrides.dimensiones === 'object') {
+    clone.dimensiones = { ...(clone.dimensiones || {}), ...overrides.dimensiones }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(overrides, 'alturaRespectoAlSuelo')) {
+    clone.alturaRespectoAlSuelo = overrides.alturaRespectoAlSuelo
+  }
+
+  return clone
+}
+
+const hasFiniteDimension = (value) => Number.isFinite(value) && value > 0
+
+const toScaledDimensions = (dims = {}, factor = 1) => {
+  const { ancho, largo, alto } = dims
+  const scaled = {}
+  if (hasFiniteDimension(ancho)) scaled.ancho = roundValue(ancho * factor)
+  if (hasFiniteDimension(largo)) scaled.largo = roundValue(largo * factor)
+  if (hasFiniteDimension(alto)) scaled.alto = roundValue(alto * factor)
+  return scaled
+}
+
+const determineWeightField = (element = {}) => {
+  if (hasFiniteDimension(element.capacidadCarga)) return 'capacidadCarga'
+  const pesoUso = element?.uso?.peso
+  if (hasFiniteDimension(pesoUso)) return 'uso.peso'
+  return null
+}
+
+const resolveAvailableCapacity = (details = {}, element = {}) => {
+  const available = Number(details.capacidadCarga ?? details.pesoMaximo ?? 0) -
+    Number(details.pesoActual ?? 0)
+  if (!Number.isFinite(available) || available <= 0) return null
+  const field = determineWeightField(element)
+  if (!field) return null
+  const current = field === 'capacidadCarga'
+    ? Number(element.capacidadCarga ?? 0)
+    : Number(element?.uso?.peso ?? 0)
+  if (!Number.isFinite(current) || available >= current) return null
+  return { available: roundValue(available), field, current }
+}
+
+export function generateDropSuggestions({ element, failure, runProbe }) {
+  if (!element || !failure || typeof runProbe !== 'function') return null
+
+  const result = {
+    overrides: {},
+    capacity: null,
+    dimension: null,
+    reason: failure.reason,
+  }
+
+  if (failure.reason === 'weight' && failure.details?.weight) {
+    const capacityInfo = resolveAvailableCapacity(failure.details.weight, element)
+    if (capacityInfo) {
+      const overrides =
+        capacityInfo.field === 'capacidadCarga'
+          ? { capacidadCarga: capacityInfo.available }
+          : { uso: { peso: capacityInfo.available } }
+      const probe = runProbe(overrides)
+      if (probe?.ok) {
+        result.overrides = { ...result.overrides, ...overrides }
+        result.capacity = {
+          newValue: capacityInfo.available,
+          field: capacityInfo.field,
+          previous: capacityInfo.current,
+          unit: 'kg',
+        }
+        return result
+      }
+    }
+    return null
+  }
+
+  if (failure.reason === 'bounds') {
+    const baseDims = failure.details?.dimsCm || element?.dimensiones
+    if (baseDims && (hasFiniteDimension(baseDims.ancho) || hasFiniteDimension(baseDims.largo))) {
+      for (const factor of SCALE_STEPS) {
+        if (!Number.isFinite(factor) || factor >= 1) continue
+        const scaled = toScaledDimensions(baseDims, factor)
+        if (!Object.keys(scaled).length) continue
+        const probe = runProbe({ dimensiones: scaled })
+        if (probe?.ok) {
+          result.overrides = { ...result.overrides, dimensiones: scaled }
+          result.dimension = {
+            scale: factor,
+            newDims: probe.dimsCm || scaled,
+            original: baseDims,
+          }
+          return result
+        }
+      }
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- allow CanvasView drop validations to return structured errors without toasts and reuse them to drive auto-suggestions
- add a DropSuggestionModal plus composables/helpers to apply dimension or capacity adjustments when viable
- cover the suggestion helper with dedicated unit tests

## Testing
- npm run test:unit -- --run *(fails: suite still expects legacy behaviours in several files)*
- npx vitest run src/inventory-smart/modules/drop/__tests__/dropPlacementAdjustments.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e035b7e5048321a4dba8208665dca3