### PR TITLE
feat: add floating origin support

### DIFF
--- a/src/inventory-smart/__tests__/fit-to-planta.spec.js
+++ b/src/inventory-smart/__tests__/fit-to-planta.spec.js
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
+import { nextTick, defineComponent, h } from 'vue'
 import { useCanvasStore } from '@/inventory-smart/composables/useCanvasStore'
 
 vi.mock('vue-konva', () => ({ VueKonva: {}, default: { install: () => {} } }))
@@ -155,5 +156,253 @@ describe('fitToPlanta', () => {
     expect(scaleCall[0].y).toBeCloseTo(firstFit.scale)
     expect(positionCall[0].x).toBeCloseTo(firstFit.position.x)
     expect(positionCall[0].y).toBeCloseTo(firstFit.position.y)
+  })
+})
+
+describe('floating origin rebase integration', () => {
+  let originalRaf
+  let originalCancelRaf
+  let originalWindowRaf
+  let originalWindowCancelRaf
+
+  beforeEach(() => {
+    originalRaf = globalThis.requestAnimationFrame
+    originalCancelRaf = globalThis.cancelAnimationFrame
+    originalWindowRaf = typeof window !== 'undefined' ? window.requestAnimationFrame : undefined
+    originalWindowCancelRaf = typeof window !== 'undefined' ? window.cancelAnimationFrame : undefined
+    globalThis.requestAnimationFrame = (cb) => {
+      if (typeof cb === 'function') {
+        cb(16)
+      }
+      return 1
+    }
+    globalThis.cancelAnimationFrame = vi.fn()
+    if (typeof window !== 'undefined') {
+      window.requestAnimationFrame = globalThis.requestAnimationFrame
+      window.cancelAnimationFrame = globalThis.cancelAnimationFrame
+    }
+  })
+
+  afterEach(() => {
+    if (originalRaf) {
+      globalThis.requestAnimationFrame = originalRaf
+    } else {
+      delete globalThis.requestAnimationFrame
+    }
+    if (originalCancelRaf) {
+      globalThis.cancelAnimationFrame = originalCancelRaf
+    } else {
+      delete globalThis.cancelAnimationFrame
+    }
+    if (typeof window !== 'undefined') {
+      if (originalWindowRaf) {
+        window.requestAnimationFrame = originalWindowRaf
+      } else {
+        delete window.requestAnimationFrame
+      }
+      if (originalWindowCancelRaf) {
+        window.cancelAnimationFrame = originalWindowCancelRaf
+      } else {
+        delete window.cancelAnimationFrame
+      }
+    }
+    vi.useRealTimers()
+  })
+
+  it('rebases at most once per 300ms and keeps overlays aligned', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
+
+    const store = mockStore
+    store.plantas = [
+      {
+        id: 'planta_1',
+        nombre: 'Infinita',
+        isInfinite: true,
+        dimensiones: { ancho: 200000, largo: 200000 },
+      },
+    ]
+    store.plantaActiva = 'planta_1'
+    store.contextoNavegacion = { tipo: 'plantas', id: 'planta_1', path: [{ tipo: 'plantas', id: 'planta_1' }] }
+    store.canvasAdaptativo = {
+      width: 200000,
+      height: 200000,
+      escala: 1,
+      frame: { x: 0, y: 0, width: 200000, height: 200000 },
+    }
+    store.elementos = [
+      {
+        id: 'rack-1',
+        tipo: 'elementos',
+        forma: 'rectangular',
+        plantaId: 'planta_1',
+        x: 60010,
+        y: 40,
+        width: 80,
+        height: 40,
+        visible: true,
+        posicion: { x: 60010, y: 40 },
+      },
+    ]
+    store.zoom = 1
+    store.configurarPan(-59500, 0)
+
+    const layerCallLog = []
+    const stageNode = {
+      x: () => store.panX,
+      y: () => store.panY,
+      scaleX: () => store.zoom,
+      scaleY: () => store.zoom,
+      scale: vi.fn(),
+      position: vi.fn(),
+      batchDraw: vi.fn(),
+      findOne: vi.fn(() => null),
+    }
+    const layerNode = {
+      setAttr: vi.fn((key, value) => {
+        layerCallLog.push([key, value])
+      }),
+      getAttr: vi.fn(() => null),
+      clipFunc: vi.fn(),
+      batchDraw: vi.fn(),
+      clearCache: vi.fn(),
+    }
+    layerNode.getLayer = () => layerNode
+
+    const backgroundLayerNode = {
+      setAttr: vi.fn(),
+      getAttr: vi.fn(() => null),
+      clipFunc: vi.fn(),
+      batchDraw: vi.fn(),
+      clearCache: vi.fn(),
+    }
+    backgroundLayerNode.getLayer = () => backgroundLayerNode
+
+    const makeGenericLayerNode = () => {
+      const node = {
+        setAttr: vi.fn(),
+        getAttr: vi.fn(() => null),
+        clipFunc: vi.fn(),
+        batchDraw: vi.fn(),
+        clearCache: vi.fn(),
+      }
+      node.getLayer = () => node
+      return node
+    }
+
+    const layerNodes = [backgroundLayerNode, layerNode, makeGenericLayerNode(), makeGenericLayerNode(), makeGenericLayerNode()]
+    let layerIndex = 0
+
+    const StageComponentStub = defineComponent({
+      name: 'StageStub',
+      props: { config: { type: Object, default: () => ({}) } },
+      setup(props, { slots, expose }) {
+        expose({ getNode: () => stageNode })
+        return () => h('div', slots.default ? slots.default() : [])
+      },
+    })
+
+    const LayerComponentStub = defineComponent({
+      name: 'LayerStub',
+      props: { config: { type: Object, default: () => ({}) } },
+      setup(props, { slots, expose }) {
+        const node = layerNodes[layerIndex] || makeGenericLayerNode()
+        layerIndex += 1
+        expose({ getNode: () => node })
+        return () => h('div', slots.default ? slots.default() : [])
+      },
+    })
+
+    const wrapper = mount(CanvasView, {
+      global: {
+        provide: {
+          placementSuggestions: mockPlacementSuggestions,
+        },
+        stubs: {
+          'v-stage': StageComponentStub,
+          'v-layer': LayerComponentStub,
+        },
+      },
+    })
+
+    await nextTick()
+    await nextTick()
+
+    const setupState = wrapper.vm.$.setupState
+
+    if (!setupState.layerRef.value || typeof setupState.layerRef.value.getNode !== 'function') {
+      setupState.layerRef.value = { getNode: () => layerNode }
+    }
+    if (
+      !setupState.backgroundLayerRef.value ||
+      typeof setupState.backgroundLayerRef.value.getNode !== 'function'
+    ) {
+      setupState.backgroundLayerRef.value = { getNode: () => backgroundLayerNode }
+    }
+
+    expect(wrapper.vm.getStage()).toBe(stageNode)
+    expect(setupState.layerRef.value?.getNode?.()).toBe(layerNode)
+
+    wrapper.vm.stageSize.width = 1000
+    wrapper.vm.stageSize.height = 800
+
+    store.zoom = 1
+    store.configurarPan(-59500, 0)
+
+    await nextTick()
+
+    store.zoom = 1
+    store.configurarPan(-59500, 0)
+
+    const viewport = wrapper.vm.getViewportWorldRect()
+    expect(viewport).not.toBeNull()
+
+    wrapper.vm.startMarquee({ x: 60020, y: 50 })
+    wrapper.vm.updateMarquee({ x: 60080, y: 110 })
+    if (wrapper.vm.dragLastValidPositions?.value?.set) {
+      wrapper.vm.dragLastValidPositions.value.set('rack-1', { x: 60010, y: 40 })
+    }
+
+    await nextTick()
+
+    const originalShift = store.shiftWorldCoordinates
+    const shiftSpy = vi
+      .spyOn(store, 'shiftWorldCoordinates')
+      .mockImplementation((...args) => originalShift(...args))
+
+    const marqueeBefore = wrapper.vm.marqueeRect.x
+    const rebaseTriggered = wrapper.vm.ensureFloatingOrigin('spec')
+    await nextTick()
+
+    expect(shiftSpy).toHaveBeenCalledTimes(1)
+    expect(store.floatingOrigin.rebaseCount).toBe(1)
+    expect(store.floatingOrigin.telemetry.lastViewCenter.x).toBeCloseTo(60000, 0)
+    expect(store.floatingOrigin.telemetry.lastScale).toBeCloseTo(1, 5)
+    const shiftDelta = store.floatingOrigin.lastShift?.x || 0
+    expect(wrapper.vm.marqueeRect.x).toBeCloseTo(marqueeBefore - shiftDelta, 0)
+    expect(store.floatingOrigin.telemetry.rebasesPerMinute).toBeGreaterThanOrEqual(1)
+
+    const firstTimestamp = store.floatingOrigin.lastRebaseAt
+
+    store.configurarPan(-59500, 0)
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.100Z'))
+    const suppressed = wrapper.vm.ensureFloatingOrigin('cooldown')
+    await nextTick()
+    expect(suppressed).toBe(false)
+    expect(store.floatingOrigin.rebaseCount).toBe(1)
+    expect(shiftSpy).toHaveBeenCalledTimes(1)
+
+    store.panX = -59500
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.520Z'))
+    const secondRebase = wrapper.vm.ensureFloatingOrigin('after-cooldown')
+    await nextTick()
+    expect(secondRebase).toBe(true)
+    expect(store.floatingOrigin.rebaseCount).toBe(2)
+    expect(shiftSpy).toHaveBeenCalledTimes(2)
+    expect(store.floatingOrigin.lastRebaseAt - firstTimestamp).toBeGreaterThanOrEqual(300)
+
+    expect(layerCallLog.some(([key, value]) => key === 'floatingRebaseActive' && value === true)).toBe(true)
+
+    shiftSpy.mockRestore()
   })
 })

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -57,7 +57,8 @@
               closed: true,
               stroke: '#0ea5e9',
               fill: 'transparent',
