### PR TITLE
fix: keep drag coordinates aligned with layer space

### DIFF
--- a/src/inventory-smart/components/CanvasView.vue
+++ b/src/inventory-smart/components/CanvasView.vue
@@ -1678,19 +1678,12 @@ const handleElementDoubleClick = (evt, elemento) => {
   }
 }
 
-const toLayerCoords = (pos) => {
-  const stage = stageRef.value.getNode()
-  const scale = stage.scaleX() || 1
-  const x = (pos.x - stage.x()) / scale
-  const y = (pos.y - stage.y()) / scale
-  return { x, y }
-}
+// Konva entrega `pos` relativo al parent inmediato del nodo (nuestro layer).
+// No debemos aplicar la transformación del stage aquí porque ocasiona saltos
+// cuando hay pan/zoom: el store ya trabaja en el mismo espacio del layer.
+const toLayerCoords = (pos) => ({ x: pos.x, y: pos.y })
 
-const toStageCoords = (pos) => {
-  const stage = stageRef.value.getNode()
-  const scale = stage.scaleX() || 1
-  return { x: pos.x * scale + stage.x(), y: pos.y * scale + stage.y() }
-}
+const toStageCoords = (pos) => ({ x: pos.x, y: pos.y })
 
 // Drag bound para cada elemento y forma (clamp mínimo al contorno)
 const dragBoundForElement = (pos, elemento) => {


### PR DESCRIPTION
## Summary
- remove erroneous stage transform application when mapping drag positions for elements
- document that Konva already provides positions in layer space to avoid future regressions

## Testing
- npm run test:unit *(fails: existing Vitest suite expects vi.mocked helper and mockable refs that are unavailable in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e680604a208321833a5f301ffcee64