### PR TITLE
Add placement suggestions modal for failed drops

### DIFF
--- a/src/inventory-smart/InventorySmart.vue
+++ b/src/inventory-smart/InventorySmart.vue
@@ -72,6 +72,7 @@
       @close="handleIdentifyEslClose"
       @save="handleIdentifyEslSave"
     />
+    <PlacementSuggestionsModal />
 
     <!-- Alerta de contexto de navegación -->
     <ContextAlert
@@ -93,6 +94,7 @@ import NavegacionJerarquica from './components/NavegacionJerarquica.vue'
 import WorkspaceEditor from './components/WorkspaceEditor.vue'
 import ManagmentFloorRoomPropertiesModal from './components/modals/ManagmentFloorRoomPropertiesModal.vue'
 import IdentifyEslModal from './components/modals/IdentifyEslModal.vue'
+import PlacementSuggestionsModal from './components/modals/PlacementSuggestionsModal.vue'
 import ContextAlert from './components/ContextAlert.vue'
 import { useCanvasImportExport } from './composables/useCanvasImportExport'
 import { useCanvasWithHistory } from './composables/useCanvasWithHistory'

--- a/src/inventory-smart/__tests__/drop-validation.spec.js
+++ b/src/inventory-smart/__tests__/drop-validation.spec.js
@@ -488,6 +488,28 @@ describe('Drop Validation - Bug Fix: Drop que nace bloqueado', () => {
       expect(res.ok).toBe(false)
     })
 