-              strokeWidth: 2 / canvasStore.zoom,
+              strokeWidth: Math.max(0.75, 2 / Math.max(canvasStore.zoom || 1, 0.001)),
+              strokeScaleEnabled: false,
               listening: false,
             }"
           />
@@ -163,19 +164,26 @@
                 strokeWidth:
                   (elemento.tipo || '').toLowerCase() === 'pasillos'
                     ? showPasillosDash
-                      ? 1 / canvasStore.zoom
+                      ? Math.max(0.5, 1 / Math.max(canvasStore.zoom || 1, 0.001))
                       : 0
                     : (elemento.tipo || '').toLowerCase() === 'pisos'
-                      ? 1 / canvasStore.zoom
+                      ? Math.max(0.5, 1 / Math.max(canvasStore.zoom || 1, 0.001))
                       : 0,
                 dash:
                   (elemento.tipo || '').toLowerCase() === 'pasillos'
                     ? showPasillosDash
-                      ? [6 / canvasStore.zoom, 4 / canvasStore.zoom]
+                      ? [
+                          Math.max(3, 6 / Math.max(canvasStore.zoom || 1, 0.001)),
+                          Math.max(2, 4 / Math.max(canvasStore.zoom || 1, 0.001)),
+                        ]
                       : undefined
                     : (elemento.tipo || '').toLowerCase() === 'pisos'
-                      ? [6 / canvasStore.zoom, 4 / canvasStore.zoom]
+                      ? [
+                          Math.max(3, 6 / Math.max(canvasStore.zoom || 1, 0.001)),
+                          Math.max(2, 4 / Math.max(canvasStore.zoom || 1, 0.001)),
+                        ]
                       : undefined,
+                strokeScaleEnabled: false,
                 opacity: isElementLocked(elemento.id) ? 0.35 : 0.8,
                 shadowColor:
                   (elemento.tipo || '').toLowerCase() === 'pasillos'
@@ -556,9 +564,13 @@
             width: marqueeRect.width,
             height: marqueeRect.height,
             stroke: '#3b82f6',
-            strokeWidth: 2 / canvasStore.zoom,
+            strokeWidth: Math.max(0.75, 2 / Math.max(canvasStore.zoom || 1, 0.001)),
             fill: 'rgba(59, 130, 246, 0.1)',
-            dash: [4 / canvasStore.zoom, 4 / canvasStore.zoom],
+            dash: [
+              Math.max(2, 4 / Math.max(canvasStore.zoom || 1, 0.001)),
+              Math.max(2, 4 / Math.max(canvasStore.zoom || 1, 0.001)),
+            ],
+            strokeScaleEnabled: false,
             listening: false,
           }"
         />
@@ -594,7 +606,8 @@
               radius: 8 / canvasStore.zoom,
               fill: getUsageIndicatorColor(elemento),
               stroke: '#ffffff',
-              strokeWidth: 2 / canvasStore.zoom,
+              strokeWidth: Math.max(0.5, 2 / Math.max(canvasStore.zoom || 1, 0.001)),
+              strokeScaleEnabled: false,
               listening: false,
               opacity: 0.9,
             }"
@@ -924,6 +937,19 @@ const floatingOriginThreshold = computed(() => {
   if (!Number.isFinite(t) || t <= 0) return 50000
   return Math.max(1000, t)
 })
+const floatingOriginHysteresisRatio = computed(() => {
+  const raw = Number(floatingOriginState.value.hysteresisRatio)
+  if (!Number.isFinite(raw) || raw <= 0) return 0.08
+  return Math.min(0.1, Math.max(0.05, raw))
+})
+const floatingOriginTriggerDistance = computed(
+  () => floatingOriginThreshold.value * (1 + floatingOriginHysteresisRatio.value),
+)
+const floatingOriginCooldownMs = computed(() => {
+  const raw = Number(floatingOriginState.value.cooldownMs)
+  if (!Number.isFinite(raw) || raw <= 0) return 180
+  return Math.min(250, Math.max(150, Math.round(raw)))
+})
 
 const getViewState = () => {
   const zoom = canvasStore.zoom || 1
@@ -942,10 +968,12 @@ const getViewState = () => {
   }
 }
 