+    it('proposes capacity adjustment when weight can be reduced', () => {
+      weightValidationMock.validarPesoElemento.mockReturnValueOnce({
+        valido: false,
+        exceso: 10,
+        capacidadCarga: 120,
+        pesoActual: 60,
+      })
+      const tpl = {
+        id: 't1',
+        tipo: 'elementos',
+        dimensiones: { ancho: 100, largo: 60, alto: 20 },
+        width: 100,
+        height: 60,
+        nombre: 'Elemento prueba',
+        capacidadCarga: 80,
+      }
+      const res = wrapper.vm.runPreDropValidations(tpl, { clientX: 50, clientY: 50 })
+      expect(res.ok).toBe(false)
+      expect(res.suggestions).toHaveLength(1)
+      expect(res.suggestions[0].type).toBe('capacity')
+    })
+
     it('rejects collision', () => {
       vi.mocked(detectConflictsFor).mockReturnValueOnce([{ bloqueante: true }])
       const tpl = { id: 't1', tipo: 'elementos', dimensiones: { ancho: 100, largo: 60, alto: 20 }, width: 100, height: 60 }

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -702,6 +702,13 @@ import { makeInnerSession } from '@/inventory-smart/composables/useInnerNoOverla
 import { getUsageIndicatorColor } from '@/inventory-smart/composables/useSimulateProducts'
 import { useObjectSnapping } from '@/inventory-smart/composables/useObjectSnapping'
 import { usePlacementGuards } from '@/inventory-smart/composables/usePlacementGuards'
+import { usePlacementSuggestionStore } from '@/inventory-smart/stores/placementSuggestions'
+import {
+  buildCapacitySuggestion,
+  buildDimensionSuggestion,
+  applyPlacementSuggestions,
+  describePlacementFailure,
+} from '@/inventory-smart/utils/placementSuggestions'
 import FloatingToolbar from '@/inventory-smart/components/FloatingToolbar.vue'
 import { useProductSimulation } from '@/inventory-smart/composables/useSimulateProducts'
 import SnapGuides from '@/inventory-smart/components/SnapGuides.vue'
@@ -745,6 +752,7 @@ const { store: canvasStore, undo, redo, canUndo, canRedo } = useCanvasWithHistor
 const { onDragStartGuard, onDragMoveGuard, onDragEndGuard, onTransformEndGuard } =
   usePlacementGuards()
 const buffer = useCanvasBuffer()
+const placementSuggestionStore = usePlacementSuggestionStore()
 const ctx = useContextMenu()
 const {
   visible: ctxVisible,
@@ -1702,7 +1710,7 @@ const getWorldCoordinatesFromPointer = (dropEvent) => {
 }
 
 // Pipeline unificado de validaciones previas al drop
-const runPreDropValidations = (elemento, dropEvent) => {
+const runPreDropValidations = (elemento, dropEvent, options = {}) => {
   if (!elemento) return { ok: false, reason: 'invalid' }
 
   const contextoActual = canvasStore.contextoActual?.tipo || 'plantas'
@@ -1731,6 +1739,11 @@ const runPreDropValidations = (elemento, dropEvent) => {
     return { ok: false, reason: 'hierarchy' }
   }
 
+  const worldPoint = options.worldPoint || (dropEvent ? getWorldCoordinatesFromPointer(dropEvent) : null)
+  if (!worldPoint || !Number.isFinite(worldPoint.x) || !Number.isFinite(worldPoint.y)) {
+    return { ok: false, reason: 'invalid' }
+  }
+
   // Si es pasillo, ajustar alto al de la planta ANTES de validar
   let elementoParaPeso = elemento
   const plantaAlto = canvasStore.plantaActivaData?.dimensiones?.alto
@@ -1748,18 +1761,30 @@ const runPreDropValidations = (elemento, dropEvent) => {
 
   if (!resultadoValidacionPeso.valido) {
     let tipoPadre = ''
-    if (canvasStore.estaEnPlanta) {
-      tipoPadre = 'la planta'
-    } else if (canvasStore.estaEnCuarto) {
-      tipoPadre = 'el cuarto'
-    } else if (canvasStore.estaEnPiso) {
-      tipoPadre = 'el piso'
-    } else if (canvasStore.estaEnContenedor) {
-      tipoPadre = 'el nivel'
-    } else if (canvasStore.estaEnElemento) {
-      tipoPadre = 'el elemento'
+    if (canvasStore.estaEnPlanta) tipoPadre = 'la planta'
+    else if (canvasStore.estaEnCuarto) tipoPadre = 'el cuarto'
+    else if (canvasStore.estaEnPiso) tipoPadre = 'el piso'
+    else if (canvasStore.estaEnContenedor) tipoPadre = 'el nivel'
+    else if (canvasStore.estaEnElemento) tipoPadre = 'el elemento'
+
+    const capacitySuggestion = buildCapacitySuggestion({
+      element: elementoParaPeso,
+      validationResult: resultadoValidacionPeso,
+    })
+
+    if (capacitySuggestion) {
+      return {
+        ok: false,
+        reason: 'weight',
+        reasonMessage:
+          resultadoValidacionPeso.exceso != null
+            ? `El elemento excede la capacidad de ${tipoPadre} por ${resultadoValidacionPeso.exceso} kg.`
+            : describePlacementFailure('weight'),
+        suggestions: [capacitySuggestion],
+        worldPoint: { ...worldPoint },
+      }
     }
-    // El elemento excedería el peso máximo permitido
+
     showToast(
       `No se puede agregar: excedería el peso máximo soportado de ${tipoPadre} (${resultadoValidacionPeso.exceso} kg más)`,
       'error',
@@ -1812,9 +1837,8 @@ const runPreDropValidations = (elemento, dropEvent) => {
   let finalWidth = Math.max(width, MIN_WIDTH)
   let finalHeight = Math.max(height, MIN_HEIGHT)
 
-  const world = getWorldCoordinatesFromPointer(dropEvent)
-  let candX = world.x - finalWidth / 2
-  let candY = world.y - finalHeight / 2
+  let candX = worldPoint.x - finalWidth / 2
+  let candY = worldPoint.y - finalHeight / 2
 
   const effectiveGrid = canvasStore.vistaActiva === 'XZ' ? 0 : (canvasStore.gridSize ?? GRID_SIZE)
   const snapped = snapToGrid(candX, candY, effectiveGrid)
@@ -1887,6 +1911,7 @@ const runPreDropValidations = (elemento, dropEvent) => {
   let finalPos = { x: candX, y: candY }
   const shouldTryNudge = blocking.length > 0 || (!isInside && boundary?.mode !== 'elastic')
   let ok = blocking.length === 0 && isInside
+  const maintainAspect = (elemento?.forma || '').toLowerCase() === 'circular'
 
   // Solo usar nudgePlace si hay conflictos de colisión o si quedó fuera del área en modo fijo
   if (shouldTryNudge) {
@@ -1913,12 +1938,54 @@ const runPreDropValidations = (elemento, dropEvent) => {
   }
 
   if (!ok) {
+    const dimensionSuggestion = buildDimensionSuggestion({
+      element: elemento,
+      vista: canvasStore.vistaActiva,
+      pointer: worldPoint,
+      areaBounds,
+      neighbors: all,
+      dimsPx: { width: finalWidth, height: finalHeight },
+      dimsCm: { ancho: anchoCm, largo: largoCm, alto: altoCm },
+      maintainAspect,
+    })
+
+    if (dimensionSuggestion) {
+      return {
+        ok: false,
+        reason: 'bounds',
+        reasonMessage: describePlacementFailure('bounds'),
+        suggestions: [dimensionSuggestion],
+        worldPoint: { ...worldPoint },
+      }
+    }
+
     showToast('No fue posible colocar el elemento dentro de los límites de la planta.', 'error')
     return { ok: false, reason: 'bounds' }
   }
 
   // Validación final: asegurar que la posición final sea válida con la misma lógica que drag
   if (!insideAreaModel(finalPos, { ...tempEl, x: finalPos.x, y: finalPos.y }, areaBounds, 0.5)) {
+    const dimensionSuggestion = buildDimensionSuggestion({
+      element: elemento,
+      vista: canvasStore.vistaActiva,
+      pointer: worldPoint,
+      areaBounds,
+      neighbors: all,
+      dimsPx: { width: finalWidth, height: finalHeight },
+      dimsCm: { ancho: anchoCm, largo: largoCm, alto: altoCm },
+      maintainAspect,
+    })
+
+    if (dimensionSuggestion) {
+      return {
+        ok: false,
+        reason: 'bounds',
+        reasonMessage: describePlacementFailure('bounds'),
+        suggestions: [dimensionSuggestion],
+        worldPoint: { ...worldPoint },
+      }
+    }
+
     showToast('El elemento quedaría fuera del área permitida.', 'error')
     return { ok: false, reason: 'bounds' }
   }
@@ -1932,15 +1999,11 @@ const runPreDropValidations = (elemento, dropEvent) => {
   }
 }
 
-const createElementFromDrop = (data, dropEvent) => {
-  const elemento = data.elemento
-  const res = runPreDropValidations(elemento, dropEvent)
-  if (!res.ok) return
-
-  let { ancho: anchoCm, largo: largoCm, alto: altoCm } = res.dimsCm
-  let finalWidth = res.width
-  let finalHeight = res.height
-  let finalPosition = res.position
+const finalizeDropPlacement = (elemento, placement) => {
+  let { ancho: anchoCm, largo: largoCm, alto: altoCm } = placement.dimsCm
+  let finalWidth = placement.width
+  let finalHeight = placement.height
+  let finalPosition = placement.position
 
   const color = elemento.color || elemento.colorBase || '#3B82F6'
 
@@ -1950,8 +2013,6 @@ const createElementFromDrop = (data, dropEvent) => {
     id: `${elemento.tipo || elemento.categoria || 'elemento'}_${Date.now()}`,
     tipo: elemento.tipo,
     categoria: elemento.categoria,
-    // Para pasillos: si vienen con nombre desde el catálogo, preservarlo;
-    // si no, dejar que el store genere el nombre por defecto.
     nombre: elemento.nombre || 'Nuevo elemento',
     dimensiones: { ancho: anchoCm, largo: largoCmFinal, alto: altoCm },
     x: finalPosition.x,
@@ -1975,6 +2036,57 @@ const createElementFromDrop = (data, dropEvent) => {
   }
   canvasStore.agregarElemento(nuevoElemento)
   canvasStore.seleccionarElemento(nuevoElemento.id)
+}
+
+const showPlacementSuggestionsForDrop = (elemento, result) => {
+  if (!Array.isArray(result.suggestions) || !result.suggestions.length) return
+  const elementClone = typeof structuredClone === 'function'
+    ? structuredClone(elemento)
+    : JSON.parse(JSON.stringify(elemento))
+
+  placementSuggestionStore.show({
+    title: `Ajustes sugeridos para ${elementClone.nombre || elementClone.tipo || 'el elemento'}`,
+    reasonMessage: result.reasonMessage || describePlacementFailure(result.reason),
+    suggestions: result.suggestions,
+    element: elementClone,
+    worldPoint: result.worldPoint,
+    onApply: async (state) => {
+      const nextElement = applyPlacementSuggestions(state.element, state.suggestions)
+      const retryRes = runPreDropValidations(nextElement, null, { worldPoint: state.worldPoint })
+      if (retryRes.ok) {
+        finalizeDropPlacement(nextElement, retryRes)
+        return { success: true }
+      }
+      if (Array.isArray(retryRes.suggestions) && retryRes.suggestions.length) {
+        return {
+          success: false,
+          nextState: {
+            element: nextElement,
+            suggestions: retryRes.suggestions,
+            reasonMessage: retryRes.reasonMessage || describePlacementFailure(retryRes.reason),
+            worldPoint: retryRes.worldPoint || state.worldPoint,
+          },
+        }
+      }
+      return {
+        success: false,
+        errorMessage: retryRes.reasonMessage || describePlacementFailure(retryRes.reason),
+      }
+    },
+  })
+}
+
+const createElementFromDrop = (data, dropEvent) => {
+  const elemento = data.elemento
+  const res = runPreDropValidations(elemento, dropEvent)
+  if (!res.ok) {
+    if (res.suggestions?.length) {
+      showPlacementSuggestionsForDrop(elemento, res)
+    }
+    return
+  }
+
+  finalizeDropPlacement(elemento, res)
 }
 
 const getElementShadow = (elemento) => {

--- a/src/inventory-smart/components/modals/PlacementSuggestionsModal.vue
+++ b/src/inventory-smart/components/modals/PlacementSuggestionsModal.vue
@@ -1,0 +1,96 @@
+<template>
+  <Teleport to="body">
+    <div v-if="isOpen" class="fixed inset-0 z-[1200] flex items-center justify-center">
+      <div class="absolute inset-0 bg-black/50" @click="handleCancel" />
+      <div class="relative bg-white rounded-2xl shadow-2xl max-w-xl w-full mx-4 p-6">
+        <header class="mb-4">
+          <h2 class="text-xl font-semibold text-slate-800">
+            {{ title }}
+          </h2>
+          <p v-if="reason" class="text-sm text-slate-500 mt-1">
+            {{ reason }}
+          </p>
+        </header>
+        <section class="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+          <article
+            v-for="suggestion in suggestions"
+            :key="suggestion.id"
+            class="border border-slate-200 rounded-xl p-4 bg-slate-50"
+          >
+            <h3 class="text-sm font-semibold text-slate-700 mb-2">
+              {{ suggestion.type === 'capacity' ? 'Capacidad' : 'Dimensiones' }}
+            </h3>
+            <p class="text-sm text-slate-600">
+              {{ suggestion.message }}
+            </p>
+            <dl v-if="suggestion.summary?.length" class="mt-3 space-y-2">
+              <div v-for="field in suggestion.summary" :key="field.key || field.label" class="flex justify-between text-sm">
+                <dt class="text-slate-500">{{ field.label }}</dt>
+                <dd class="text-slate-800 font-medium">
+                  <span class="line-through text-slate-400 mr-2">{{ formatValue(field.from, field.unit) }}</span>
+                  <span>{{ formatValue(field.to, field.unit) }}</span>
+                </dd>
+              </div>
+            </dl>
+          </article>
+          <p v-if="errorMessage" class="text-sm text-rose-600 bg-rose-50 border border-rose-200 rounded-lg p-3">
+            {{ errorMessage }}
+          </p>
+        </section>
+        <footer class="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg border border-slate-300 text-slate-600 hover:bg-slate-100 transition"
+            @click="handleCancel"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg bg-primary text-white hover:bg-primary/90 transition disabled:opacity-60 disabled:cursor-not-allowed"
+            :disabled="!hasSuggestions || processing"
+            @click="handleAccept"
+          >
+            {{ processing ? 'Aplicando…' : 'Aplicar y colocar' }}
+          </button>
+        </footer>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { usePlacementSuggestionStore } from '@/inventory-smart/stores/placementSuggestions'
+
+const store = usePlacementSuggestionStore()
+
+const isOpen = computed(() => store.open && store.hasSuggestions)
+const suggestions = computed(() => store.payload?.suggestions || [])
+const processing = computed(() => store.processing)
+const errorMessage = computed(() => store.errorMessage)
+const hasSuggestions = computed(() => store.hasSuggestions)
+const title = computed(() => store.payload?.title || 'Ajustes sugeridos para el elemento')
+const reason = computed(() => store.payload?.reasonMessage || '')
+
+const formatValue = (value, unit = '') => {
+  if (value == null) return '—'
+  const val = typeof value === 'number' ? value.toFixed(2).replace(/\.00$/, '') : value
+  return unit ? `${val} ${unit}` : String(val)
+}
+
+const handleCancel = () => {
+  store.close()
+}
+
+const handleAccept = async () => {
+  await store.accept()
+}
+</script>
+
+<style scoped>
+:focus-visible {
+  outline: 2px solid theme('colors.primary.DEFAULT');
+  outline-offset: 2px;
+}
+</style>

--- a/src/inventory-smart/stores/placementSuggestions.js
+++ b/src/inventory-smart/stores/placementSuggestions.js
@@ -1,0 +1,76 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export const usePlacementSuggestionStore = defineStore('placementSuggestions', () => {
+  const open = ref(false)
+  const payload = ref(null)
+  const processing = ref(false)
+  const errorMessage = ref('')
+
+  const hasSuggestions = computed(() => Array.isArray(payload.value?.suggestions) && payload.value.suggestions.length > 0)
+
+  const reset = () => {
+    open.value = false
+    payload.value = null
+    processing.value = false
+    errorMessage.value = ''
+  }
+
+  const show = (data) => {
+    payload.value = data
+    errorMessage.value = data?.errorMessage || ''
+    open.value = true
+  }
+
+  const close = () => {
+    reset()
+  }
+
+  const updateState = (nextState = {}) => {
+    payload.value = { ...payload.value, ...nextState }
+    if (typeof nextState.errorMessage === 'string') {
+      errorMessage.value = nextState.errorMessage
+    } else {
+      errorMessage.value = ''
+    }
+  }
+
+  const accept = async () => {
+    if (!payload.value?.onApply || typeof payload.value.onApply !== 'function') {
+      reset()
+      return { success: false }
+    }
+    processing.value = true
+    errorMessage.value = ''
+    try {
+      const result = await payload.value.onApply({ ...payload.value })
+      if (result?.success) {
+        reset()
+        return { success: true }
+      }
+      if (result?.nextState) {
+        updateState(result.nextState)
+        processing.value = false
+        return { success: false }
+      }
+      if (result?.errorMessage) {
+        errorMessage.value = result.errorMessage
+      }
+    } catch (err) {
+      errorMessage.value = err?.message || 'No se pudo aplicar los ajustes.'
+    }
+    processing.value = false
+    return { success: false }
+  }
+
+  return {
+    open,
+    payload,
+    processing,
+    errorMessage,
+    hasSuggestions,
+    show,
+    close,
+    accept,
+  }
+})

--- a/src/inventory-smart/utils/placementSuggestions.js
+++ b/src/inventory-smart/utils/placementSuggestions.js
@@ -1,0 +1,239 @@
+import { toPrecisionCm } from '@/inventory-smart/utils/fixedDimensions'
+import { formatLengthsCm } from '@/inventory-smart/utils/units'
+
+const MIN_SIZE_PX = 10
+const TOLERANCE_PX = 0.5
+const WEIGHT_DECIMALS = 2
+
+function rectLineOverlap(rangeStart, rangeEnd, value) {
+  return value > rangeStart && value < rangeEnd
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function roundWeight(value) {
+  if (!isFiniteNumber(value)) return value
+  const factor = Math.pow(10, WEIGHT_DECIMALS)
+  return Math.round((value + Number.EPSILON) * factor) / factor
+}
+
+function buildDimensionFields({
+  vista,
+  original,
+  updated,
+}) {
+  const fields = []
+  const labels = {
+    ancho: 'Ancho',
+    largo: vista === 'XZ' ? 'Profundidad' : 'Largo',
+    alto: 'Alto',
+  }
+  for (const key of ['ancho', 'largo', 'alto']) {
+    const from = original[key]
+    const to = updated[key]
+    if (!isFiniteNumber(from) || !isFiniteNumber(to)) continue
+    if (Math.abs(from - to) < 1e-3) continue
+    fields.push({
+      key,
+      label: labels[key],
+      from: toPrecisionCm(from),
+      to: toPrecisionCm(to),
+      unit: 'cm',
+    })
+  }
+  return fields
+}
+
+export function buildCapacitySuggestion({ element, validationResult }) {
+  if (!element) return null
+  const current = Number(element.capacidadCarga || 0)
+  const available = Number(validationResult?.capacidadCarga ?? 0) - Number(validationResult?.pesoActual ?? 0)
+  if (!isFiniteNumber(current) || !isFiniteNumber(available)) return null
+  if (available <= 0) return null
+  if (available + 1e-6 >= current) return null
+  const minUsage = Number(element?.uso?.peso ?? 0)
+  if (available < minUsage) return null
+
+  const suggested = roundWeight(Math.max(minUsage, available))
+  if (!isFiniteNumber(suggested) || suggested <= 0) return null
+
+  return {
+    id: 'capacity-adjustment',
+    type: 'capacity',
+    message: 'Reducir la capacidad del elemento para respetar el límite disponible.',
+    summary: [
+      {
+        label: 'Capacidad de carga',
+        from: roundWeight(current),
+        to: suggested,
+        unit: 'kg',
+      },
+    ],
+    patch: {
+      capacidadCarga: suggested,
+      uso: element?.uso?.peso > suggested ? { peso: suggested } : undefined,
+    },
+  }
+}
+
+export function buildDimensionSuggestion({
+  element,
+  vista,
+  pointer,
+  areaBounds,
+  neighbors,
+  dimsPx,
+  dimsCm,
+  maintainAspect = false,
+}) {
+  if (!element || !pointer || !dimsPx || !dimsCm || !areaBounds) return null
+  const width = Number(dimsPx.width || 0)
+  const height = Number(dimsPx.height || 0)
+  if (width <= 0 || height <= 0) return null
+
+  let leftLimit = areaBounds.minX ?? 0
+  let rightLimit = areaBounds.maxX ?? (leftLimit + width)
+  let topLimit = areaBounds.minY ?? 0
+  let bottomLimit = areaBounds.maxY ?? (topLimit + height)
+
+  const centerX = pointer.x
+  const centerY = pointer.y
+
+  const effectiveNeighbors = Array.isArray(neighbors) ? neighbors : []
+  for (const n of effectiveNeighbors) {
+    const nx = Number(n?.x)
+    const ny = Number(n?.y)
+    const nw = Number(n?.width || 0)
+    const nh = Number(n?.height || 0)
+    if (!isFiniteNumber(nx) || !isFiniteNumber(ny) || !isFiniteNumber(nw) || !isFiniteNumber(nh)) continue
+    const left = nx
+    const right = nx + nw
+    const top = ny
+    const bottom = ny + nh
+
+    if (rectLineOverlap(top - TOLERANCE_PX, bottom + TOLERANCE_PX, centerY)) {
+      if (right <= centerX) {
+        leftLimit = Math.max(leftLimit, right)
+      } else if (left >= centerX) {
+        rightLimit = Math.min(rightLimit, left)
+      }
+    }
+
+    if (rectLineOverlap(left - TOLERANCE_PX, right + TOLERANCE_PX, centerX)) {
+      if (bottom <= centerY) {
+        topLimit = Math.max(topLimit, bottom)
+      } else if (top >= centerY) {
+        bottomLimit = Math.min(bottomLimit, top)
+      }
+    }
+  }
+
+  const availableWidth = Math.max(0, rightLimit - leftLimit)
+  const availableHeight = Math.max(0, bottomLimit - topLimit)
+
+  const widthScale = width > 0 ? Math.min(1, availableWidth / width) : 1
+  const heightScale = height > 0 ? Math.min(1, availableHeight / height) : 1
+
+  let newWidth = width
+  let newHeight = height
+
+  if (maintainAspect) {
+    const aspectScale = Math.min(widthScale, heightScale)
+    if (aspectScale < 1) {
+      newWidth = Math.max(MIN_SIZE_PX, width * aspectScale)
+      newHeight = Math.max(MIN_SIZE_PX, height * aspectScale)
+    }
+  } else {
+    if (widthScale < 1) newWidth = Math.max(MIN_SIZE_PX, width * widthScale)
+    if (heightScale < 1) newHeight = Math.max(MIN_SIZE_PX, height * heightScale)
+  }
+
+  if (Math.abs(newWidth - width) < TOLERANCE_PX && Math.abs(newHeight - height) < TOLERANCE_PX) {
+    return null
+  }
+
+  const widthRatio = width > 0 ? newWidth / width : 1
+  const heightRatio = height > 0 ? newHeight / height : 1
+
+  const original = {
+    ancho: Number(dimsCm.ancho),
+    largo: Number(dimsCm.largo),
+    alto: Number(dimsCm.alto),
+  }
+
+  const updated = { ...original }
+  if (vista === 'XY') {
+    if (isFiniteNumber(updated.ancho)) updated.ancho = toPrecisionCm(updated.ancho * widthRatio)
+    if (isFiniteNumber(updated.largo)) updated.largo = toPrecisionCm(updated.largo * heightRatio)
+  } else if (vista === 'XZ') {
+    if (isFiniteNumber(updated.ancho)) updated.ancho = toPrecisionCm(updated.ancho * widthRatio)
+    if (isFiniteNumber(updated.alto)) updated.alto = toPrecisionCm(updated.alto * heightRatio)
+  } else {
+    if (isFiniteNumber(updated.largo)) updated.largo = toPrecisionCm(updated.largo * widthRatio)
+    if (isFiniteNumber(updated.alto)) updated.alto = toPrecisionCm(updated.alto * heightRatio)
+  }
+
+  const fields = buildDimensionFields({ vista, original, updated })
+  if (!fields.length) return null
+
+  const values = [updated.ancho, updated.largo, updated.alto].filter(isFiniteNumber)
+  const formattedValues = values.filter((v) => isFiniteNumber(v) && v > 0)
+  const formatted = formattedValues.length ? formatLengthsCm(formattedValues) : ''
+
+  return {
+    id: 'dimension-adjustment',
+    type: 'dimensions',
+    message: formatted
+      ? `Reducir dimensiones propuestas a ${formatted} para encajar en el espacio disponible.`
+      : 'Reducir dimensiones para encajar en el espacio disponible.',
+    summary: fields,
+    patch: {
+      dimensiones: updated,
+      width: newWidth,
+      height: newHeight,
+    },
+    maintainAspect,
+  }
+}
+
+export function applyPlacementSuggestions(element, suggestions = []) {
+  const next = structuredClone(element)
+  if (!Array.isArray(suggestions)) return next
+
+  for (const suggestion of suggestions) {
+    if (!suggestion?.patch) continue
+    if (suggestion.type === 'dimensions') {
+      const dimsPatch = suggestion.patch.dimensiones || {}
+      next.dimensiones = {
+        ...(next.dimensiones || {}),
+        ...dimsPatch,
+      }
+      if (isFiniteNumber(suggestion.patch.width)) next.width = suggestion.patch.width
+      if (isFiniteNumber(suggestion.patch.height)) next.height = suggestion.patch.height
+    } else if (suggestion.type === 'capacity') {
+      if (isFiniteNumber(suggestion.patch.capacidadCarga)) {
+        next.capacidadCarga = suggestion.patch.capacidadCarga
+      }
+      if (suggestion.patch.uso && typeof suggestion.patch.uso === 'object') {
+        next.uso = { ...(next.uso || {}), ...suggestion.patch.uso }
+      }
+    }
+  }
+
+  return next
+}
+
+export function describePlacementFailure(reason) {
+  if (reason === 'weight') return 'El elemento excede la capacidad disponible.'
+  if (reason === 'bounds') return 'El elemento no cabe en la posición seleccionada.'
+  return 'No se pudo colocar el elemento.'
+}
+
+export default {
+  buildCapacitySuggestion,
+  buildDimensionSuggestion,
+  applyPlacementSuggestions,
+  describePlacementFailure,
+}


### PR DESCRIPTION
## Summary
- add a placement suggestion modal so users can review and accept auto-adjustments when drop validations fail
- provide utilities and a Pinia store to calculate dimension/capacity suggestions and retry placement after applying them
- extend drop validation coverage to assert the new capacity adjustment suggestion path

## Testing
- npm run test:unit *(fails: suite has numerous pre-existing failing specs in this environment; see vitest output for details)*

------
https://chatgpt.com/codex/tasks/task_e_68e035b7e5048321a4dba8208665dca3