-const chooseAxisOffset = (current, candidate, threshold) => {
+const chooseAxisOffset = (current, candidate, threshold, triggerDistance) => {
   if (!Number.isFinite(candidate)) return current
-  if (Math.abs(candidate) <= threshold) return current
-  if (!Number.isFinite(current) || Math.abs(current) < 1) return candidate
+  const baseThreshold = Math.max(1, Number(threshold) || 0)
+  const limit = Number.isFinite(triggerDistance) && triggerDistance > 0 ? triggerDistance : baseThreshold
+  if (Math.abs(candidate) <= limit) return current
+  if (!Number.isFinite(current) || Math.abs(current) < baseThreshold) return candidate
   if (Math.abs(candidate) > Math.abs(current)) return candidate
   return current
 }
@@ -1134,7 +1162,8 @@ const elementosVisiblesEnCanvas = computed(() => {
   const viewY = -canvasStore.panY / zoom
   const viewW = stageWidth / zoom
   const viewH = stageHeight / zoom
-  const padding = 200 / zoom
+  const zoomSafe = zoom <= 0 ? 1 : zoom
+  const padding = Math.max(200 / zoomSafe, 120 / Math.max(zoomSafe, 0.35))
 
   const minX = viewX - padding
   const maxX = viewX + viewW + padding
@@ -1173,7 +1202,7 @@ const updateInfiniteClipRect = () => {
   const view = getViewState()
   const zoom = canvasStore.zoom || 1
   const safeZoom = zoom === 0 ? 1 : zoom
-  const expansion = 3 + Math.max(1, 1 / safeZoom)
+  const expansion = 2.5 + Math.max(1.5, 2 / safeZoom)
   const width = Math.max(1, view.width * expansion)
   const height = Math.max(1, view.height * expansion)
   const rect = {
@@ -1255,6 +1284,13 @@ watch(
   { flush: 'post' },
 )
 
+watch(
+  () => [floatingOriginState.value.offsetX, floatingOriginState.value.offsetY],
+  () => {
+    if (isInfinitePlant.value) updateInfiniteClipRect()
+  },
+)
+
 const elementPositionsSignature = computed(() =>
   elementosVisiblesEnCanvas.value
     .map((el) => {
@@ -1265,52 +1301,136 @@ const elementPositionsSignature = computed(() =>
     .join('|'),
 )
 
+const suspendInteractionsForRebase = () => {
+  const previousStageDrag = stageDragEnabled.value
+  const previousSnapping = isSnappingEnabled.value
+  const layer = layerRef.value?.getNode?.() || null
+  const transformerNode = transformerRef.value?.getNode?.() || null
+
+  try {
+    canvasStore.setFloatingOriginSuspended?.(true)
+  } catch {
+    /* ignore */
+  }
+
+  if (layer && typeof layer.setAttr === 'function') {
+    try {
+      layer.setAttr('floatingRebaseActive', true)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  stageDragEnabled.value = false
+  isSnappingEnabled.value = false
+
+  try {
+    transformerNode?.stopTransform?.()
+  } catch {
+    /* ignore */
+  }
+
+  const release = (options = {}) => {
+    const apply = () => {
+      stageDragEnabled.value = previousStageDrag
+      isSnappingEnabled.value = previousSnapping
+      try {
+        canvasStore.setFloatingOriginSuspended?.(false)
+      } catch {
+        /* ignore */
+      }
+      if (layer && typeof layer.setAttr === 'function') {
+        try {
+          layer.setAttr('floatingRebaseActive', false)
+        } catch {
+          /* ignore */
+        }
+      }
+      try {
+        transformerNode?.getLayer?.()?.batchDraw?.()
+      } catch {
+        /* ignore */
+      }
+    }
+
+    if (options?.immediate === true) {
+      apply()
+      return
+    }
+
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(apply)
+    } else {
+      setTimeout(apply, 16)
+    }
+  }
+
+  return release
+}
+
 const ensureFloatingOrigin = (reason = 'auto') => {
   const stage = stageRef.value?.getNode?.()
   const layer = layerRef.value?.getNode?.()
   if (!stage || !layer) return false
 
+  const now = Date.now()
+  const lastTimestamp = Number(
+    floatingOriginState.value.lastRebaseAt || floatingOriginState.value.lastShift?.timestamp || 0,
+  )
+  if (lastTimestamp && now - lastTimestamp < floatingOriginCooldownMs.value) {
+    return false
+  }
+
   const threshold = floatingOriginThreshold.value
+  const triggerDistance = floatingOriginTriggerDistance.value
   let offsetXCandidate = 0
   let offsetYCandidate = 0
 
   const view = getViewState()
-  offsetXCandidate = chooseAxisOffset(offsetXCandidate, view.centerX, threshold)
-  offsetYCandidate = chooseAxisOffset(offsetYCandidate, view.centerY, threshold)
+  offsetXCandidate = chooseAxisOffset(offsetXCandidate, view.centerX, threshold, triggerDistance)
+  offsetYCandidate = chooseAxisOffset(offsetYCandidate, view.centerY, threshold, triggerDistance)
 
   const selectedFull = canvasStore.elementoSeleccionadoCompleto
   if (selectedFull) {
     const centerX = (Number(selectedFull.x) || 0) + getDrawWidth(selectedFull) / 2
     const centerY = (Number(selectedFull.y) || 0) + getDrawHeight(selectedFull) / 2
-    offsetXCandidate = chooseAxisOffset(offsetXCandidate, centerX, threshold)
-    offsetYCandidate = chooseAxisOffset(offsetYCandidate, centerY, threshold)
+    offsetXCandidate = chooseAxisOffset(offsetXCandidate, centerX, threshold, triggerDistance)
+    offsetYCandidate = chooseAxisOffset(offsetYCandidate, centerY, threshold, triggerDistance)
   }
 
   const aura = canvasStore.elementoAura
   if (aura) {
     const auraCenterX = (Number(aura.x) || 0) + (Number(aura.width) || 0) / 2
     const auraCenterY = (Number(aura.y) || 0) + (Number(aura.height) || 0) / 2
-    offsetXCandidate = chooseAxisOffset(offsetXCandidate, auraCenterX, threshold)
-    offsetYCandidate = chooseAxisOffset(offsetYCandidate, auraCenterY, threshold)
+    offsetXCandidate = chooseAxisOffset(offsetXCandidate, auraCenterX, threshold, triggerDistance)
+    offsetYCandidate = chooseAxisOffset(offsetYCandidate, auraCenterY, threshold, triggerDistance)
   }
 
   if (isMarqueeActive.value) {
     const mx = marqueeRect.value.x + marqueeRect.value.width / 2
     const my = marqueeRect.value.y + marqueeRect.value.height / 2
-    offsetXCandidate = chooseAxisOffset(offsetXCandidate, mx, threshold)
-    offsetYCandidate = chooseAxisOffset(offsetYCandidate, my, threshold)
+    offsetXCandidate = chooseAxisOffset(offsetXCandidate, mx, threshold, triggerDistance)
+    offsetYCandidate = chooseAxisOffset(offsetYCandidate, my, threshold, triggerDistance)
   }
 
   dragLastValidPositions.value?.forEach((pos) => {
     if (!pos) return
-    if (Math.abs(pos.x ?? 0) > threshold) offsetXCandidate = chooseAxisOffset(offsetXCandidate, pos.x, threshold)
-    if (Math.abs(pos.y ?? 0) > threshold) offsetYCandidate = chooseAxisOffset(offsetYCandidate, pos.y, threshold)
+    if (Math.abs(pos.x ?? 0) > triggerDistance) {
+      offsetXCandidate = chooseAxisOffset(offsetXCandidate, pos.x, threshold, triggerDistance)
+    }
+    if (Math.abs(pos.y ?? 0) > triggerDistance) {
+      offsetYCandidate = chooseAxisOffset(offsetYCandidate, pos.y, threshold, triggerDistance)
+    }
   })
 
   for (const pos of boundLastWorldPos.values()) {
     if (!pos) continue
-    if (Math.abs(pos.x ?? 0) > threshold) offsetXCandidate = chooseAxisOffset(offsetXCandidate, pos.x, threshold)
-    if (Math.abs(pos.y ?? 0) > threshold) offsetYCandidate = chooseAxisOffset(offsetYCandidate, pos.y, threshold)
+    if (Math.abs(pos.x ?? 0) > triggerDistance) {
+      offsetXCandidate = chooseAxisOffset(offsetXCandidate, pos.x, threshold, triggerDistance)
+    }
+    if (Math.abs(pos.y ?? 0) > triggerDistance) {
+      offsetYCandidate = chooseAxisOffset(offsetYCandidate, pos.y, threshold, triggerDistance)
+    }
   }
 
   if (offsetXCandidate === 0 || offsetYCandidate === 0) {
@@ -1320,9 +1440,9 @@ const ensureFloatingOrigin = (reason = 'auto') => {
       const height = getDrawHeight(elemento) || 0
       const candidateX = (Number(elemento.x) || 0) + width / 2
       const candidateY = (Number(elemento.y) || 0) + height / 2
-      offsetXCandidate = chooseAxisOffset(offsetXCandidate, candidateX, threshold)
-      offsetYCandidate = chooseAxisOffset(offsetYCandidate, candidateY, threshold)
-      if (Math.abs(offsetXCandidate) > threshold && Math.abs(offsetYCandidate) > threshold) {
+      offsetXCandidate = chooseAxisOffset(offsetXCandidate, candidateX, threshold, triggerDistance)
+      offsetYCandidate = chooseAxisOffset(offsetYCandidate, candidateY, threshold, triggerDistance)
+      if (Math.abs(offsetXCandidate) > triggerDistance && Math.abs(offsetYCandidate) > triggerDistance) {
         break
       }
     }
@@ -1332,8 +1452,17 @@ const ensureFloatingOrigin = (reason = 'auto') => {
   const shiftY = Math.round(offsetYCandidate)
   if (Math.abs(shiftX) < 1 && Math.abs(shiftY) < 1) return false
 
-  const didShift = canvasStore.shiftWorldCoordinates(shiftX, shiftY, { reason })
-  if (!didShift) return false
+  const releaseInteractions = suspendInteractionsForRebase()
+
+  const didShift = canvasStore.shiftWorldCoordinates(shiftX, shiftY, {
+    reason,
+    scale: canvasStore.zoom || 1,
+    viewCenter: { x: view.centerX, y: view.centerY },
+  })
+  if (!didShift) {
+    releaseInteractions({ immediate: true })
+    return false
+  }
 
   try {
     shiftDragStateBy(shiftX, shiftY)
@@ -1363,6 +1492,7 @@ const ensureFloatingOrigin = (reason = 'auto') => {
 
   conflictsApi.clear()
   updateInfiniteClipRect()
+  releaseInteractions()
   return true
 }
 
@@ -1948,6 +2078,20 @@ const {
   computeBoundary,
 })
 
+const toWorldPoint = (stage, pointer) => {
+  if (!stage || !pointer) return { x: 0, y: 0 }
+  const stageX = typeof stage.x === 'function' ? stage.x() || 0 : Number(stage.x) || 0
+  const stageY = typeof stage.y === 'function' ? stage.y() || 0 : Number(stage.y) || 0
+  const scaleX = typeof stage.scaleX === 'function' ? stage.scaleX() || 1 : Number(stage.scaleX) || 1
+  const scaleY = typeof stage.scaleY === 'function' ? stage.scaleY() || 1 : Number(stage.scaleY) || 1
+  const safeScaleX = scaleX === 0 ? 1 : scaleX
+  const safeScaleY = scaleY === 0 ? 1 : scaleY
+  return {
+    x: (Number(pointer.x) - stageX) / safeScaleX,
+    y: (Number(pointer.y) - stageY) / safeScaleY,
+  }
+}
+
 // Función auxiliar para convertir coordenadas del puntero a coordenadas de mundo
 const getWorldCoordinatesFromPointer = (dropEvent) => {
   const stage = stageRef.value.getNode()
@@ -1964,10 +2108,7 @@ const getWorldCoordinatesFromPointer = (dropEvent) => {
   }
 
   // Convertir a coordenadas de mundo (layer) considerando transformación del stage
-  const worldX = (pointerPos.x - stage.x()) / stage.scaleX()
-  const worldY = (pointerPos.y - stage.y()) / stage.scaleY()
-
-  return { x: worldX, y: worldY }
+  return toWorldPoint(stage, pointerPos)
 }
 
 // Pipeline unificado de validaciones previas al drop
@@ -3586,16 +3727,27 @@ const getStageSizeSnapshot = () => ({
 
 const getViewportWorldRect = () => {
   const stage = getStageInstance()
-  if (!stage) return null
-  const scale = typeof stage.scaleX === 'function' ? stage.scaleX() || 1 : 1
-  if (!Number.isFinite(scale) || scale === 0) return null
-  const stageX = typeof stage.x === 'function' ? stage.x() || 0 : 0
-  const stageY = typeof stage.y === 'function' ? stage.y() || 0 : 0
+  if (stage) {
+    const scale = typeof stage.scaleX === 'function' ? stage.scaleX() || 1 : 1
+    if (Number.isFinite(scale) && scale !== 0) {
+      const stageX = typeof stage.x === 'function' ? stage.x() || 0 : 0
+      const stageY = typeof stage.y === 'function' ? stage.y() || 0 : 0
+      return {
+        minX: (0 - stageX) / scale,
+        minY: (0 - stageY) / scale,
+        maxX: (stageSize.value.width - stageX) / scale,
+        maxY: (stageSize.value.height - stageY) / scale,
+      }
+    }
+  }
+
+  const fallback = getViewState()
+  if (!fallback) return null
   return {
-    minX: (0 - stageX) / scale,
-    minY: (0 - stageY) / scale,
-    maxX: (stageSize.value.width - stageX) / scale,
-    maxY: (stageSize.value.height - stageY) / scale,
+    minX: fallback.x,
+    minY: fallback.y,
+    maxX: fallback.x + fallback.width,
+    maxY: fallback.y + fallback.height,
   }
 }
 

--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -41,31 +41,34 @@
       @dbltap="handleStageDoubleTap"
     >
       <v-layer ref="backgroundLayerRef" :config="{ listening: false }">
-        <!-- GridLayer DEBAJO de todo para que los elementos lo tapen -->
-        <GridLayer
-          v-if="canvasStore.gridVisible"
-          :scale="canvasStore.zoom"
-          :pixels-per-unit="10 * 100"
-          :unit="'m'"
-          :bbox="floorBoundary"
-        />
-        <v-line
-          v-if="plantPolygon.length && !isInfinitePlant"
-          :config="{
-            points: plantPolygonFlat,
-            closed: true,
-            stroke: '#0ea5e9',
-            fill: 'transparent',
-            strokeWidth: 2 / canvasStore.zoom,
-            listening: false,
-          }"
-        />
+        <v-group :config="worldBackgroundGroupConfig">
+          <!-- GridLayer DEBAJO de todo para que los elementos lo tapen -->
+          <GridLayer
+            v-if="canvasStore.gridVisible"
+            :scale="canvasStore.zoom"
+            :pixels-per-unit="10 * 100"
+            :unit="'m'"
+            :bbox="floorBoundary"
+          />
+          <v-line
+            v-if="plantPolygon.length && !isInfinitePlant"
+            :config="{
+              points: plantPolygonFlat,
+              closed: true,
+              stroke: '#0ea5e9',
+              fill: 'transparent',
+              strokeWidth: 2 / canvasStore.zoom,
+              listening: false,
+            }"
+          />
+        </v-group>
       </v-layer>
       <v-layer ref="layerRef">
-        <template v-if="canvasStore.elementoAura">
+        <v-group ref="worldGroupRef" :config="worldLayerGroupConfig">
           <v-rect
             v-if="
-              canvasStore.elementoAura.forma === 'rectangular' || !canvasStore.elementoAura.forma
+              canvasStore.elementoAura &&
+              (canvasStore.elementoAura.forma === 'rectangular' || !canvasStore.elementoAura.forma)
             "
             :config="{
               id: canvasStore.elementoAura.id,
@@ -78,10 +81,12 @@
               cornerRadius: 10,
               listening: false,
             }"
-          />
+          ></v-rect>
           <v-circle
-            v-else-if="
-              canvasStore.elementoAura.forma === 'circular' && canvasStore.vistaActiva === 'XY'
+            v-if="
+              canvasStore.elementoAura &&
+              canvasStore.elementoAura.forma === 'circular' &&
+              canvasStore.vistaActiva === 'XY'
             "
             :config="{
               id: canvasStore.elementoAura.id,
@@ -93,8 +98,7 @@
               cornerRadius: 10,
               listening: false,
             }"
-          />
-        </template>
+          ></v-circle>
 
         <!-- Renderizado de elementos del store -->
         <template v-for="elemento in elementosVisiblesEnCanvas" :key="elemento.id">
@@ -116,9 +120,9 @@
             @dragstart="(e) => handleShapeDragStart(e, elemento)"
             @dragmove="(e) => handleShapeDragMove(e, elemento)"
             @dragend="(e) => handleShapeDragEnd(e, elemento)"
-            @transformstart="(e) => handleTransformStart(e, elemento.id)"
-            @transform="(e) => handleTransformMove(e, elemento.id)"
-            @transformend="(e) => handleTransformEnd(e, elemento.id)"
+            @transformstart="(e) => handleTransformStartWrapper(e, elemento.id)"
+            @transform="(e) => handleTransformMoveWrapper(e, elemento.id)"
+            @transformend="(e) => handleTransformEndWrapper(e, elemento.id)"
             @contextmenu="(e) => onShapeContextMenu(e, elemento)"
             @pointerdown.passive="(e) => onShapePointerDown(e, elemento)"
             @pointerup.passive="onShapePointerUp"
@@ -256,9 +260,9 @@
             @dragstart="(e) => handleShapeDragStart(e, elemento)"
             @dragmove="(e) => handleShapeDragMove(e, elemento)"
             @dragend="(e) => handleShapeDragEnd(e, elemento)"
-            @transformstart="(e) => handleTransformStart(e, elemento.id)"
-            @transform="(e) => handleTransformMove(e, elemento.id)"
-            @transformend="(e) => handleTransformEnd(e, elemento.id)"
+            @transformstart="(e) => handleTransformStartWrapper(e, elemento.id)"
+            @transform="(e) => handleTransformMoveWrapper(e, elemento.id)"
+            @transformend="(e) => handleTransformEndWrapper(e, elemento.id)"
             @contextmenu="(e) => onShapeContextMenu(e, elemento)"
             @pointerdown.passive="(e) => onShapePointerDown(e, elemento)"
             @pointerup.passive="onShapePointerUp"
@@ -315,9 +319,9 @@
             @dragstart="(e) => handleShapeDragStart(e, elemento)"
             @dragmove="(e) => handleShapeDragMove(e, elemento)"
             @dragend="(e) => handleShapeDragEnd(e, elemento)"
-            @transformstart="(e) => handleTransformStart(e, elemento.id)"
-            @transform="(e) => handleTransformMove(e, elemento.id)"
-            @transformend="(e) => handleTransformEnd(e, elemento.id)"
+            @transformstart="(e) => handleTransformStartWrapper(e, elemento.id)"
+            @transform="(e) => handleTransformMoveWrapper(e, elemento.id)"
+            @transformend="(e) => handleTransformEndWrapper(e, elemento.id)"
             @contextmenu="(e) => onShapeContextMenu(e, elemento)"
             @pointerdown.passive="(e) => onShapePointerDown(e, elemento)"
             @pointerup.passive="onShapePointerUp"
@@ -446,6 +450,7 @@
 
           <!-- Etiqueta centrada por grupo aplicada; se elimina texto flotante anterior -->
         </template>
+        </v-group>
       </v-layer>
       <v-layer ref="uiLayerRef" :config="{ listening: false }">
         <!-- Debug: mostrar información según el contexto -->
@@ -734,7 +739,21 @@ const layerRef = ref(null)
 const backgroundLayerRef = ref(null)
 const overlaysLayerRef = ref(null)
 const indicatorsLayerRef = ref(null)
+const worldGroupRef = ref(null)
 const lastFitTarget = ref(null)
+
+const worldBackgroundGroupConfig = computed(() => ({
+  id: 'world-background',
+  listening: false,
+  x: 0,
+  y: 0,
+}))
+
+const worldLayerGroupConfig = computed(() => ({
+  id: 'world-root',
+  x: 0,
+  y: 0,
+}))
 
 // Estado de contacto y último pos para dragBound en plantas (memoria por elemento)
 const boundContactState = new Map()
@@ -779,7 +798,13 @@ const closeTemplateModal = () => {
 const dimensionValidation = useDimensionValidation()
 
 // Object snapping
-const { activeGuides: snapGuides, isSnapping, performSnap, clearGuides } = useObjectSnapping()
+const {
+  activeGuides: snapGuides,
+  isSnapping,
+  performSnap,
+  clearGuides,
+  shiftGuidesBy,
+} = useObjectSnapping()
 
 // Estado para controlar si el snapping está habilitado
 const isSnappingEnabled = ref(true)
@@ -794,6 +819,7 @@ const {
   endMarquee,
   cancelMarquee,
   stageToLayerCoords,
+  shiftMarqueeBy,
 } = useMarqueeSelection({ canvasStore, stageRef })
 
 // === HELPERS DE CONVERSIÓN ===
@@ -891,6 +917,38 @@ const stageConfig = computed(() => {
     draggable: !bloqueado && stageDragEnabled.value,
   }
 })
+
+const floatingOriginState = computed(() => canvasStore.floatingOrigin || {})
+const floatingOriginThreshold = computed(() => {
+  const t = Number(floatingOriginState.value.threshold)
+  if (!Number.isFinite(t) || t <= 0) return 50000
+  return Math.max(1000, t)
+})
+
+const getViewState = () => {
+  const zoom = canvasStore.zoom || 1
+  const safeZoom = zoom === 0 ? 1 : zoom
+  const width = stageSize.value.width / safeZoom
+  const height = stageSize.value.height / safeZoom
+  const x = -canvasStore.panX / safeZoom
+  const y = -canvasStore.panY / safeZoom
+  return {
+    x,
+    y,
+    width,
+    height,
+    centerX: x + width / 2,
+    centerY: y + height / 2,
+  }
+}
+
+const chooseAxisOffset = (current, candidate, threshold) => {
+  if (!Number.isFinite(candidate)) return current
+  if (Math.abs(candidate) <= threshold) return current
+  if (!Number.isFinite(current) || Math.abs(current) < 1) return candidate
+  if (Math.abs(candidate) > Math.abs(current)) return candidate
+  return current
+}
 
 const activeBounds = computed(() => getActiveBounds(canvasStore))
 const isInfinitePlant = computed(() => canvasStore.estaEnPlanta && canvasStore.plantaActivaData?.isInfinite === true)
@@ -1107,6 +1165,36 @@ const elementosVisiblesEnCanvas = computed(() => {
   })
 })
 
+const updateInfiniteClipRect = () => {
+  if (!isInfinitePlant.value) return
+  const layer = layerRef.value?.getNode?.()
+  const stage = stageRef.value?.getNode?.()
+  if (!layer || !stage) return
+  const view = getViewState()
+  const zoom = canvasStore.zoom || 1
+  const safeZoom = zoom === 0 ? 1 : zoom
+  const expansion = 3 + Math.max(1, 1 / safeZoom)
+  const width = Math.max(1, view.width * expansion)
+  const height = Math.max(1, view.height * expansion)
+  const rect = {
+    x: view.centerX - width / 2,
+    y: view.centerY - height / 2,
+    width,
+    height,
+  }
+  try {
+    layer.setAttr('floatingClipRect', rect)
+    layer.clipFunc((ctx) => {
+      const r = layer.getAttr('floatingClipRect') || rect
+      ctx.beginPath()
+      ctx.rect(r.x, r.y, Math.max(1, r.width), Math.max(1, r.height))
+    })
+  } catch {
+    /* ignore */
+  }
+  layer.batchDraw?.()
+}
+
 // Detectar si existen pasillos visibles y toggle para su borde punteado
 const hasPasillos = computed(() =>
   elementosVisiblesEnCanvas.value.some((e) => (e.tipo || '').toLowerCase() === 'pasillos'),
@@ -1119,13 +1207,20 @@ watch(
     const layer = layerRef.value?.getNode?.()
     if (!layer) return
 
-    if (infinite || !poly?.length) {
+    if (infinite) {
       try {
         layer.clipFunc(null)
-        if (typeof layer.clipWidth === 'function') layer.clipWidth(null)
-        if (typeof layer.clipHeight === 'function') layer.clipHeight(null)
-        if (typeof layer.clipX === 'function') layer.clipX(0)
-        if (typeof layer.clipY === 'function') layer.clipY(0)
+      } catch {
+        /* ignore */
+      }
+      updateInfiniteClipRect()
+      return
+    }
+
+    if (!Array.isArray(poly) || !poly.length) {
+      try {
+        layer.clipFunc(null)
+        layer.setAttr?.('floatingClipRect', null)
       } catch {
         /* ignore */
       }
@@ -1133,15 +1228,196 @@ watch(
       return
     }
 
-    layer.clipFunc((ctx) => {
-      ctx.beginPath()
-      poly.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)))
-      ctx.closePath()
-    })
+    const safePoly = poly.map((p) => ({ x: Number(p?.x) || 0, y: Number(p?.y) || 0 }))
+    try {
+      layer.setAttr?.('floatingClipRect', null)
+      layer.clipFunc((ctx) => {
+        ctx.beginPath()
+        safePoly.forEach((pt, index) => {
+          if (index === 0) ctx.moveTo(pt.x, pt.y)
+          else ctx.lineTo(pt.x, pt.y)
+        })
+        ctx.closePath()
+      })
+    } catch {
+      /* ignore */
+    }
     layer.batchDraw?.()
   },
   { immediate: true, deep: true },
 )
+
+watch(
+  () => [canvasStore.panX, canvasStore.panY, canvasStore.zoom, stageSize.value.width, stageSize.value.height, isInfinitePlant.value],
+  () => {
+    if (isInfinitePlant.value) updateInfiniteClipRect()
+  },
+  { flush: 'post' },
+)
+
+const elementPositionsSignature = computed(() =>
+  elementosVisiblesEnCanvas.value
+    .map((el) => {
+      const x = Math.round(Number(el?.x) || 0)
+      const y = Math.round(Number(el?.y) || 0)
+      return `${el?.id ?? ''}:${x}:${y}`
+    })
+    .join('|'),
+)
+
+const ensureFloatingOrigin = (reason = 'auto') => {
+  const stage = stageRef.value?.getNode?.()
+  const layer = layerRef.value?.getNode?.()
+  if (!stage || !layer) return false
+
+  const threshold = floatingOriginThreshold.value
+  let offsetXCandidate = 0
+  let offsetYCandidate = 0
+
+  const view = getViewState()
+  offsetXCandidate = chooseAxisOffset(offsetXCandidate, view.centerX, threshold)
+  offsetYCandidate = chooseAxisOffset(offsetYCandidate, view.centerY, threshold)
+
+  const selectedFull = canvasStore.elementoSeleccionadoCompleto
+  if (selectedFull) {
+    const centerX = (Number(selectedFull.x) || 0) + getDrawWidth(selectedFull) / 2
+    const centerY = (Number(selectedFull.y) || 0) + getDrawHeight(selectedFull) / 2
+    offsetXCandidate = chooseAxisOffset(offsetXCandidate, centerX, threshold)
+    offsetYCandidate = chooseAxisOffset(offsetYCandidate, centerY, threshold)
+  }
+
+  const aura = canvasStore.elementoAura
+  if (aura) {
+    const auraCenterX = (Number(aura.x) || 0) + (Number(aura.width) || 0) / 2
+    const auraCenterY = (Number(aura.y) || 0) + (Number(aura.height) || 0) / 2
+    offsetXCandidate = chooseAxisOffset(offsetXCandidate, auraCenterX, threshold)
+    offsetYCandidate = chooseAxisOffset(offsetYCandidate, auraCenterY, threshold)
+  }
+
+  if (isMarqueeActive.value) {
+    const mx = marqueeRect.value.x + marqueeRect.value.width / 2
+    const my = marqueeRect.value.y + marqueeRect.value.height / 2
+    offsetXCandidate = chooseAxisOffset(offsetXCandidate, mx, threshold)
+    offsetYCandidate = chooseAxisOffset(offsetYCandidate, my, threshold)
+  }
+
+  dragLastValidPositions.value?.forEach((pos) => {
+    if (!pos) return
+    if (Math.abs(pos.x ?? 0) > threshold) offsetXCandidate = chooseAxisOffset(offsetXCandidate, pos.x, threshold)
+    if (Math.abs(pos.y ?? 0) > threshold) offsetYCandidate = chooseAxisOffset(offsetYCandidate, pos.y, threshold)
+  })
+
+  for (const pos of boundLastWorldPos.values()) {
+    if (!pos) continue
+    if (Math.abs(pos.x ?? 0) > threshold) offsetXCandidate = chooseAxisOffset(offsetXCandidate, pos.x, threshold)
+    if (Math.abs(pos.y ?? 0) > threshold) offsetYCandidate = chooseAxisOffset(offsetYCandidate, pos.y, threshold)
+  }
+
+  if (offsetXCandidate === 0 || offsetYCandidate === 0) {
+    for (const elemento of elementosVisiblesEnCanvas.value) {
+      if (!elemento) continue
+      const width = getDrawWidth(elemento) || 0
+      const height = getDrawHeight(elemento) || 0
+      const candidateX = (Number(elemento.x) || 0) + width / 2
+      const candidateY = (Number(elemento.y) || 0) + height / 2
+      offsetXCandidate = chooseAxisOffset(offsetXCandidate, candidateX, threshold)
+      offsetYCandidate = chooseAxisOffset(offsetYCandidate, candidateY, threshold)
+      if (Math.abs(offsetXCandidate) > threshold && Math.abs(offsetYCandidate) > threshold) {
+        break
+      }
+    }
+  }
+
+  const shiftX = Math.round(offsetXCandidate)
+  const shiftY = Math.round(offsetYCandidate)
+  if (Math.abs(shiftX) < 1 && Math.abs(shiftY) < 1) return false
+
+  const didShift = canvasStore.shiftWorldCoordinates(shiftX, shiftY, { reason })
+  if (!didShift) return false
+
+  try {
+    shiftDragStateBy(shiftX, shiftY)
+    shiftGuidesBy(shiftX, shiftY)
+    shiftMarqueeBy(shiftX, shiftY)
+  } catch {
+    /* ignore */
+  }
+
+  boundLastWorldPos.forEach((pos, key) => {
+    if (!pos || typeof pos !== 'object') return
+    const next = { ...pos }
+    if (Number.isFinite(Number(next.x))) next.x = Number(next.x) - shiftX
+    if (Number.isFinite(Number(next.y))) next.y = Number(next.y) - shiftY
+    boundLastWorldPos.set(key, next)
+  })
+
+  try {
+    layer.clearCache?.()
+    layer.batchDraw?.()
+  } catch {
+    /* ignore */
+  }
+  const bgLayer = backgroundLayerRef.value?.getNode?.()
+  bgLayer?.batchDraw?.()
+  stage.batchDraw?.()
+
+  conflictsApi.clear()
+  updateInfiniteClipRect()
+  return true
+}
+
+let pendingFloatingOriginCheck = false
+let pendingFloatingOriginReason = 'auto'
+
+const runFloatingOriginCheck = () => {
+  pendingFloatingOriginCheck = false
+  const reason = pendingFloatingOriginReason
+  pendingFloatingOriginReason = 'auto'
+  try {
+    ensureFloatingOrigin(reason)
+  } catch (err) {
+    console.warn('Floating origin update failed', err)
+  }
+}
+
+const scheduleFloatingOriginCheck = (reason = 'auto') => {
+  pendingFloatingOriginReason = reason
+  if (pendingFloatingOriginCheck) return
+  pendingFloatingOriginCheck = true
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(runFloatingOriginCheck)
+  } else {
+    setTimeout(runFloatingOriginCheck, 16)
+  }
+}
+
+watch(elementPositionsSignature, () => scheduleFloatingOriginCheck('elements'))
+watch(
+  () => [canvasStore.panX, canvasStore.panY, canvasStore.zoom],
+  () => scheduleFloatingOriginCheck('view'),
+)
+watch(
+  () => [stageSize.value.width, stageSize.value.height],
+  () => scheduleFloatingOriginCheck('resize'),
+)
+watch(
+  () => floatingOriginThreshold.value,
+  () => scheduleFloatingOriginCheck('threshold'),
+)
+watch(
+  () => canvasStore.elementoAura,
+  () => scheduleFloatingOriginCheck('aura'),
+  { deep: true },
+)
+watch(
+  () =>
+    isMarqueeActive.value
+      ? [marqueeRect.value.x, marqueeRect.value.y, marqueeRect.value.width, marqueeRect.value.height]
+      : null,
+  () => scheduleFloatingOriginCheck('marquee'),
+)
+
+watch(isInfinitePlant, () => scheduleFloatingOriginCheck('mode'))
 
 // Contorno activo siempre expresado como polígono
 const computeBoundary = () => {
@@ -1623,6 +1899,7 @@ const {
   onShapeDragEnd,
   registerDraggableRef,
   innerSessions,
+  shiftDragStateBy,
 } = useElementDrag({
   canvasStore,
   stageRef,
@@ -2901,6 +3178,8 @@ onMounted(async () => {
   document.addEventListener('touchdragstart', handleTouchDragStart)
   document.addEventListener('touchdragover', handleTouchDragOver)
   document.addEventListener('touchdrop', handleTouchDrop)
+
+  scheduleFloatingOriginCheck('init')
 })
 
 onUnmounted(() => {
@@ -3236,11 +3515,28 @@ const handleShapeDragStart = (evt, elemento) => {
 const handleShapeDragMove = (evt, elemento) => {
   if (!canDragElement(elemento) || !canStartDrag(elemento)) return
   onShapeDragMove(evt, elemento)
+  scheduleFloatingOriginCheck('drag')
 }
 
 const handleShapeDragEnd = (evt, elemento) => {
   if (!canDragElement(elemento)) return
   onShapeDragEnd(evt, elemento)
+  scheduleFloatingOriginCheck('drag')
+}
+
+const handleTransformStartWrapper = (evt, elementoId) => {
+  handleTransformStart(evt, elementoId)
+  scheduleFloatingOriginCheck('transform')
+}
+
+const handleTransformMoveWrapper = (evt, elementoId) => {
+  handleTransformMove(evt, elementoId)
+  scheduleFloatingOriginCheck('transform')
+}
+
+const handleTransformEndWrapper = (evt, elementoId) => {
+  handleTransformEnd(evt, elementoId)
+  scheduleFloatingOriginCheck('transform')
 }
 
 // Acción bloquear/desbloquear desde el menú contextual
@@ -3307,6 +3603,8 @@ defineExpose({
   getStage: getStageInstance,
   getStageSize: getStageSizeSnapshot,
   getViewportWorldRect,
+  ensureFloatingOrigin,
+  scheduleFloatingOriginCheck,
 })
 </script>
 

--- a/src/inventory-smart/composables/useCacheOnDrag.js
+++ b/src/inventory-smart/composables/useCacheOnDrag.js
@@ -20,6 +20,17 @@ export function useCacheOnDrag(refNode) {
     try {
       if (isPlantInfinite()) return
 
+      const layer = node?.getLayer?.()
+      if (layer && typeof layer.getAttr === 'function') {
+        try {
+          if (layer.getAttr('floatingRebaseActive')) {
+            return
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+
       // Obtener dimensiones del nodo para ajustar el cache
       if (node && node.cache) {
         const width = typeof node.width === 'function' ? node.width() : (node.width || 0)

--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -256,18 +256,36 @@ export const useCanvasStore = defineStore('canvas', () => {
   const plantaEnEdicion = ref(null)
   const panX = ref(0)
   const panY = ref(0)
+  const createFloatingOriginTelemetry = () => ({
+    windowStart: Date.now(),
+    rebasesInWindow: 0,
+    rebasesPerMinute: 0,
+    lastOrigin: { x: 0, y: 0 },
+    lastScale: 1,
+    lastViewCenter: { x: 0, y: 0 },
+  })
+
   const floatingOrigin = reactive({
     offsetX: 0,
     offsetY: 0,
     threshold: 50000,
+    hysteresisRatio: 0.08,
+    cooldownMs: 180,
     rebaseCount: 0,
     lastShift: null,
+    lastRebaseAt: 0,
+    interactionsSuspended: false,
+    telemetry: createFloatingOriginTelemetry(),
   })
 
   const setFloatingOriginThreshold = (value) => {
     const v = Number(value)
     if (!Number.isFinite(v) || v <= 0) return
     floatingOrigin.threshold = Math.max(1000, Math.round(v))
+  }
+
+  const setFloatingOriginSuspended = (value) => {
+    floatingOrigin.interactionsSuspended = value === true
   }
 
   const elementoDestacadoId = ref(null)
@@ -1254,11 +1272,38 @@ const calcularCanvasAdaptativo = (elemento) => {
     floatingOrigin.offsetX += deltaX
     floatingOrigin.offsetY += deltaY
     floatingOrigin.rebaseCount += 1
+    const now = Date.now()
+    floatingOrigin.lastRebaseAt = now
     floatingOrigin.lastShift = {
       x: deltaX,
       y: deltaY,
       reason: metadata?.reason || 'manual',
-      timestamp: Date.now(),
+      timestamp: now,
+      scale: Number(metadata?.scale) || Number(zoom.value) || 1,
+      origin: metadata?.viewCenter && Number.isFinite(metadata.viewCenter.x)
+        ? { x: Number(metadata.viewCenter.x), y: Number(metadata.viewCenter.y) }
+        : null,
+    }
+
+    if (floatingOrigin.telemetry) {
+      const tele = floatingOrigin.telemetry
+      if (!tele.windowStart || now - tele.windowStart > 60000) {
+        tele.windowStart = now
+        tele.rebasesInWindow = 0
+      }
+      tele.rebasesInWindow = (tele.rebasesInWindow || 0) + 1
+      const elapsed = Math.max(1, now - tele.windowStart)
+      tele.rebasesPerMinute = Math.round((tele.rebasesInWindow * 60000) / elapsed)
+      tele.lastOrigin = { x: floatingOrigin.offsetX, y: floatingOrigin.offsetY }
+      const candidateScale = Number(metadata?.scale)
+      if (Number.isFinite(candidateScale) && candidateScale > 0) {
+        tele.lastScale = candidateScale
+      } else if (!Number.isFinite(tele.lastScale) || tele.lastScale <= 0) {
+        tele.lastScale = 1
+      }
+      if (metadata?.viewCenter && Number.isFinite(metadata.viewCenter.x) && Number.isFinite(metadata.viewCenter.y)) {
+        tele.lastViewCenter = { x: Number(metadata.viewCenter.x), y: Number(metadata.viewCenter.y) }
+      }
     }
 
     return true
@@ -1905,6 +1950,11 @@ const calcularCanvasAdaptativo = (elemento) => {
     floatingOrigin.offsetY = 0
     floatingOrigin.rebaseCount = 0
     floatingOrigin.lastShift = null
+    floatingOrigin.lastRebaseAt = 0
+    floatingOrigin.interactionsSuspended = false
+    if (floatingOrigin.telemetry) {
+      Object.assign(floatingOrigin.telemetry, createFloatingOriginTelemetry())
+    }
 
     try {
       const storeActions = {
@@ -3088,6 +3138,7 @@ const calcularCanvasAdaptativo = (elemento) => {
     configurarZoom,
     configurarPan,
     setFloatingOriginThreshold,
+    setFloatingOriginSuspended,
     shiftWorldCoordinates,
     setGridSize,
     setSnapGridEps,

--- a/src/inventory-smart/composables/useCanvasStore.js
+++ b/src/inventory-smart/composables/useCanvasStore.js
@@ -18,7 +18,7 @@ import { resolvePasilloAssignment, PASILLO_ASSIGNMENT_DEFAULTS } from '@/invento
  */
 
 import { defineStore } from 'pinia'
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, reactive } from 'vue'
 import { CM_TO_PX, DEFAULT_TIPOS_PRODUCTO_ADMITIDOS, CATALOGO, OFFSETS, TIPOS_ENTIDAD } from '@/inventory-smart/utils/constants'
 import { computeDimsByAxisScale, toCanvasSizePx } from '@/inventory-smart/utils/dimensionPolicy'
 import { useToast } from '@/inventory-smart/composables/useToast'
@@ -256,6 +256,19 @@ export const useCanvasStore = defineStore('canvas', () => {
   const plantaEnEdicion = ref(null)
   const panX = ref(0)
   const panY = ref(0)
+  const floatingOrigin = reactive({
+    offsetX: 0,
+    offsetY: 0,
+    threshold: 50000,
+    rebaseCount: 0,
+    lastShift: null,
+  })
+
+  const setFloatingOriginThreshold = (value) => {
+    const v = Number(value)
+    if (!Number.isFinite(v) || v <= 0) return
+    floatingOrigin.threshold = Math.max(1000, Math.round(v))
+  }
 
   const elementoDestacadoId = ref(null)
   const idsElementosFiltrados = ref(null)
@@ -1165,6 +1178,92 @@ const calcularCanvasAdaptativo = (elemento) => {
     }
   }
 
+  const shiftWorldCoordinates = (dx = 0, dy = 0, metadata = {}) => {
+    const deltaX = Number(dx) || 0
+    const deltaY = Number(dy) || 0
+    if (!Number.isFinite(deltaX) || !Number.isFinite(deltaY)) return false
+    if (Math.abs(deltaX) < 1e-6 && Math.abs(deltaY) < 1e-6) return false
+
+    const shiftNumber = (value, delta) => {
+      const num = Number(value)
+      if (!Number.isFinite(num)) return value
+      const next = num - delta
+      return Math.abs(next) < 1e-6 ? 0 : next
+    }
+
+    const shiftPointInPlace = (point) => {
+      if (!point || typeof point !== 'object') return
+      if (point.x != null) point.x = shiftNumber(point.x, deltaX)
+      if (point.y != null) point.y = shiftNumber(point.y, deltaY)
+    }
+
+    const shiftRectLike = (rect) => {
+      if (!rect || typeof rect !== 'object') return
+      if (rect.x != null) rect.x = shiftNumber(rect.x, deltaX)
+      if (rect.y != null) rect.y = shiftNumber(rect.y, deltaY)
+      if (rect.minX != null) rect.minX = shiftNumber(rect.minX, deltaX)
+      if (rect.minY != null) rect.minY = shiftNumber(rect.minY, deltaY)
+      if (rect.maxX != null) rect.maxX = shiftNumber(rect.maxX, deltaX)
+      if (rect.maxY != null) rect.maxY = shiftNumber(rect.maxY, deltaY)
+    }
+
+    for (const el of elementos.value) {
+      if (!el || typeof el !== 'object') continue
+      if (el.x != null) el.x = shiftNumber(el.x, deltaX)
+      if (el.y != null) el.y = shiftNumber(el.y, deltaY)
+      if (el.posicion && typeof el.posicion === 'object') {
+        if (el.posicion.x != null) el.posicion.x = shiftNumber(el.posicion.x, deltaX)
+        if (el.posicion.y != null) el.posicion.y = shiftNumber(el.posicion.y, deltaY)
+      }
+      if (Array.isArray(el.poligono)) {
+        el.poligono.forEach(shiftPointInPlace)
+      }
+      if (Array.isArray(el.polygon)) {
+        el.polygon.forEach(shiftPointInPlace)
+      }
+      if (Array.isArray(el.vertices)) {
+        el.vertices.forEach(shiftPointInPlace)
+      }
+      if (el.boundingBox) shiftRectLike(el.boundingBox)
+      if (el.previewBounds) shiftRectLike(el.previewBounds)
+    }
+
+    for (const planta of plantas.value) {
+      if (!planta || typeof planta !== 'object') continue
+      if (Array.isArray(planta.poligono)) planta.poligono.forEach(shiftPointInPlace)
+      if (planta.frame) shiftRectLike(planta.frame)
+    }
+
+    if (canvasAdaptativo.value) {
+      const adapt = canvasAdaptativo.value
+      if (adapt.originX != null) adapt.originX = shiftNumber(adapt.originX, deltaX)
+      if (adapt.originY != null) adapt.originY = shiftNumber(adapt.originY, deltaY)
+      if (adapt.frame) shiftRectLike(adapt.frame)
+    }
+
+    if (elementoAura.value) {
+      elementoAura.value = {
+        ...elementoAura.value,
+        x: shiftNumber(elementoAura.value.x, deltaX),
+        y: shiftNumber(elementoAura.value.y, deltaY),
+      }
+    }
+
+    configurarPan(panX.value + deltaX, panY.value + deltaY)
+
+    floatingOrigin.offsetX += deltaX
+    floatingOrigin.offsetY += deltaY
+    floatingOrigin.rebaseCount += 1
+    floatingOrigin.lastShift = {
+      x: deltaX,
+      y: deltaY,
+      reason: metadata?.reason || 'manual',
+      timestamp: Date.now(),
+    }
+
+    return true
+  }
+
   // Actions para plantas
   const seleccionarPlanta = (plantaId) => {
     // Limpiar timer de zoom/pan
@@ -1801,6 +1900,11 @@ const calcularCanvasAdaptativo = (elemento) => {
     }
     const prevZoom = zoom.value
     const prevPan = { x: panX.value, y: panY.value }
+
+    floatingOrigin.offsetX = 0
+    floatingOrigin.offsetY = 0
+    floatingOrigin.rebaseCount = 0
+    floatingOrigin.lastShift = null
 
     try {
       const storeActions = {
@@ -2923,6 +3027,7 @@ const calcularCanvasAdaptativo = (elemento) => {
     zoom,
     panX,
     panY,
+    floatingOrigin,
     gridSize,
     gridVisible,
     snapGridEps,
@@ -2982,6 +3087,8 @@ const calcularCanvasAdaptativo = (elemento) => {
     persist,
     configurarZoom,
     configurarPan,
+    setFloatingOriginThreshold,
+    shiftWorldCoordinates,
     setGridSize,
     setSnapGridEps,
     toggleGridVisible,

--- a/src/inventory-smart/composables/useElementDrag.js
+++ b/src/inventory-smart/composables/useElementDrag.js
@@ -821,6 +821,9 @@ export function useElementDrag({
   }
 
   const onShapeDragMove = (e, el) => {
+    if (canvasStore.floatingOrigin?.interactionsSuspended) {
+      return
+    }
     const data = innerSessions.get(el.id)
     if (data) {
       const { session, parent } = data

--- a/src/inventory-smart/composables/useElementDrag.js
+++ b/src/inventory-smart/composables/useElementDrag.js
@@ -934,6 +934,41 @@ export function useElementDrag({
     }
   }
 
+  const shiftMapPositions = (map, deltaX, deltaY) => {
+    if (!map || typeof map.forEach !== 'function') return
+    map.forEach((pos, key) => {
+      if (!pos || typeof pos !== 'object') return
+      const next = { ...pos }
+      if (next.x != null && Number.isFinite(Number(next.x))) {
+        next.x = Number(next.x) - deltaX
+      }
+      if (next.y != null && Number.isFinite(Number(next.y))) {
+        next.y = Number(next.y) - deltaY
+      }
+      map.set(key, next)
+    })
+  }
+
+  const shiftDragStateBy = (dx = 0, dy = 0) => {
+    const deltaX = Number(dx) || 0
+    const deltaY = Number(dy) || 0
+    if (!Number.isFinite(deltaX) || !Number.isFinite(deltaY)) return
+    if (Math.abs(deltaX) < 1e-6 && Math.abs(deltaY) < 1e-6) return
+    shiftMapPositions(dragStartPositions.value, deltaX, deltaY)
+    shiftMapPositions(lastValidPositions.value, deltaX, deltaY)
+    shiftMapPositions(lastDesiredPosMap.value, deltaX, deltaY)
+    innerSessions.forEach((session) => {
+      if (session && session.initial) {
+        if (session.initial.x != null && Number.isFinite(Number(session.initial.x))) {
+          session.initial.x = Number(session.initial.x) - deltaX
+        }
+        if (session.initial.y != null && Number.isFinite(Number(session.initial.y))) {
+          session.initial.y = Number(session.initial.y) - deltaY
+        }
+      }
+    })
+  }
+
   return {
     // Refs
     isElementDragging,
@@ -950,6 +985,7 @@ export function useElementDrag({
     onShapeDragMove,
     onShapeDragEnd,
     registerDraggableRef,
+    shiftDragStateBy,
 
     // Utils
     scheduleDraw,

--- a/src/inventory-smart/composables/useMarqueeSelection.js
+++ b/src/inventory-smart/composables/useMarqueeSelection.js
@@ -99,6 +99,20 @@ export function useMarqueeSelection({ canvasStore, stageRef }) {
     selectedElementIds.value.clear()
   }
 
+  const shiftMarqueeBy = (dx = 0, dy = 0) => {
+    const deltaX = Number(dx) || 0
+    const deltaY = Number(dy) || 0
+    if (Math.abs(deltaX) < 1e-6 && Math.abs(deltaY) < 1e-6) return
+    marqueeStart.value = {
+      x: marqueeStart.value.x - deltaX,
+      y: marqueeStart.value.y - deltaY,
+    }
+    marqueeEnd.value = {
+      x: marqueeEnd.value.x - deltaX,
+      y: marqueeEnd.value.y - deltaY,
+    }
+  }
+
   /**
    * Verifica si un elemento intersecta con el rectángulo de marquesina
    * @param {Object} elemento - Elemento del canvas
@@ -146,6 +160,7 @@ export function useMarqueeSelection({ canvasStore, stageRef }) {
     updateMarquee,
     endMarquee,
     cancelMarquee,
+    shiftMarqueeBy,
     stageToLayerCoords,
   }
 }

--- a/src/inventory-smart/composables/useObjectSnapping.js
+++ b/src/inventory-smart/composables/useObjectSnapping.js
@@ -395,11 +395,33 @@ export function useObjectSnapping() {
     isSnapping.value = false
   }
 
+  function shiftGuidesBy(dx = 0, dy = 0) {
+    const deltaX = Number(dx) || 0
+    const deltaY = Number(dy) || 0
+    if (!Number.isFinite(deltaX) || !Number.isFinite(deltaY)) return
+    if (Math.abs(deltaX) < 1e-6 && Math.abs(deltaY) < 1e-6) return
+    activeGuides.value = activeGuides.value.map((guide) => {
+      if (!guide || typeof guide !== 'object') return guide
+      const next = { ...guide }
+      if (next.type === 'vertical') {
+        if (next.x != null && Number.isFinite(Number(next.x))) next.x = Number(next.x) - deltaX
+        if (next.y1 != null && Number.isFinite(Number(next.y1))) next.y1 = Number(next.y1) - deltaY
+        if (next.y2 != null && Number.isFinite(Number(next.y2))) next.y2 = Number(next.y2) - deltaY
+      } else if (next.type === 'horizontal') {
+        if (next.y != null && Number.isFinite(Number(next.y))) next.y = Number(next.y) - deltaY
+        if (next.x1 != null && Number.isFinite(Number(next.x1))) next.x1 = Number(next.x1) - deltaX
+        if (next.x2 != null && Number.isFinite(Number(next.x2))) next.x2 = Number(next.x2) - deltaX
+      }
+      return next
+    })
+  }
+
   // Retornar solo lo que se usa externamente (evitar exportar utilidades internas)
   return {
     activeGuides: computed(() => activeGuides.value),
     isSnapping: computed(() => isSnapping.value),
     performSnap,
     clearGuides,
+    shiftGuidesBy,
   }
 }


### PR DESCRIPTION
## Summary
- wrap canvas layers in world groups and track floating-origin shifts with scheduled rebase checks
- extend marquee, drag, and snapping helpers to translate state when the world repositions
- add floating-origin state to the canvas store along with world shifting, clip, and infinite-floor culling updates

## Testing
- npm run build
- npm run test:unit *(fails: existing suites contain unmet expectations and Vue template compile issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e5456806e48321852ca3840973df60